### PR TITLE
Upgrade Indexable [ADAM-82]

### DIFF
--- a/adam_core/utils/indexable.py
+++ b/adam_core/utils/indexable.py
@@ -333,7 +333,9 @@ class Indexable:
 
         for k, v in copy_self.__dict__.items():
             if k != "_class_index":
-                if isinstance(v, (list, np.ndarray, np.ma.masked_array, Time, Indexable)):
+                if isinstance(
+                    v, (list, np.ndarray, np.ma.masked_array, Time, Indexable)
+                ):
                     copy_self.__dict__[k] = v[member_ind]
                 elif isinstance(v, UNSLICEABLE_DATA_STRUCTURES):
                     copy_self.__dict__[k] = v
@@ -376,6 +378,8 @@ class Indexable:
 
             else:
                 self.__dict__[k] = np.delete(v, np.s_[class_ind], axis=0)
+
+        self.set_index(self._class_index_attribute)
 
         return
 

--- a/adam_core/utils/indexable.py
+++ b/adam_core/utils/indexable.py
@@ -285,7 +285,7 @@ class Indexable:
                 )
                 return np.concatenate([self._class_index[s] for s in slices])
 
-        elif np.all(self._class_index == self._member_index):
+        elif np.array_equal(self._class_index, self._member_index):
             logger.debug("Using class index to index member arrays.")
             return self._class_index[ind]
         else:

--- a/adam_core/utils/indexable.py
+++ b/adam_core/utils/indexable.py
@@ -204,10 +204,9 @@ class Indexable:
         # If the index is to be set using an array that has a non-integer dtype
         # then we map the unique values of the index to integers. This will make querying the
         # index significantly faster.
-        if isinstance(class_index_values, np.ndarray) and class_index_values.dtype in [
-            object,
-            float,
-        ]:
+        if isinstance(class_index_values, np.ndarray) and class_index_values.dtype.type != int:
+            logger.debug("Mapping class index values to integers.")
+            # We use pandas since numpy unique is slower for object dtypes
             df = pd.DataFrame({"class_index_values": class_index_values})
             df_unique = df.drop_duplicates(keep="first").copy()
             df_unique["class_index_values_mapped"] = np.arange(0, len(df_unique))
@@ -223,7 +222,7 @@ class Indexable:
 
         # If the class index values are monotonically increasing then we can convert the class index
         # into an array of slices. This will make __getitem__ significantly faster.
