### PR TITLE
Add pytest-cov as a tests dependency, move testing to workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: jpribyl/action-docker-layer-caching@v0.1.0
         # Ignore the failure of a step and avoid terminating the job.
         continue-on-error: true
-      - name: Build Precovery in Docker
+      - name: Build adam_core in Docker
         run: docker build -t adam-core:$IMAGE_TAG .
       - name: isort check
         run:  docker run -i adam-core:$IMAGE_TAG isort --check-only .
@@ -25,3 +25,5 @@ jobs:
         run:  docker run -i adam-core:$IMAGE_TAG black --check --diff .
       - name: flake8
         run:  docker run -i adam-core:$IMAGE_TAG flake8
+      - name: tests
+        run: docker run -i adam-core:$IMAGE_TAG pytest . --cov

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,3 @@ RUN mkdir /code/
 ADD . /code/
 WORKDIR /code/
 RUN pip install -e .[tests]
-
-CMD ["pytest", "."]

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ tests =
     flake8
     isort
     pytest
+    pytest-cov
     autoflake
 
 


### PR DESCRIPTION
Relatively simple PR: adds pytest-cov as a tests dependency and then drops the pytest command in the Docker recipe in favor of running tests as part of the GitHub workflow. 

These commits were originally in #2 but have been extracted here. 