-        is_sorted = np.all((class_index_values[1:] - class_index_values[:-1]) >= 1)
+        is_sorted = np.all((class_index_values[1:] - class_index_values[:-1]) >= 0)
         if is_sorted:
             logger.debug(
                 "Class index is sorted. Converting class index to an array of slices."

--- a/adam_core/utils/indexable.py
+++ b/adam_core/utils/indexable.py
@@ -333,7 +333,7 @@ class Indexable:
 
         for k, v in copy_self.__dict__.items():
             if k != "_class_index":
-                if isinstance(v, (np.ndarray, np.ma.masked_array, Time, Indexable)):
+                if isinstance(v, (list, np.ndarray, np.ma.masked_array, Time, Indexable)):
                     copy_self.__dict__[k] = v[member_ind]
                 elif isinstance(v, UNSLICEABLE_DATA_STRUCTURES):
                     copy_self.__dict__[k] = v

--- a/adam_core/utils/indexable.py
+++ b/adam_core/utils/indexable.py
@@ -87,46 +87,19 @@ class Indexable:
         return
 
     @property
-    def class_index(self):
+    def index(self):
         """
-        Externally facing index.
+        The externally facing index of the class.
         """
         return self._class_index
 
-    @property
-    def class_index_to_members(self):
-        """
-        Mapping from externally facing index to class members.
-        """
-        return self._class_index_to_members
+    @index.setter
+    def index(self, value):
+        self.set_index(value)
 
-    @property
-    def class_index_to_members_is_slice(self):
-        """
-        Whether the mapping from externally facing index to class members is a slice.
-        """
-        return self._class_index_to_members_is_slice
-
-    @property
-    def class_index_attribute(self):
-        """
-        Attribute on which the class index was set.
-        """
-        return self._class_index_attribute
-
-    @property
-    def member_index(self):
-        """
-        Index of the class members.
-        """
-        return self._member_index
-
-    @property
-    def member_length(self):
-        """
-        Length of the class members.
-        """
-        return self._member_length
+    @index.deleter
+    def index(self):
+        self.set_index()
 
     def set_index(self, index_values: Optional[Union[str, npt.ArrayLike]] = None):
         """
@@ -204,7 +177,10 @@ class Indexable:
         # If the index is to be set using an array that has a non-integer dtype
         # then we map the unique values of the index to integers. This will make querying the
         # index significantly faster.
-        if isinstance(class_index_values, np.ndarray) and class_index_values.dtype.type != int:
+        if (
+            isinstance(class_index_values, np.ndarray)
+            and class_index_values.dtype.type != int
+        ):
             logger.debug("Mapping class index values to integers.")
             # We use pandas since numpy unique is slower for object dtypes
             df = pd.DataFrame({"class_index_values": class_index_values})
@@ -332,9 +308,7 @@ class Indexable:
 
         for k, v in copy_self.__dict__.items():
             if k != "_class_index":
-                if isinstance(
-                    v, (np.ndarray, np.ma.masked_array, Time, Indexable)
-                ):
+                if isinstance(v, (np.ndarray, np.ma.masked_array, Time, Indexable)):
                     copy_self.__dict__[k] = v[member_ind]
                 elif isinstance(v, UNSLICEABLE_DATA_STRUCTURES):
                     copy_self.__dict__[k] = v

--- a/adam_core/utils/indexable.py
+++ b/adam_core/utils/indexable.py
@@ -1,48 +1,247 @@
+import logging
 from collections import OrderedDict
-from copy import deepcopy
-from typing import List, Union
+from copy import copy, deepcopy
+from typing import List, Optional, Union
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from astropy.time import Time
 
 __all__ = ["Indexable", "concatenate"]
 
+logger = logging.getLogger(__name__)
+
+SLICEABLE_DATA_STRUCTURES = (np.ndarray, np.ma.masked_array, list, Time)
 UNSLICEABLE_DATA_STRUCTURES = (str, int, float, dict, bool, set, OrderedDict)
 
 
 class Indexable:
     """
     Class that enables indexing and slicing of itself and its members.
-    If an Indexable subclass has members that are `~numpy.ndarray`s,
-    `~numpy.ma.core.MaskedArray`s, lists, or `~astropy.time.core.Time`s
-    then these members are appropriately sliced and indexed along their first axis.
-    Any members that are dicts, OrderedDicts, floats, integers or strings are
-    not indexed and left unchanged.
+    If an Indexable subclass has members that are `~numpy.ndarray`s, `~numpy.ma.core.MaskedArray`s,
+    lists, or `~astropy.time.core.Time`s then these members are appropriately sliced and indexed along their first axis.
+    Any members that are dicts, OrderedDicts, floats, integers or strings are not indexed and left unchanged.
+
+    Indexable maintains two array indexes:
+        - class: the externally facing index (ie. the index into the class itself)
+        - members: the index of the members of the class (ie. the index into the data structures carried by the class)
+
+
+    Class Index:
+    [0, 1, 2]
+    The class index is used to determine the length (size) of the class. In this example,
+    the len(instance) would be 3.
+
+    Class To Members Mapping:
+    [0, 0, 0, 1, 1, 1, 2, 2, 2]
+    If, as above, the class to members mapping is sorted (monotonically increasing), then
+    it is converted to an array of slices which allows for faster querying.
+    [slice(0, 2), slice(2, 5), slice(5, 8)]
+
+    Members Index:
+    [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+    For example, here orbits is a subclass of Indexable and has members that are
+    `~numpy.ndarray`s, `~numpy.ma.core.MaskedArray`s, and `~astropy.time.core.Time`s.
+
+    ```
+    from adam_core.orbits import Orbits
+    from adam_core.backend import PYOORB
+    from astropy.time import Time
+    from astropy import units as u
+
+    # Instantiate an Orbits object with 3 orbits
+    t0 = Time([59000.0], scale="utc", format="mjd")
+    orbits = Orbits.from_horizons(["Eros", "Ceres", "Duende"], t0)
+    len(orbits) == 3
+
+    # If I only wanted one orbit
+    single_orbit = orbits[0] # Orbits with one orbit
+
+    # Lets remove the other ones
+    del orbits[1:]
+
+    # Lets propagate the orbits to 10 new times
+    orbits = Orbits.from_horizons(["Eros", "Ceres", "Duende"], t0)
+    t1 = t0 + np.arange(0, 10) * u.day
+    backend = PYOORB()
+    propagated_orbits = backend.propagate_orbits(orbits, t1)
+
+    # The underlying arrays are now 10 * 3 in length
+    len(propagated_orbits) == 30
+
+    # If we update the index to be on orbit_id
+    # then the length of the class is 3 even though each
+    # member is 10 * 3 in length
+    propagated_orbits.set_index("orbit_id")
+    len(propagated_orbits) == 3
+
+    # Lets delete all of the states for "Duende"
+    del propagated_orbits[2]
+    ```
     """
 
-    def __init__(self, index: Union[str, np.ndarray]):
-        self.set_index(index)
+    def __init__(self, index_values: Optional[Union[str, npt.ArrayLike]] = None):
+        self.set_index(index_values)
         return
 
-    def _handle_index(self, i: Union[int, slice, tuple, list, np.ndarray]):
-        if isinstance(i, int):
-            if i < 0:
-                _i = i + len(self)
-            else:
-                _i = i
-            ind = slice(_i, _i + 1)
+    @property
+    def class_index(self):
+        """
+        Externally facing index.
+        """
+        return self._class_index
 
-        elif isinstance(i, tuple):
-            ind = list(i)
+    @property
+    def class_index_to_members(self):
+        """
+        Mapping from externally facing index to class members.
+        """
+        return self._class_index_to_members
 
-        elif isinstance(i, (slice, np.ndarray, list)):
-            ind = i
+    @property
+    def class_index_to_members_is_slice(self):
+        """
+        Whether the mapping from externally facing index to class members is a slice.
+        """
+        return self._class_index_to_members_is_slice
+
+    @property
+    def class_index_attribute(self):
+        """
+        Attribute on which the class index was set.
+        """
+        return self._class_index_attribute
+
+    @property
+    def member_index(self):
+        """
+        Index of the class members.
+        """
+        return self._member_index
+
+    @property
+    def member_length(self):
+        """
+        Length of the class members.
+        """
+        return self._member_length
+
+    def set_index(self, index_values: Optional[Union[str, npt.ArrayLike]] = None):
+        """
+        Set an index on the class for the given values or attribute name.
+
+        Parameters
+        ----------
+        index_values : str, np.ArrayLike
+            The values to be indexed. If a string is given then the values are taken from the
+            attribute of the same name. If an array is given then the values are taken from the
+            array itself. If None is given then the index is set to the range of length
+            of the class's sliceable members.
+
+        Sets
+        ----
+        self._class_index : `~numpy.ndarray`
+            The externally facing index of the class.
+        self._class_index_to_members : `~numpy.ndarray`
+            The mapping from the externally facing index to the class members.
+        self._class_index_to_members_is_slice : bool
+            Whether the mapping from the externally facing index to the class members are slices.
+        self._class_index_attribute : str, None
+            The attribute on which the index was set, if any. None if no attribute was used.
+        self._member_index : `~numpy.ndarray`
+            The index of the members of the class.
+        self._member_length : int
+            The length of the members of the class.
+
+
+        Raises
+        ------
+        ValueError: If all sliceable members do not have the same length.
+        """
+        ### Part 1: Determine the validity of this instance's members
+
+        # Scan members and if they are of a type that is sliceable
+        # then store the length. All sliceable members should have the same length
+        # along their first axis.
+        member_lengths = []
+        member_attributes = []
+        for k, v in self.__dict__.items():
+            if isinstance(v, SLICEABLE_DATA_STRUCTURES):
+                member_lengths.append(len(v))
+                member_attributes.append(k)
+
+        if len(np.unique(member_lengths)) != 1:
+            raise ValueError("All sliceable members must have the same length.")
         else:
-            raise IndexError("Index should be either an int or a slice.")
+            member_length = member_lengths[0]
 
-        if isinstance(ind, slice) and ind.start is not None and ind.start >= len(self):
-            raise IndexError(f"Index {ind.start} is out of bounds.")
+        self._member_length = member_length
+        self._member_index = np.arange(0, member_length, dtype=int)
+
+        ### Part 2: Figure out the values that are going to be mapped to an index
+        ### If the values are strings or floats, map their unique values to integers
+        ### to make future queries faster.
+
+        # If no index values are given then we set the class index
+        # to be the range of the member lengths
+        if index_values is None:
+            # Use the range of the member lengths
+            class_index_values = np.arange(0, self._member_length)
+            self._class_index_attribute = None
+        elif isinstance(index_values, str):
+            # Use the provided string as an attribute lookup
+            class_index_values = getattr(self, index_values)
+            self._class_index_attribute = index_values
+        elif isinstance(index_values, np.ndarray):
+            # Use the provided values directly
+            class_index_values = index_values
+            self._class_index_attribute = None
+        else:
+            raise ValueError("values must be None, str, or numpy.ndarray")
+
+        # If the index is to be set using an array that has a non-integer dtype
+        # then we map the unique values of the index to integers. This will make querying the
+        # index significantly faster.
+        if isinstance(class_index_values, np.ndarray) and class_index_values.dtype in [
+            object,
+            float,
+        ]:
+            df = pd.DataFrame({"class_index_values": class_index_values})
+            df_unique = df.drop_duplicates(keep="first").copy()
+            df_unique["class_index_values_mapped"] = np.arange(0, len(df_unique))
+            class_index_values = df.merge(
+                df_unique, on="class_index_values", how="left"
+            )["class_index_values_mapped"].values
+
+        ### Part 3: Now that we have the values that are going to be mapped to an index
+        ### we can create the index.
+
+        # Extract unique values to act as the externally facing index.
+        self._class_index = pd.unique(class_index_values)
+
+        # If the class index values are monotonically increasing then we can convert the class index
+        # into an array of slices. This will make __getitem__ significantly faster.
+        is_sorted = np.all((class_index_values[1:] - class_index_values[:-1]) >= 1)
+        if is_sorted:
+            logger.debug(
+                "Class index is sorted. Converting class index to an array of slices."
+            )
+            slices = []
+            slice_start = 0
+            for i in self._class_index:
+                mask = class_index_values[class_index_values == i]
+                slices.append(slice(slice_start, slice_start + len(mask)))
+                slice_start += len(mask)
+
+            self._class_index_to_members = np.array(slices)
+            self._class_index_to_members_is_slice = True
+        else:
+            self._class_index_to_members = class_index_values
+            self._class_index_to_members_is_slice = False
+
+        return
 
         unique_ind = self.index.unique(level="class_index")
         return self.index.get_locs([unique_ind[ind], slice(None)])

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -305,11 +305,12 @@ def test_Indexable_set_index_int_unsorted():
         indexable._class_index, np.unique(indexable.index_array_int)
     )
 
-    # We expect the class index to be the unique values of the index
+    # The class index to members mapping should be an array of integers
+    # since the index is cannot be represented as slices
     np.testing.assert_equal(
-        indexable._class_index_to_members, indexable.index_array_int
+        indexable._class_index_to_integers, indexable.index_array_int
     )
-    assert indexable._class_index_to_members_is_slice is False
+    assert indexable._class_index_to_slices is None
 
     # If we grab the first element of the class now we expect each member array to the every 10th element
     # in the original members
@@ -334,13 +335,13 @@ def test_Indexable_set_index_int_sorted():
         indexable._class_index, np.unique(indexable.index_array_int)
     )
 
-    # Because the class index is sorted we now expect the class index to members mapping to be
-    # an array of slices
+    # The class index to slices mapping should be an array of slices
+    # since the index is can be represented as slices
     np.testing.assert_equal(
-        indexable._class_index_to_members,
+        indexable._class_index_to_slices,
         np.array([slice(10 * i, 10 * (i + 1), 1) for i in range(10)]),
     )
-    assert indexable._class_index_to_members_is_slice is True
+    assert indexable._class_index_to_integers is None
 
     # If we grab the first element of the class now we expect each member array to the every 10th element
     # in the original members
@@ -365,11 +366,12 @@ def test_Indexable_set_index_str_unsorted():
     assert indexable._class_index_attribute == "index_array_str"
     np.testing.assert_equal(indexable._class_index, np.arange(0, 10))
 
-    # We expect the class index to be the unique values of the index
+    # The class index to members mapping should be an array of integers
+    # since the index is cannot be represented as slices
     np.testing.assert_equal(
-        indexable._class_index_to_members, indexable.index_array_int
+        indexable._class_index_to_integers, indexable.index_array_int
     )
-    assert indexable._class_index_to_members_is_slice is False
+    assert indexable._class_index_to_slices is None
 
     # If we grab the first element of the class now we expect each member array to the every 10th element
     # in the original members
@@ -399,12 +401,13 @@ def test_Indexable_set_index_str_sorted():
     assert indexable._class_index_attribute == "index_array_str"
     np.testing.assert_equal(indexable._class_index, np.arange(0, 10))
 
-    # We expect the class index to be the unique values of the index
+    # The class index to slices mapping should be an array of slices
+    # since the index is can be represented as slices
     np.testing.assert_equal(
-        indexable._class_index_to_members,
+        indexable._class_index_to_slices,
         np.array([slice(10 * i, 10 * (i + 1), 1) for i in range(10)]),
     )
-    assert indexable._class_index_to_members_is_slice is True
+    assert indexable._class_index_to_integers is None
 
     # If we grab the first element of the class now we expect each member array to the every 10th element
     # in the original members

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -6,13 +6,16 @@ from astropy.time import Time
 from ..indexable import Indexable
 
 SLICES = [
-    slice(0, 1, 1),  # 0
-    slice(1, 2, 1),  # 1
-    slice(8, 9, 1),  # -1
-    slice(7, 8, 1),  # -2
+    slice(0, 1, 1),
+    slice(1, 2, 1),
+    slice(8, 9, 1),
+    slice(7, 8, 1),
     slice(0, 10, 1),
     slice(0, 5, 1),
     slice(5, 10, 1),
+    slice(50, 60, 2),
+    slice(50, 60, 2),
+    slice(99, 10, -2),
 ]
 
 ATTRIBUTES = ["array", "masked_array", "times"]
@@ -94,7 +97,30 @@ def test_Indexable_deletion():
     for attribute_i in ATTRIBUTES:
         assert_equal(
             indexable_mod.__dict__[attribute_i],
-            indexable.__dict__[attribute_i][1 : N - 9],
+            indexable.__dict__[attribute_i][1 : N - 10],
+        )
+
+    # Delete the first 20 elements of the indexable and check that this operation
+    # is equivalent to deleting the first 20 elements of the individual attributes
+    del indexable_mod[:20]
+    for attribute_i in ATTRIBUTES:
+        assert_equal(
+            indexable_mod.__dict__[attribute_i],
+            # We've removed the first 1 element in the first test, and now
+            # we remove the next 20
+            indexable.__dict__[attribute_i][21 : N - 10],
+        )
+
+    # Delete the first and last element and check that this operation is equivalent to
+    # deleting the first and last element of the individual attributes
+    array_slice = np.array([0, -1])
+    del indexable_mod[array_slice]
+    for attribute_i in ATTRIBUTES:
+        assert_equal(
+            indexable_mod.__dict__[attribute_i],
+            # We've removed the first 21 elements in test 1 and 3, and now
+            # we remove the next one and the last element
+            indexable.__dict__[attribute_i][22 : N - 11],
         )
 
     return

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -130,3 +130,30 @@ def test_Indexable_iteration_time():
         tester.assert_equal(indexable_i.values[0], tester.values[i])
 
     return
+
+def test_Indexable_deletion_array():
+
+    tester = NumpyArrayTester()
+    indexable = TestIndexable(values=tester.values)
+    del indexable[0]
+    tester.assert_equal(indexable.values[0], tester.values[1])
+
+    return
+
+def test_Indexable_deletion_marray():
+
+    tester = NumpyMaskedArrayTester()
+    indexable = TestIndexable(values=tester.values)
+    del indexable[0]
+    tester.assert_equal(indexable.values[0], tester.values[1])
+
+    return
+
+def test_Indexable_deletion_time():
+
+    tester = NumpyMaskedArrayTester()
+    indexable = TestIndexable(values=tester.values)
+    del indexable[0]
+    tester.assert_equal(indexable.values[0], tester.values[1])
+
+    return

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -6,8 +6,10 @@ from ..indexable import Indexable
 
 class TestIndexable(Indexable):
 
-    def __init__(self, values):
-        self.values = values
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
         Indexable.__init__(self)
 
 SLICES = [
@@ -24,9 +26,9 @@ def test_Indexable_slicing_array():
 
     array = np.arange(0, 10)
 
-    indexable = TestIndexable(array)
+    indexable = TestIndexable(array=array)
     for s in SLICES:
-        np.testing.assert_equal(indexable[s].values, indexable.values[s])
+        np.testing.assert_equal(indexable[s].array, indexable.array[s])
 
     return
 
@@ -36,10 +38,10 @@ def test_Indexable_slicing_marray():
     masked_array.mask = np.zeros(len(masked_array))
     masked_array.mask[0:10:2] = 1
 
-    indexable = TestIndexable(masked_array)
+    indexable = TestIndexable(masked_array=masked_array)
     for s in SLICES:
-        np.testing.assert_equal(indexable[s].values.data, indexable.values[s].data)
-        np.testing.assert_equal(indexable[s].values.mask, indexable.values[s].mask)
+        np.testing.assert_equal(indexable[s].masked_array.data, indexable.masked_array[s].data)
+        np.testing.assert_equal(indexable[s].masked_array.mask, indexable.masked_array[s].mask)
 
     return
 
@@ -47,10 +49,11 @@ def test_Indexable_slicing_time():
 
     times = Time(np.arange(59000, 59010), scale="utc", format="mjd")
 
-    indexable = TestIndexable(times)
+    indexable = TestIndexable(times=times)
     for s in SLICES:
-        np.testing.assert_equal(indexable[s].values.mjd, indexable.values[s].mjd)
-        assert indexable[s].values.scale == indexable.values[s].scale
-        assert indexable[s].values.format == indexable.values[s].format
+        np.testing.assert_equal(indexable[s].times.mjd, indexable.times[s].mjd)
+        assert indexable[s].times.scale == indexable.times[s].scale
+        assert indexable[s].times.format == indexable.times[s].format
 
     return
+

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -4,7 +4,12 @@ import numpy as np
 import pytest
 from astropy.time import Time
 
-from ..indexable import Indexable, _convert_grouped_array_to_slices, concatenate
+from ..indexable import (
+    Indexable,
+    _convert_grouped_array_to_slices,
+    _map_values_to_integers,
+    concatenate,
+)
 
 SLICES = [
     slice(0, 1, 1),
@@ -127,6 +132,32 @@ def test__convert_grouped_array_to_slices():
         ]
     )
     np.testing.assert_equal(slices, desired)
+
+
+def test__map_values_to_integers():
+    # Test that the function correctly maps integer values to integers
+    values = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    mapping = _map_values_to_integers(values)
+    desired = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    np.testing.assert_equal(mapping, desired)
+
+    # Test that the function correctly maps string values to integers
+    values = np.array(["a", "a", "b", "c", "d", "e", "e", "e"])
+    mapping = _map_values_to_integers(values)
+    desired = np.array([0, 0, 1, 2, 3, 4, 4, 4])
+    np.testing.assert_equal(mapping, desired)
+
+    # Test that the function correctly maps float values with duplicates to integers
+    values = np.array([0, 1, 0, 1], dtype=float)
+    mapping = _map_values_to_integers(values)
+    desired = np.array([0, 1, 0, 1])
+    np.testing.assert_equal(mapping, desired)
+
+    # Test that the function correctly maps unsorted strings with duplicates to integers
+    values = np.array(["a", "b", "a"])
+    mapping = _map_values_to_integers(values)
+    desired = np.array([0, 1, 0])
+    np.testing.assert_equal(mapping, desired)
 
 
 def test__check_member_validity_raises():

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -57,3 +57,36 @@ def test_Indexable_slicing_time():
 
     return
 
+def test_Indexable_iteration_array():
+
+    array = np.arange(0, 10)
+
+    indexable = TestIndexable(array=array)
+    for i, indexable_i in enumerate(indexable):
+        np.testing.assert_equal(indexable_i.array[0], array[i])
+
+    return
+
+def test_Indexable_iteration_marray():
+
+    masked_array = np.ma.arange(0, 10)
+    masked_array.mask = np.zeros(len(masked_array))
+    masked_array.mask[0:10:2] = 1
+
+    indexable = TestIndexable(masked_array=masked_array)
+    for i, ind in enumerate(indexable):
+        np.testing.assert_equal(ind.masked_array.data[0], masked_array.data[i])
+        np.testing.assert_equal(ind.masked_array.mask[0], masked_array.mask[i])
+
+    return
+
+def test_Indexable_iteration_time():
+
+    times = Time(np.arange(59000, 59010), scale="utc", format="mjd")
+
+    indexable = TestIndexable(times=times)
+    for i, ind in enumerate(indexable):
+        np.testing.assert_equal(ind.times.mjd[0], times.mjd[i])
+
+    return
+

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -56,6 +56,13 @@ class TestIndexable(Indexable):
         Indexable.__init__(self)
 
 
+class DummyIndexable(Indexable):
+    def __init__(self, array):
+        self.array = array
+
+        Indexable.__init__(self)
+
+
 def assert_equal(a, b):
     if isinstance(a, (np.ndarray)) and isinstance(b, (np.ndarray)):
         np.testing.assert_equal(a, b)
@@ -192,12 +199,70 @@ def test__check_member_validity_raises():
 def test__check_member_validity():
     # Create invalid test indexable
     indexable = TestIndexable()
-    member_length, member_index = indexable._check_member_validity()
+    member_length = indexable._check_member_validity()
 
     # Assert that the function correctly computes the length of the member
     # attributes and sets the according member length and index
     assert member_length == N
-    np.testing.assert_equal(member_index, np.arange(0, 100))
+
+
+def test_Indexable__query_index_int():
+    # Array is grouped and can be represented by slices
+    indexable = DummyIndexable(np.array([0, 1, 2, 3, 4, 5]))
+    indexable.set_index("array")
+    index = indexable._query_index(2)
+    assert index == slice(2, 3, 1)
+
+    # Array is not grouped and can be not be represented by slices
+    indexable = DummyIndexable(np.array([0, 1, 0]))
+    indexable.set_index("array")
+    index = indexable._query_index(1)
+    assert index == np.array([1])
+
+
+def test_Indexable__query_index_slice():
+    # Array is grouped and can be represented by slices
+    indexable = DummyIndexable(np.array([0, 1, 2, 3, 4, 5]))
+    indexable.set_index("array")
+    index = indexable._query_index(slice(0, 2, 1))
+    assert index == slice(0, 2, 1)
+
+    # Array is not grouped and can be not be represented by slices
+    indexable = DummyIndexable(np.array([0, 1, 0]))
+    indexable.set_index("array")
+    # I want the first two unique values in array which is the entire array
+    index = indexable._query_index(slice(0, 2, 1))
+    np.testing.assert_equal(index, np.array([0, 1, 2]))
+
+
+def test_Indexable__query_index_array():
+    # Array is grouped and can be represented by slices
+    indexable = DummyIndexable(np.array([0, 1, 2, 3, 4, 5]))
+    indexable.set_index("array")
+    index = indexable._query_index(np.array([0, 1]))
+    assert index == slice(0, 2, 1)
+
+    # Array is not grouped and can be not be represented by slices
+    indexable = DummyIndexable(np.array([0, 1, 0]))
+    indexable.set_index("array")
+    # I want the first two unique values in array which is the entire array
+    index = indexable._query_index(np.array([0, 1]))
+    np.testing.assert_equal(index, np.array([0, 1, 2]))
+
+
+def test_Indexable__query_index_list():
+    # Array is grouped and can be represented by slices
+    indexable = DummyIndexable(np.array([0, 1, 2, 3, 4, 5]))
+    indexable.set_index("array")
+    index = indexable._query_index([0, 1])
+    assert index == slice(0, 2, 1)
+
+    # Array is not grouped and can be not be represented by slices
+    indexable = DummyIndexable(np.array([0, 1, 0]))
+    indexable.set_index("array")
+    # I want the first two unique values in array which is the entire array
+    index = indexable._query_index([0, 1])
+    np.testing.assert_equal(index, [0, 1, 2])
 
 
 def test_Indexable_slicing():

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -1,92 +1,132 @@
 import pytest
 import numpy as np
 from astropy.time import Time
+from abc import ABC, abstractmethod
 
 from ..indexable import Indexable
 
-class TestIndexable(Indexable):
+SLICES = [
+    slice(0, 1, 1),  #  0
+    slice(1, 2, 1),  #  1
+    slice(8, 9, 1),  # -1
+    slice(7, 8, 1),  # -2
+    slice(0, 10, 1),
+    slice(0, 5, 1),
+    slice(5, 10, 1),
+]
 
+
+class TestIndexable(Indexable):
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
 
         Indexable.__init__(self)
 
-SLICES = [
-    slice(0, 1, 1),   #  0
-    slice(1, 2, 1),   #  1
-    slice(8, 9, 1),   # -1
-    slice(7, 8, 1),   # -2
-    slice(0, 10, 1),
-    slice(0, 5, 1),
-    slice(5, 10, 1),
-]
+
+class SliceableDataStructureTester(ABC):
+    @abstractmethod
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def assert_equal(self, a, b):
+        pass
+
+
+class NumpyArrayTester(SliceableDataStructureTester):
+    def __init__(self):
+        array = np.arange(0, 100)
+        self.values = array
+
+    def assert_equal(self, a, b):
+        if isinstance(a, (np.int_, np.float_)):
+            assert a == b
+        else:
+            np.testing.assert_equal(a, b)
+
+
+class NumpyMaskedArrayTester(SliceableDataStructureTester):
+    def __init__(self):
+        masked_array = np.ma.arange(0, 10)
+        masked_array.mask = np.zeros(len(masked_array))
+        masked_array.mask[0:10:2] = 1
+        self.values = masked_array
+
+    def assert_equal(self, a, b):
+        if isinstance(a, (np.int_, np.float_)):
+            assert a == b
+        else:
+            np.testing.assert_equal(a.data, b.data)
+            np.testing.assert_equal(a.mask, b.mask)
+
+
+class AstropyTimeTester(SliceableDataStructureTester):
+    def __init__(self):
+        times = Time(np.arange(59000, 59100), scale="utc", format="mjd")
+        self.values = times
+
+    def assert_equal(self, a, b):
+        if isinstance(a, (np.int_, np.float_)):
+            assert a == b
+        else:
+            np.testing.assert_equal(a.mjd, b.mjd)
+            assert a.scale == b.scale
+            assert a.format == b.format
+
 
 def test_Indexable_slicing_array():
 
-    array = np.arange(0, 10)
-
-    indexable = TestIndexable(array=array)
+    tester = NumpyArrayTester()
+    indexable = TestIndexable(values=tester.values)
     for s in SLICES:
-        np.testing.assert_equal(indexable[s].array, indexable.array[s])
+        tester.assert_equal(indexable[s].values, indexable.values[s])
 
     return
+
 
 def test_Indexable_slicing_marray():
 
-    masked_array = np.ma.arange(0, 10)
-    masked_array.mask = np.zeros(len(masked_array))
-    masked_array.mask[0:10:2] = 1
-
-    indexable = TestIndexable(masked_array=masked_array)
+    tester = NumpyMaskedArrayTester()
+    indexable = TestIndexable(values=tester.values)
     for s in SLICES:
-        np.testing.assert_equal(indexable[s].masked_array.data, indexable.masked_array[s].data)
-        np.testing.assert_equal(indexable[s].masked_array.mask, indexable.masked_array[s].mask)
+        tester.assert_equal(indexable[s].values, indexable.values[s])
 
     return
 
+
 def test_Indexable_slicing_time():
 
-    times = Time(np.arange(59000, 59010), scale="utc", format="mjd")
-
-    indexable = TestIndexable(times=times)
+    tester = AstropyTimeTester()
+    indexable = TestIndexable(values=tester.values)
     for s in SLICES:
-        np.testing.assert_equal(indexable[s].times.mjd, indexable.times[s].mjd)
-        assert indexable[s].times.scale == indexable.times[s].scale
-        assert indexable[s].times.format == indexable.times[s].format
+        tester.assert_equal(indexable[s].values, indexable.values[s])
 
     return
 
 def test_Indexable_iteration_array():
 
-    array = np.arange(0, 10)
-
-    indexable = TestIndexable(array=array)
+    tester = NumpyArrayTester()
+    indexable = TestIndexable(values=tester.values)
     for i, indexable_i in enumerate(indexable):
-        np.testing.assert_equal(indexable_i.array[0], array[i])
+        tester.assert_equal(indexable_i.values[0], tester.values[i])
 
     return
 
 def test_Indexable_iteration_marray():
 
-    masked_array = np.ma.arange(0, 10)
-    masked_array.mask = np.zeros(len(masked_array))
-    masked_array.mask[0:10:2] = 1
-
-    indexable = TestIndexable(masked_array=masked_array)
-    for i, ind in enumerate(indexable):
-        np.testing.assert_equal(ind.masked_array.data[0], masked_array.data[i])
-        np.testing.assert_equal(ind.masked_array.mask[0], masked_array.mask[i])
+    tester = NumpyMaskedArrayTester()
+    indexable = TestIndexable(values=tester.values)
+    for i, indexable_i in enumerate(indexable):
+        tester.assert_equal(indexable_i.values[0], tester.values[i])
 
     return
 
 def test_Indexable_iteration_time():
 
-    times = Time(np.arange(59000, 59010), scale="utc", format="mjd")
-
-    indexable = TestIndexable(times=times)
-    for i, ind in enumerate(indexable):
-        np.testing.assert_equal(ind.times.mjd[0], times.mjd[i])
+    tester = AstropyTimeTester()
+    indexable = TestIndexable(values=tester.values)
+    for i, indexable_i in enumerate(indexable):
+        tester.assert_equal(indexable_i.values[0], tester.values[i])
 
     return
-

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 import numpy as np
+import pytest
 from astropy.time import Time
 
 from ..indexable import Indexable, concatenate

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -66,6 +66,31 @@ def assert_equal(a, b):
     return
 
 
+def test__check_member_validity_raises():
+    # Create invalid test indexable
+    class InvalidTestIndexable(Indexable):
+        def __init__(self):
+            self.index_array_1 = np.arange(11, dtype=int)
+            self.index_array_2 = np.arange(10, dtype=int)
+
+            Indexable.__init__(self)
+
+    # Check that the invalid test indexable raises a ValueError
+    with pytest.raises(ValueError):
+        InvalidTestIndexable()
+
+
+def test__check_member_validity():
+    # Create invalid test indexable
+    indexable = TestIndexable()
+    member_length, member_index = indexable._check_member_validity()
+
+    # Assert that the function correctly computes the length of the member
+    # attributes and sets the according member length and index
+    assert member_length == N
+    np.testing.assert_equal(member_index, np.arange(0, 100))
+
+
 def test_Indexable_slicing():
     # Create test indexable
     indexable = TestIndexable()

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -1,0 +1,56 @@
+import pytest
+import numpy as np
+from astropy.time import Time
+
+from ..indexable import Indexable
+
+class TestIndexable(Indexable):
+
+    def __init__(self, values):
+        self.values = values
+        Indexable.__init__(self)
+
+SLICES = [
+    slice(0, 1, 1),   #  0
+    slice(1, 2, 1),   #  1
+    slice(8, 9, 1),   # -1
+    slice(7, 8, 1),   # -2
+    slice(0, 10, 1),
+    slice(0, 5, 1),
+    slice(5, 10, 1),
+]
+
+def test_Indexable_slicing_array():
+
+    array = np.arange(0, 10)
+
+    indexable = TestIndexable(array)
+    for s in SLICES:
+        np.testing.assert_equal(indexable[s].values, indexable.values[s])
+
+    return
+
+def test_Indexable_slicing_marray():
+
+    masked_array = np.ma.arange(0, 10)
+    masked_array.mask = np.zeros(len(masked_array))
+    masked_array.mask[0:10:2] = 1
+
+    indexable = TestIndexable(masked_array)
+    for s in SLICES:
+        np.testing.assert_equal(indexable[s].values.data, indexable.values[s].data)
+        np.testing.assert_equal(indexable[s].values.mask, indexable.values[s].mask)
+
+    return
+
+def test_Indexable_slicing_time():
+
+    times = Time(np.arange(59000, 59010), scale="utc", format="mjd")
+
+    indexable = TestIndexable(times)
+    for s in SLICES:
+        np.testing.assert_equal(indexable[s].values.mjd, indexable.values[s].mjd)
+        assert indexable[s].values.scale == indexable.values[s].scale
+        assert indexable[s].values.format == indexable.values[s].format
+
+    return

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -175,7 +175,7 @@ def test_Indexable_set_index_int_unsorted():
     np.testing.assert_equal(
         indexable._class_index_to_members, indexable.index_array_int
     )
-    assert indexable._class_index_to_members_is_slice == False
+    assert indexable._class_index_to_members_is_slice is False
 
     # If we grab the first element of the class now we expect each member array to the every 10th element
     # in the original members
@@ -206,7 +206,7 @@ def test_Indexable_set_index_int_sorted():
         indexable._class_index_to_members,
         np.array([slice(10 * i, 10 * (i + 1)) for i in range(10)]),
     )
-    assert indexable._class_index_to_members_is_slice == True
+    assert indexable._class_index_to_members_is_slice is True
 
     # If we grab the first element of the class now we expect each member array to the every 10th element
     # in the original members
@@ -220,6 +220,11 @@ def test_Indexable_set_index_int_sorted():
 def test_Indexable_set_index_str_unsorted():
     # Create test indexable
     indexable = TestIndexable()
+
+    # Test that the length of the class is the same as the length of the index
+    assert len(indexable) == 100
+
+    # Set the index
     indexable.set_index("index_array_str")
 
     # The index is unsorted with the numbers 0-9 repeated 10 times
@@ -230,7 +235,7 @@ def test_Indexable_set_index_str_unsorted():
     np.testing.assert_equal(
         indexable._class_index_to_members, indexable.index_array_int
     )
-    assert indexable._class_index_to_members_is_slice == False
+    assert indexable._class_index_to_members_is_slice is False
 
     # If we grab the first element of the class now we expect each member array to the every 10th element
     # in the original members
@@ -240,12 +245,19 @@ def test_Indexable_set_index_str_unsorted():
             indexable_i.__dict__[attribute_i], indexable.__dict__[attribute_i][::10]
         )
 
+    # Test that the length of the class is the same as the length of the index
+    assert len(indexable) == 10
     return
 
 
 def test_Indexable_set_index_str_sorted():
     # Create test indexable
     indexable = TestIndexable()
+
+    # Test that the length of the class is the same as the length of the index
+    assert len(indexable) == 100
+
+    # Set the index
     indexable.index_array_str.sort()
     indexable.set_index("index_array_str")
 
@@ -258,7 +270,7 @@ def test_Indexable_set_index_str_sorted():
         indexable._class_index_to_members,
         np.array([slice(10 * i, 10 * (i + 1)) for i in range(10)]),
     )
-    assert indexable._class_index_to_members_is_slice == True
+    assert indexable._class_index_to_members_is_slice is True
 
     # If we grab the first element of the class now we expect each member array to the every 10th element
     # in the original members
@@ -268,6 +280,8 @@ def test_Indexable_set_index_str_sorted():
             indexable_i.__dict__[attribute_i], indexable.__dict__[attribute_i][:10]
         )
 
+    # Test that the length of the class is the same as the length of the index
+    assert len(indexable) == 10
     return
 
 
@@ -294,6 +308,41 @@ def test_Indexable_concatenate():
         assert_equal(
             indexable.__dict__[attribute_i][200:300],
             indexable3.__dict__[attribute_i][:100],
+        )
+
+    return
+
+
+def test_Indexable_sort_values():
+    # Create test indexable
+    indexable = TestIndexable()
+
+    # Sort the indexable by the index array
+    indexable_sorted = indexable.sort_values("index_array_int", inplace=False)
+
+    # Test that the attributes are correctly sorted
+    for attribute_i in ATTRIBUTES:
+        assert_equal(
+            indexable_sorted.__dict__[attribute_i][:10],
+            indexable.__dict__[attribute_i][::10],
+        )
+
+    return
+
+
+def test_Indexable_sort_values_inplace():
+    # Create test indexable
+    indexable = TestIndexable()
+    indexable_unsorted = deepcopy(indexable)
+
+    # Sort the indexable by the index array
+    indexable.sort_values("index_array_int", inplace=True)
+
+    # Test that the attributes are correctly sorted
+    for attribute_i in ATTRIBUTES:
+        assert_equal(
+            indexable.__dict__[attribute_i][:10],
+            indexable_unsorted.__dict__[attribute_i][::10],
         )
 
     return

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -6,6 +6,7 @@ from astropy.time import Time
 
 from ..indexable import (
     Indexable,
+    _check_slices_are_consecutive,
     _convert_grouped_array_to_slices,
     _map_values_to_integers,
     concatenate,
@@ -158,6 +159,20 @@ def test__map_values_to_integers():
     mapping = _map_values_to_integers(values)
     desired = np.array([0, 1, 0])
     np.testing.assert_equal(mapping, desired)
+
+
+def test__check_slices_are_consecutive():
+    # Slices are consecutive and share the same step
+    slices = np.array([slice(0, 1, 1), slice(1, 2, 1), slice(2, 10, 1)])
+    assert _check_slices_are_consecutive(slices) is True
+
+    # Step is not consistent
+    slices = np.array([slice(0, 1, 1), slice(1, 2, 2), slice(2, 10, 1)])
+    assert _check_slices_are_consecutive(slices) is False
+
+    # Step is consistent but slices are not consecutive
+    slices = np.array([slice(0, 1, 1), slice(1, 2, 1), slice(0, 1, 1)])
+    assert _check_slices_are_consecutive(slices) is False
 
 
 def test__check_member_validity_raises():

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -1,13 +1,13 @@
-import pytest
+from copy import deepcopy
+
 import numpy as np
 from astropy.time import Time
-from abc import ABC, abstractmethod
 
 from ..indexable import Indexable
 
 SLICES = [
-    slice(0, 1, 1),  #  0
-    slice(1, 2, 1),  #  1
+    slice(0, 1, 1),  # 0
+    slice(1, 2, 1),  # 1
     slice(8, 9, 1),  # -1
     slice(7, 8, 1),  # -2
     slice(0, 10, 1),
@@ -15,145 +15,86 @@ SLICES = [
     slice(5, 10, 1),
 ]
 
+ATTRIBUTES = ["array", "masked_array", "times"]
+N = 100
+
 
 class TestIndexable(Indexable):
-    def __init__(self, **kwargs):
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+    def __init__(self, N: int = 100):
+        self.array = np.arange(0, N)
+        self.masked_array = np.ma.arange(0, N)
+        self.masked_array.mask = np.zeros(N)
+        self.masked_array.mask[0:N:2] = 1
+        self.times = Time(np.arange(59000, 59000 + N), scale="utc", format="mjd")
 
         Indexable.__init__(self)
 
 
-class SliceableDataStructureTester(ABC):
-    @abstractmethod
-    def __init__(self):
-        pass
+def assert_equal(a, b):
+    if isinstance(a, (np.ndarray)) and isinstance(b, (np.ndarray)):
+        np.testing.assert_equal(a, b)
+    elif isinstance(a, (np.ma.masked_array)) and isinstance(b, (np.ma.masked_array)):
+        np.testing.assert_equal(a.data, b.data)
+        np.testing.assert_equal(a.mask, b.mask)
+    elif isinstance(a, (Time)) and isinstance(b, (Time)):
+        np.testing.assert_equal(a.mjd, b.mjd)
+        assert a.scale == b.scale
+        assert a.format == b.format
+    else:
+        assert a == b
 
-    @abstractmethod
-    def assert_equal(self, a, b):
-        pass
-
-
-class NumpyArrayTester(SliceableDataStructureTester):
-    def __init__(self):
-        array = np.arange(0, 100)
-        self.values = array
-
-    def assert_equal(self, a, b):
-        if isinstance(a, (np.int_, np.float_)):
-            assert a == b
-        else:
-            np.testing.assert_equal(a, b)
+    return
 
 
-class NumpyMaskedArrayTester(SliceableDataStructureTester):
-    def __init__(self):
-        masked_array = np.ma.arange(0, 10)
-        masked_array.mask = np.zeros(len(masked_array))
-        masked_array.mask[0:10:2] = 1
-        self.values = masked_array
+def test_Indexable_slicing():
+    # Create test indexable
+    indexable = TestIndexable()
 
-    def assert_equal(self, a, b):
-        if isinstance(a, (np.int_, np.float_)):
-            assert a == b
-        else:
-            np.testing.assert_equal(a.data, b.data)
-            np.testing.assert_equal(a.mask, b.mask)
-
-
-class AstropyTimeTester(SliceableDataStructureTester):
-    def __init__(self):
-        times = Time(np.arange(59000, 59100), scale="utc", format="mjd")
-        self.values = times
-
-    def assert_equal(self, a, b):
-        if isinstance(a, (np.int_, np.float_)):
-            assert a == b
-        else:
-            np.testing.assert_equal(a.mjd, b.mjd)
-            assert a.scale == b.scale
-            assert a.format == b.format
-
-
-def test_Indexable_slicing_array():
-
-    tester = NumpyArrayTester()
-    indexable = TestIndexable(values=tester.values)
+    # For each slice, slice the test indexable and check that this operation
+    # is equivalent to slicing the individual attributes
     for s in SLICES:
-        tester.assert_equal(indexable[s].values, indexable.values[s])
+        for attribute_i in ATTRIBUTES:
+            indexable_i = indexable[s]
+            assert_equal(
+                indexable_i.__dict__[attribute_i], indexable.__dict__[attribute_i][s]
+            )
 
     return
 
 
-def test_Indexable_slicing_marray():
+def test_Indexable_iteration():
+    # Create test indexable
+    indexable = TestIndexable()
 
-    tester = NumpyMaskedArrayTester()
-    indexable = TestIndexable(values=tester.values)
-    for s in SLICES:
-        tester.assert_equal(indexable[s].values, indexable.values[s])
-
-    return
-
-
-def test_Indexable_slicing_time():
-
-    tester = AstropyTimeTester()
-    indexable = TestIndexable(values=tester.values)
-    for s in SLICES:
-        tester.assert_equal(indexable[s].values, indexable.values[s])
-
-    return
-
-def test_Indexable_iteration_array():
-
-    tester = NumpyArrayTester()
-    indexable = TestIndexable(values=tester.values)
+    # Iterate through the indexable and check that this operation
+    # is equivalent to iterating through the individual attributes
     for i, indexable_i in enumerate(indexable):
-        tester.assert_equal(indexable_i.values[0], tester.values[i])
+        for attribute_i in ATTRIBUTES:
+            assert_equal(
+                indexable_i.__dict__[attribute_i], indexable.__dict__[attribute_i][i]
+            )
 
-    return
 
-def test_Indexable_iteration_marray():
+def test_Indexable_deletion():
+    # Create test indexable
+    indexable = TestIndexable()
 
-    tester = NumpyMaskedArrayTester()
-    indexable = TestIndexable(values=tester.values)
-    for i, indexable_i in enumerate(indexable):
-        tester.assert_equal(indexable_i.values[0], tester.values[i])
+    # Delete the first element of the indexable and check that this operation
+    # is equivalent to deleting the first element of the individual attributes
+    indexable_mod = deepcopy(indexable)
+    del indexable_mod[0]
+    for attribute_i in ATTRIBUTES:
+        assert_equal(
+            indexable_mod.__dict__[attribute_i], indexable.__dict__[attribute_i][1:]
+        )
 
-    return
-
-def test_Indexable_iteration_time():
-
-    tester = AstropyTimeTester()
-    indexable = TestIndexable(values=tester.values)
-    for i, indexable_i in enumerate(indexable):
-        tester.assert_equal(indexable_i.values[0], tester.values[i])
-
-    return
-
-def test_Indexable_deletion_array():
-
-    tester = NumpyArrayTester()
-    indexable = TestIndexable(values=tester.values)
-    del indexable[0]
-    tester.assert_equal(indexable.values[0], tester.values[1])
-
-    return
-
-def test_Indexable_deletion_marray():
-
-    tester = NumpyMaskedArrayTester()
-    indexable = TestIndexable(values=tester.values)
-    del indexable[0]
-    tester.assert_equal(indexable.values[0], tester.values[1])
-
-    return
-
-def test_Indexable_deletion_time():
-
-    tester = NumpyMaskedArrayTester()
-    indexable = TestIndexable(values=tester.values)
-    del indexable[0]
-    tester.assert_equal(indexable.values[0], tester.values[1])
+    # Delete the last 10 elements of the indexable and check that this operation
+    # is equivalent to deleting the last 10 elements of the individual attributes
+    del indexable_mod[-10:]
+    for attribute_i in ATTRIBUTES:
+        assert_equal(
+            indexable_mod.__dict__[attribute_i],
+            indexable.__dict__[attribute_i][1 : N - 9],
+        )
 
     return


### PR DESCRIPTION
This PR adds a variety of upgrades to the Indexable class (which really needs to be renamed: how about `IndexedDataTable` or `IndexedDataStructures`?)

Why was it developed? In short, I wanted to be able to have a class that allowed the user to store different data structures such as astropy Time objects, numpy arrays, numpy masked arrays, and then be able to slice the class as one would an array and have the class correctly slice its members. However, the different supported data structures all have different interfaces to do that kind of slicing. This is an effort to generalize this desired behavior behind the functions of a class and most importantly make it user-friendly as a whole. It's difficult to show the utility of the class without showing how classes that inherit from this class work in practice. I'd encourage looking at the unit tests that have been added to get an idea of what the class is doing. In two follow-up PRs, I'll add the upgrades to the coordinates class and the orbits class with examples.

Additionally, this class supports the idea of an index in to its underlying member data structures. Iteration always occurs over the index *not* the rows of the underlying data structures. The index can be equivalent to the range of the length of the class's underlying members in which case `Indexable.__iter__` will iterate over each row (this is the default behavior when no index is set). Why is an index useful? Imagine if you have orbits (N) that you propagate to a series of times (M), if you set the index to the orbit ID you can then iterate over the grouped ephemerides in groups of slices of length (M). Super useful for things like THOR, etc... 