### PR TITLE
Add initial Orbits class [ADAM-90]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,110 @@ A set of shared astrodynamics libraries and utilities.
 
 ## Usage
 
-### Coordinates
+### Orbits
+
+To define an orbit: 
+```python
+from astropy.time import Time
+from adam_core.coordinates import KeplerianCoordinates
+from adam_core.orbits import Orbits
+
+keplerian_elements = KeplerianCoordinates(
+    times=Time(59000.0, scale="tdb", format="mjd"),
+    a=1.0, 
+    e=0.002,
+    i=10.,
+    raan=50.0,
+    ap=20.0,
+    M=30.0, 
+)
+orbits = Orbits(
+    keplerian_elements,
+    orbit_ids=["1"],
+    object_ids=["Test Orbit"]
+)
+```
+The underlying orbits class is 2 dimensional and can store elements and covariances for multiple orbits.
+
+Orbits can be easily converted to a pandas DataFrame:
+```python
+orbits.to_df()
+  orbit_id   object_id  mjd_tdb    a      e     i  raan    ap     M       origin     frame
+0        1  Test Orbit  59000.0  1.0  0.002  10.0  50.0  20.0  30.0  heliocenter  ecliptic
+```
+
+Orbits can also be defined with uncertainties. 
+```python
+from astropy.time import Time
+from adam_core.coordinates import KeplerianCoordinates
+from adam_core.orbits import Orbits
+
+keplerian_elements = KeplerianCoordinates(
+    times=Time(59000.0, scale="tdb", format="mjd"),
+    a=1.0, 
+    e=0.002,
+    i=10.,
+    raan=50.0,
+    ap=20.0,
+    M=30.0, 
+    sigma_a=0.002,
+    sigma_e=0.001,
+    sigma_i=0.01,
+    sigma_raan=0.01,
+    sigma_ap=0.1,
+    sigma_M=0.1,
+)
+
+orbits = Orbits(
+    keplerian_elements,
+    orbit_ids=["1"],
+    object_ids=["Test Orbit with Uncertainties"]
+)
+orbits.to_df(sigmas=True)
+  orbit_id                      object_id  mjd_tdb    a  ...  sigma_ap  sigma_M       origin     frame
+0        1  Test Orbit with Uncertainties  59000.0  1.0  ...       0.1      0.1  heliocenter  ecliptic
+```
+
+To query orbits from JPL Horizons: 
+```python
+from astropy.time import Time
+from adam_core.orbits.query import query_horizons
+
+times = Time([60000.0], scale="tdb", format="mjd")
+object_ids = ["Duende", "Eros", "Ceres"]
+orbits = query_horizons(object_ids, times)
+```
+
+To query orbits from JPL SBDB: 
+```python
+from adam_core.orbits.query import query_sbdb
+
+object_ids = ["Duende", "Eros", "Ceres"]
+orbits = query_sbdb(object_ids)
+```
+
+#### Orbital Element Conversions
+Orbital elements can be accessed via the corresponding attribute. All conversions, including covariances, are done on demand and stored. 
+
+```python
+# Keplerian Elements
+orbits.keplerian
+
+# Cometary Elements
+orbits.cometary
+
+# Cartesian Elements
+orbits.cartesian
+
+# Spherical Elements
+orbits.spherical
+```
+
+### Lower Level Classes
+These classes are designed more for developers interested in building codes derived from utilities 
+in this package. 
+
+#### Coordinates
 
 ```python
 from astropy.time import Time
@@ -37,7 +140,6 @@ keplerian_coordinates = transform_coordinates(
 )
 
 print(keplerian_coordinates)
-
 ```
 
 
@@ -48,6 +150,7 @@ adam_core
 ├── constants.py  # Shared constants
 ├── coordinates   # Coordinate classes and transformations
 ├── dynamics      # Numerical solutions
+├── orbits        # Orbits class and query utilities
 └── utils         # Utility classes like Indexable or conversions like times_from_df
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,17 +25,39 @@ keplerian_elements = KeplerianCoordinates(
 )
 orbits = Orbits(
     keplerian_elements,
-    orbit_ids=["1"],
-    object_ids=["Test Orbit"]
+    orbit_ids="1",
+    object_ids="Test Orbit"
 )
 ```
 The underlying orbits class is 2 dimensional and can store elements and covariances for multiple orbits.
 
+```python
+from astropy.time import Time
+from adam_core.coordinates import KeplerianCoordinates
+from adam_core.orbits import Orbits
+
+keplerian_elements = KeplerianCoordinates(
+    times=Time([59000.0, 60000.0], scale="tdb", format="mjd"),
+    a=[1.0, 3.0], 
+    e=[0.002, 0.0],
+    i=[10., 30.],
+    raan=[50.0, 32.0],
+    ap=[20.0, 94.0],
+    M=[30.0, 159.0],
+)
+orbits = Orbits(
+    keplerian_elements,
+    orbit_ids=["1", "2"],
+    object_ids=["Test Orbit 1", "Test Orbit 2"]
+)
+```
+
 Orbits can be easily converted to a pandas DataFrame:
 ```python
 orbits.to_df()
-  orbit_id   object_id  mjd_tdb    a      e     i  raan    ap     M       origin     frame
-0        1  Test Orbit  59000.0  1.0  0.002  10.0  50.0  20.0  30.0  heliocenter  ecliptic
+  orbit_id     object_id  mjd_tdb    a      e     i  raan    ap      M       origin     frame
+0        1  Test Orbit 1  59000.0  1.0  0.002  10.0  50.0  20.0   30.0  heliocenter  ecliptic
+1        2  Test Orbit 2  60000.0  3.0  0.000  30.0  32.0  94.0  159.0  heliocenter  ecliptic
 ```
 
 Orbits can also be defined with uncertainties. 

--- a/adam_core/coordinates/cometary.py
+++ b/adam_core/coordinates/cometary.py
@@ -472,6 +472,8 @@ class CometaryCoordinates(Coordinates):
                 cartesian.values,
                 cartesian.covariances,
                 _cartesian_to_cometary,
+                in_axes=(0, 0, None),
+                out_axes=0,
                 t0=cartesian.times.tdb.mjd,
                 mu=mu,
             )

--- a/adam_core/coordinates/coordinates.py
+++ b/adam_core/coordinates/coordinates.py
@@ -178,10 +178,7 @@ class Coordinates(Indexable):
         D = len(kwargs)
         units_ = {}
         for d, (name, q) in enumerate(kwargs.items()):
-            if isinstance(q, (int, float)):
-                q_ = np.array([q], dtype=np.float64)
-            else:
-                q_ = q
+            q_ = self._convert_to_array(q)
 
             # If the coordinate dimension has a coresponding unit
             # then use that unit. If it does not look for the unit

--- a/adam_core/coordinates/covariances.py
+++ b/adam_core/coordinates/covariances.py
@@ -63,9 +63,11 @@ def sigmas_to_covariance(
         I = np.identity(D, dtype=sigmas_.dtype)  # NOQA: E741
         covariances = np.einsum("kj,ji->kij", sigmas_**2, I)
         covariances = np.ma.masked_array(
-            covariances, dtype=np.float64, fill_value=COVARIANCE_FILL_VALUE
+            covariances,
+            dtype=np.float64,
+            fill_value=COVARIANCE_FILL_VALUE,
         )
-        covariances.mask = np.where(np.isnan(covariances) | (covariances == 0), 1, 0)
+        covariances.mask = np.ma.zeros((N, D, D), dtype=bool)
 
     return covariances
 

--- a/adam_core/coordinates/members.py
+++ b/adam_core/coordinates/members.py
@@ -67,7 +67,7 @@ class CoordinateMembers(Indexable):
         else:
             index = np.array([])
 
-        Indexable.__init__(self, index)
+        super().__init__(self, index)
         return
 
     def cartesian(self):

--- a/adam_core/coordinates/members.py
+++ b/adam_core/coordinates/members.py
@@ -1,3 +1,4 @@
+import logging
 from copy import deepcopy
 from typing import Optional
 
@@ -12,7 +13,7 @@ from .keplerian import KEPLERIAN_COLS, KeplerianCoordinates
 from .spherical import SPHERICAL_COLS, SphericalCoordinates
 from .transform import cartesian_to_frame, cartesian_to_origin, transform_coordinates
 
-__all__ = ["CoordinateMembers"]
+logger = logging.getLogger(__name__)
 
 
 class CoordinateMembers(Indexable):
@@ -65,11 +66,12 @@ class CoordinateMembers(Indexable):
         if coordinates is not None:
             index = np.arange(0, len(coordinates), 1)
         else:
-            index = np.array([])
+            index = None
 
         super().__init__(self, index)
         return
 
+    @property
     def cartesian(self):
         if "CartesianCoordinates" not in self.__allowed_coordinate_types:
             err = "Cartesian coordinates are not supported by this class."
@@ -94,6 +96,31 @@ class CoordinateMembers(Indexable):
 
         return self._cartesian
 
+    @cartesian.setter
+    def cartesian(self, coords: CartesianCoordinates):
+        if "CartesianCoordinates" not in self.__allowed_coordinate_types:
+            err = "Cartesian coordinates are not supported by this class."
+            raise ValueError(err)
+
+        if len(coords) != len(self):
+            err = "Length of new coordinates must match length of existing coordinates."
+            raise ValueError(err)
+
+        logger.debug(
+            "Setting cartesian coordinates and clearing other cached representations."
+        )
+        self._cartesian = coords
+        self._keplerian = None
+        self._cometary = None
+        self._spherical = None
+        return
+
+    @cartesian.deleter
+    def cartesian(self):
+        self._cartesian = None
+        return
+
+    @property
     def spherical(self):
         if "SphericalCoordinates" not in self.__allowed_coordinate_types:
             err = "Spherical coordinates are not supported by this class."
@@ -118,6 +145,31 @@ class CoordinateMembers(Indexable):
 
         return self._spherical
 
+    @spherical.setter
+    def spherical(self, coords: SphericalCoordinates):
+        if "SphericalCoordinates" not in self.__allowed_coordinate_types:
+            err = "Spherical coordinates are not supported by this class."
+            raise ValueError(err)
+
+        if len(coords) != len(self):
+            err = "Length of new coordinates must match length of existing coordinates."
+            raise ValueError(err)
+
+        logger.debug(
+            "Setting spherical coordinates and clearing other cached representations."
+        )
+        self._spherical = coords
+        self._cartesian = None
+        self._keplerian = None
+        self._cometary = None
+        return
+
+    @spherical.deleter
+    def spherical(self):
+        self._spherical = None
+        return
+
+    @property
     def keplerian(self):
         if "KeplerianCoordinates" not in self.__allowed_coordinate_types:
             err = "Keplerian coordinates are not supported by this class."
@@ -142,6 +194,30 @@ class CoordinateMembers(Indexable):
 
         return self._keplerian
 
+    @keplerian.setter
+    def keplerian(self, coords: KeplerianCoordinates):
+        if "KeplerianCoordinates" not in self.__allowed_coordinate_types:
+            err = "Keplerian coordinates are not supported by this class."
+            raise ValueError(err)
+        if len(coords) != len(self):
+            err = "Length of new coordinates must match length of existing coordinates."
+            raise ValueError(err)
+
+        logger.debug(
+            "Setting keplerian coordinates and clearing other cached representations."
+        )
+        self._keplerian = coords
+        self._cartesian = None
+        self._spherical = None
+        self._cometary = None
+        return
+
+    @keplerian.deleter
+    def keplerian(self):
+        self._keplerian = None
+        return
+
+    @property
     def cometary(self):
         if "CometaryCoordinates" not in self.__allowed_coordinate_types:
             err = "Keplerian coordinates are not supported by this class."
@@ -164,6 +240,29 @@ class CoordinateMembers(Indexable):
             ):
                 self._cometary = transform_coordinates(self._spherical, "cometary")
         return self._cometary
+
+    @cometary.setter
+    def cometary(self, coords: CometaryCoordinates):
+        if "CometaryCoordinates" not in self.__allowed_coordinate_types:
+            err = "Cometary coordinates are not supported by this class."
+            raise ValueError(err)
+        if len(coords) != len(self):
+            err = "Length of new coordinates must match length of existing coordinates."
+            raise ValueError(err)
+
+        logger.debug(
+            "Setting cometary coordinates and clearing other cached representations."
+        )
+        self._cometary = coords
+        self._cartesian = None
+        self._keplerian = None
+        self._spherical = None
+        return
+
+    @cometary.deleter
+    def cometary(self):
+        self._cometary = None
+        return
 
     def to_frame(self, frame: str):
         """

--- a/adam_core/dynamics/__init__.py
+++ b/adam_core/dynamics/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa: F401
 from .barker import solve_barker
 from .kepler import solve_kepler
+from .tisserand import calc_tisserand_parameter

--- a/adam_core/dynamics/tests/test_tisserand.py
+++ b/adam_core/dynamics/tests/test_tisserand.py
@@ -1,0 +1,50 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from ..tisserand import calc_tisserand_parameter
+
+# --- Tests last updated: 2023-02-09
+
+# From JPL's SBDB (2023-02-01) https://ssd.jpl.nasa.gov/sbdb.cgi
+# a, e, i
+DAMOCLES = {
+    "aei": (11.87052898293103, 0.8659079806381217, 61.6840796497527),
+    "T_jupiter": 1.155,
+}
+CERES = {
+    "aei": (2.767181743149466, 0.07881745101960996, 10.58634326912728),
+    "T_jupiter": 3.310,
+}
+# 3D/Biela
+BIELA = {
+    "aei": (3.53465808340135, 0.751299, 13.2164),
+    "T_jupiter": 2.531,
+}
+
+
+def test_calc_tisserand_parameter_damocloids():
+    Tp = calc_tisserand_parameter(*DAMOCLES["aei"], third_body="jupiter")
+
+    npt.assert_allclose(np.round(Tp, 3), DAMOCLES["T_jupiter"])
+    return
+
+
+def test_calc_tisserand_parameter_asteroids():
+    Tp = calc_tisserand_parameter(*CERES["aei"], third_body="jupiter")
+
+    npt.assert_allclose(np.round(Tp, 3), CERES["T_jupiter"])
+    return
+
+
+def test_calc_tisserand_parameter_jupiter_family_comets():
+    Tp = calc_tisserand_parameter(*BIELA["aei"], third_body="jupiter")
+
+    npt.assert_allclose(np.round(Tp, 3), BIELA["T_jupiter"])
+    return
+
+
+def test_calc_tisserand_parameter_raise():
+    # Not a valid planet name
+    with pytest.raises(ValueError):
+        calc_tisserand_parameter(*CERES["aei"], third_body="")

--- a/adam_core/dynamics/tisserand.py
+++ b/adam_core/dynamics/tisserand.py
@@ -1,0 +1,65 @@
+"""
+This code generates the dictionary of semi-major axes for the
+third body needed for the Tisserand parameter
+
+from astropy.time import Time
+from adam_core.orbits.query import _get_horizons_elements
+
+ids = ["199", "299", "399", "499", "599", "699", "799", "899"]
+elements = _get_horizons_elements(ids, times, id_type="majorbody")
+
+MAJOR_BODIES = {}
+for i, r in elements[["targetname", "a"]].iterrows():
+   body_name = r["targetname"].split(" ")[0].lower()
+   MAJOR_BODIES[body_name] = r["a"]
+
+"""
+import numpy as np
+
+MAJOR_BODIES = {
+    "mercury": 0.3870970330236769,
+    "venus": 0.723341974974844,
+    "earth": 0.9997889954736553,
+    "mars": 1.523803685638066,
+    "jupiter": 5.203719697535582,
+    "saturn": 9.579110220472034,
+    "uranus": 19.18646168457971,
+    "neptune": 30.22486701698071,
+}
+
+
+def calc_tisserand_parameter(a, e, i, third_body="jupiter"):
+    """
+    Calculate Tisserand's parameter used to identify potential comets.
+    For example, objects with Tisserand parameter's with respect to Jupiter greater than 3 are
+    typically asteroids, whereas Jupiter family comets may have Tisserand's parameter
+    between 2 and 3. Damocloids have Jupiter Tisserand's parameter of less than 2.
+
+    Parameters
+    ----------
+    a : float or `~numpy.ndarray` (N)
+        Semi-major axis in au.
+    e : float or `~numpy.ndarray` (N)
+        Eccentricity.
+    i : float or `~numpy.ndarray` (N)
+        Inclination in degrees.
+    third_body : str
+        Name of planet with respect to which Tisserand's parameter
+        should be calculated.
+
+    Returns
+    -------
+    Tp : float or `~numpy.ndarray` (N)
+        Tisserand's parameter.
+    """
+    i_rad = np.radians(i)
+
+    major_bodies = MAJOR_BODIES.keys()
+    if third_body not in major_bodies:
+        err = f"third_body should be one of {','.join(major_bodies)}"
+        raise ValueError(err)
+
+    ap = MAJOR_BODIES[third_body]
+    Tp = ap / a + 2 * np.cos(i_rad) * np.sqrt(a / ap * (1 - e**2))
+
+    return Tp

--- a/adam_core/orbits/__init__.py
+++ b/adam_core/orbits/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa: F401
+from .orbits import Orbits

--- a/adam_core/orbits/__init__.py
+++ b/adam_core/orbits/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa: F401
+from .classification import calc_orbit_class
 from .orbits import Orbits

--- a/adam_core/orbits/classification.py
+++ b/adam_core/orbits/classification.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from ..coordinates.keplerian import KeplerianCoordinates
+
+
+def calc_orbit_class(keplerian_coordinates: KeplerianCoordinates) -> dict:
+    """
+    Calculate the orbital class for each Keplerian orbit.
+
+    Based on the classification scheme defined by the Planetary Data System Small
+    Bodies Node (see: https://pdssbn.astro.umd.edu/data_other/objclass.shtml).
+
+    TODO: Classification is currently limited to asteroid dynamical classes. Cometary class
+    have not yet been implemented.
+
+    Parameters
+    ----------
+    keplerian_coordinates : KeplerianCoordinates
+        Keplerian orbits for which to find classes.
+
+    Returns
+    -------
+    orbit_class : `~numpy.ndarray`
+        Class for each orbit.
+    """
+    a = keplerian_coordinates.a.filled()
+    e = keplerian_coordinates.e.filled()
+    q = keplerian_coordinates.q.filled()
+    Q = keplerian_coordinates.Q.filled()
+
+    orbit_class = np.array(["AST" for i in range(len(keplerian_coordinates))])
+
+    orbit_class_dict = {
+        "AMO": np.where((a > 1.0) & (q > 1.017) & (q < 1.3)),
+        "APO": np.where((a > 1.0) & (q < 1.017)),
+        "ATE": np.where((a < 1.0) & (Q > 0.983)),
+        "CEN": np.where((a > 5.5) & (a < 30.3)),
+        "IEO": np.where((Q < 0.983))[0],
+        "IMB": np.where((a < 2.0) & (q > 1.666))[0],
+        "MBA": np.where((a > 2.0) & (a < 3.2) & (q > 1.666)),
+        "MCA": np.where((a < 3.2) & (q > 1.3) & (q < 1.666)),
+        "OMB": np.where((a > 3.2) & (a < 4.6)),
+        "TJN": np.where((a > 4.6) & (a < 5.5) & (e < 0.3)),
+        "TNO": np.where((a > 30.1)),
+        "PAA": np.where((e == 1)),
+        "HYA": np.where((e > 1)),
+    }
+    for c, v in orbit_class_dict.items():
+        orbit_class[v] = c
+
+    return orbit_class

--- a/adam_core/orbits/orbits.py
+++ b/adam_core/orbits/orbits.py
@@ -21,17 +21,17 @@ class Orbits(CoordinateMembers):
         classes: Optional[npt.ArrayLike] = None,
     ):
         if orbit_ids is not None:
-            self._orbit_ids = orbit_ids
+            self._orbit_ids = self._convert_to_array(orbit_ids)
         else:
             self._orbit_ids = np.arange(0, len(coordinates))
 
         if object_ids is not None:
-            self._object_ids = object_ids
+            self._object_ids = self._convert_to_array(object_ids)
         else:
             self._object_ids = np.array(["None" for i in range(len(coordinates))])
 
         if classes is not None:
-            self._classes = classes
+            self._classes = self._convert_to_array(classes)
         else:
             self._classes = None
 

--- a/adam_core/orbits/orbits.py
+++ b/adam_core/orbits/orbits.py
@@ -1,0 +1,166 @@
+import logging
+from typing import Optional
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+from ..coordinates.coordinates import Coordinates
+from ..coordinates.members import CoordinateMembers
+
+logger = logging.getLogger(__name__)
+
+
+class Orbits(CoordinateMembers):
+    def __init__(
+        self,
+        coordinates: Coordinates,
+        orbit_ids: Optional[npt.ArrayLike] = None,
+        object_ids: Optional[npt.ArrayLike] = None,
+    ):
+        if orbit_ids is not None:
+            self._orbit_ids = orbit_ids
+        else:
+            self._orbit_ids = np.arange(0, len(coordinates))
+
+        if object_ids is not None:
+            self._object_ids = object_ids
+        else:
+            self._object_ids = np.array(["None" for i in range(len(coordinates))])
+
+        super().__init__(
+            self,
+            coordinates=coordinates,
+            cartesian=True,
+            keplerian=True,
+            spherical=True,
+            cometary=True,
+        )
+        return
+
+    @property
+    def orbit_ids(self):
+        return self._orbit_ids
+
+    @orbit_ids.setter
+    def orbit_ids(self, orbit_ids):
+        if len(orbit_ids) != len(self._orbit_ids):
+            raise ValueError(
+                "Orbit IDs must be the same length as the number of orbits."
+            )
+        self._orbit_ids = orbit_ids
+
+    @orbit_ids.deleter
+    def orbit_ids(self):
+        self._orbit_ids = np.arange(0, len(self._orbit_ids))
+
+    @property
+    def object_ids(self):
+        return self._object_ids
+
+    @object_ids.setter
+    def object_ids(self, object_ids):
+        if len(object_ids) != len(self._object_ids):
+            raise ValueError(
+                "Object IDs must be the same length as the number of orbits."
+            )
+        self._object_ids = object_ids
+
+    @object_ids.deleter
+    def object_ids(self):
+        self._object_ids = np.array(["None" for i in range(len(self._object_ids))])
+
+    def to_df(
+        self,
+        time_scale: str = "tdb",
+        coordinate_type: Optional[str] = None,
+        sigmas: bool = False,
+        covariances: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Represent Orbits as a `~pandas.DataFrame`.
+
+        Parameters
+        ----------
+        time_scale : {"tdb", "tt", "utc"}
+            Desired timescale of the output MJDs.
+        coordinate_type : {"cartesian", "spherical", "keplerian", "cometary"}
+            Desired output representation of the orbits.
+        sigmas : bool, optional
+            Include 1-sigma uncertainty columns.
+        covariances : bool, optional
+            Include lower triangular covariance matrix columns.
+
+        Returns
+        -------
+        df : `~pandas.DataFrame`
+            Pandas DataFrame containing orbits.
+        """
+        df = CoordinateMembers.to_df(
+            self,
+            time_scale=time_scale,
+            coordinate_type=coordinate_type,
+            sigmas=sigmas,
+            covariances=covariances,
+        )
+        df.insert(0, "orbit_id", self.orbit_ids)
+        df.insert(1, "object_id", self.object_ids)
+
+        return df
+
+    @classmethod
+    def from_df(
+        cls: "Orbits",
+        df: pd.DataFrame,
+        coord_cols: Optional[dict] = None,
+        origin_col: str = "origin",
+        frame_col: str = "frame",
+    ) -> "Orbits":
+        """
+        Read Orbits class from a `~pandas.DataFrame`.
+
+        Parameters
+        ----------
+        df : `~pandas.DataFrame`
+            DataFrame containing orbits.
+        coord_cols : dict, optional
+            Dictionary containing the coordinate dimensions as keys and their equivalent columns
+            as values. If None, this function will use the default dictionaries for each coordinate class.
+            The following coordinate (dictionary) keys are supported:
+                Cartesian columns: x, y, z, vx, vy, vz
+                Keplerian columns: a, e, i, raan, ap, M
+                Cometary columns: q, e, i, raan, ap, tp
+                Spherical columns: rho, lon, lat, vrho, vlon, vlat
+        origin_col : str
+            Name of the column containing the origin of each coordinate.
+        frame_col : str
+            Name of the column containing the coordinate frame.
+
+        Returns
+        -------
+        cls : `~adam_core.orbits.Orbits`
+            Orbits class.
+        """
+        data = cls._dict_from_df(
+            df,
+            cartesian=True,
+            keplerian=True,
+            cometary=True,
+            spherical=True,
+            coord_cols=coord_cols,
+            origin_col=origin_col,
+            frame_col=frame_col,
+        )
+
+        columns = df.columns.values
+        if "orbit_id" in columns:
+            data["orbit_ids"] = df["orbit_id"].values
+        else:
+            data["orbit_ids"] = None
+
+        if "object_id" in columns:
+            data["object_ids"] = df["object_id"].values
+        else:
+            data["object_ids"] = None
+
+        return cls(**data)

--- a/adam_core/orbits/query/__init__.py
+++ b/adam_core/orbits/query/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa: F401
 from .horizons import query_horizons
+from .sbdb import query_sbdb

--- a/adam_core/orbits/query/__init__.py
+++ b/adam_core/orbits/query/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa: F401
+from .horizons import query_horizons

--- a/adam_core/orbits/query/horizons.py
+++ b/adam_core/orbits/query/horizons.py
@@ -1,0 +1,220 @@
+from typing import List, Union
+
+import numpy.typing as npt
+import pandas as pd
+from astropy.time import Time
+from astroquery.jplhorizons import Horizons
+
+from ...coordinates.cartesian import CartesianCoordinates
+from ...coordinates.cometary import CometaryCoordinates
+from ...coordinates.keplerian import KeplerianCoordinates
+from ...utils.astropy import _check_times
+from ..orbits import Orbits
+
+
+def _get_horizons_vectors(
+    object_ids: Union[List, npt.ArrayLike],
+    times: Time,
+    location: str = "@sun",
+    id_type: str = "smallbody",
+    aberrations: str = "geometric",
+) -> pd.DataFrame:
+    """
+    Query JPL Horizons (through astroquery) for an object's
+    state vectors at the given times.
+
+    Parameters
+    ----------
+    object_ids : `~numpy.ndarray` (N)
+        Object IDs / designations recognizable by HORIZONS.
+    times : `~astropy.core.time.Time` (M)
+        Astropy time object at which to gather state vectors.
+    location : str, optional
+        Location of the origin typically a NAIF code.
+        ('0' or '@ssb' for solar system barycenter, '10' or '@sun' for heliocenter)
+        [Default = '@sun']
+    id_type : {'majorbody', 'smallbody', 'designation',
+               'name', 'asteroid_name', 'comet_name', 'id'}
+        ID type, Horizons will find closest match under any given type.
+    aberrations : {'geometric', 'astrometric', 'apparent'}
+        Adjust state for one of three different aberrations.
+
+    Returns
+    -------
+    vectors : `~pandas.DataFrame`
+        Dataframe containing the full cartesian state, r, r_rate, delta, delta_rate and light time
+        of the object at each time.
+    """
+    _check_times(times, "times")
+    dfs = []
+    for obj_id in object_ids:
+        obj = Horizons(
+            id=obj_id,
+            epochs=times.tdb.mjd,
+            location=location,
+            id_type=id_type,
+        )
+        vectors = obj.vectors(
+            refplane="ecliptic", aberrations=aberrations, cache=False
+        ).to_pandas()
+        dfs.append(vectors)
+
+    vectors = pd.concat(dfs, ignore_index=True)
+    return vectors
+
+
+def _get_horizons_elements(
+    object_ids: Union[List, npt.ArrayLike],
+    times: Time,
+    location: str = "@sun",
+    id_type: str = "smallbody",
+) -> pd.DataFrame:
+    """
+    Query JPL Horizons (through astroquery) for an object's
+    elements at the given times.
+
+    Parameters
+    ----------
+    object_ids : `~numpy.ndarray` (N)
+        Object IDs / designations recognizable by HORIZONS.
+    times : `~astropy.core.time.Time`
+        Astropy time object at which to gather state vectors.
+    location : str, optional
+        Location of the origin typically a NAIF code.
+        ('0' or '@ssb' for solar system barycenter, '10' or '@sun' for heliocenter)
+        [Default = '@sun']
+    id_type : {'majorbody', 'smallbody', 'designation',
+               'name', 'asteroid_name', 'comet_name', 'id'}
+        ID type, Horizons will find closest match under any given type.
+
+    Returns
+    -------
+    elements : `~pandas.DataFrame`
+        Dataframe containing the full cartesian state, r, r_rate, delta, delta_rate and light time
+        of the object at each time.
+    """
+    _check_times(times, "times")
+    dfs = []
+    for obj_id in object_ids:
+        obj = Horizons(
+            id=obj_id,
+            epochs=times.tdb.mjd,
+            location=location,
+            id_type=id_type,
+        )
+        elements = obj.elements(
+            refsystem="J2000", refplane="ecliptic", tp_type="absolute", cache=False
+        ).to_pandas()
+        dfs.append(elements)
+
+    elements = pd.concat(dfs, ignore_index=True)
+    return elements
+
+
+def query_horizons(
+    object_ids: Union[List, npt.ArrayLike],
+    times: Time,
+    coordinate_type: str = "cartesian",
+    location: str = "@sun",
+    id_type: str = "smallbody",
+    aberrations: str = "geometric",
+) -> Orbits:
+    """
+    Query JPL Horizons (through astroquery) for an object's state vectors or elements at the given times.
+
+    Parameters
+    ----------
+    object_ids : npt.ArrayLike (N)
+        Object IDs / designations recognizable by HORIZONS.
+    times : `~astropy.core.time.Time` (M)
+        Astropy time object at which to gather state vectors.
+    coordinate_type : {'cartesian', 'keplerian', 'cometary'}
+        Type of orbital elements to return.
+    location : str, optional
+        Location of the origin typically a NAIF code.
+        ('0' or '@ssb' for solar system barycenter, '10' or '@sun' for heliocenter)
+        [Default = '@sun']
+    id_type : {'majorbody', 'smallbody', 'designation',
+                'name', 'asteroid_name', 'comet_name', 'id'}
+        ID type, Horizons will find closest match under any given type.
+    aberrations : {'geometric', 'astrometric', 'apparent'}
+        Adjust state for one of three different aberrations.
+
+    Returns
+    -------
+    orbits : `~adam_core.orbits.orbits.Orbits`
+        Orbits object containing the state vectors or elements of the object at each time.
+    """
+    if coordinate_type == "cartesian":
+        vectors = _get_horizons_vectors(
+            object_ids,
+            times,
+            location=location,
+            id_type=id_type,
+            aberrations=aberrations,
+        )
+
+        coordinates = CartesianCoordinates(
+            times=Time(vectors["datetime_jd"].values, scale="tdb", format="jd"),
+            x=vectors["x"].values,
+            y=vectors["y"].values,
+            z=vectors["z"].values,
+            vx=vectors["vx"].values,
+            vy=vectors["vy"].values,
+            vz=vectors["vz"].values,
+            origin="heliocenter",
+            frame="ecliptic",
+        )
+        object_ids = vectors["targetname"].values
+
+        return Orbits(coordinates, object_ids=object_ids)
+
+    elif coordinate_type == "keplerian":
+        elements = _get_horizons_elements(
+            object_ids,
+            times,
+            location=location,
+            id_type=id_type,
+        )
+
+        coordinates = KeplerianCoordinates(
+            times=Time(elements["datetime_jd"].values, scale="tdb", format="jd"),
+            a=elements["a"].values,
+            e=elements["e"].values,
+            i=elements["incl"].values,
+            raan=elements["Omega"].values,
+            ap=elements["w"].values,
+            M=elements["M"].values,
+            origin="heliocenter",
+            frame="ecliptic",
+        )
+        object_ids = elements["targetname"].values
+
+        return Orbits(coordinates, object_ids=object_ids)
+
+    elif coordinate_type == "cometary":
+        elements = _get_horizons_elements(
+            object_ids,
+            times,
+            location=location,
+            id_type=id_type,
+        )
+
+        tp = Time(elements["Tp_jd"].values, scale="tdb", format="jd")
+        coordinates = CometaryCoordinates(
+            times=Time(elements["datetime_jd"].values, scale="tdb", format="jd"),
+            q=elements["q"].values,
+            e=elements["e"].values,
+            i=elements["incl"].values,
+            raan=elements["Omega"].values,
+            ap=elements["w"].values,
+            tp=tp.tdb.mjd,
+            origin="heliocenter",
+            frame="ecliptic",
+        )
+        object_ids = elements["targetname"].values
+        return Orbits(coordinates, object_ids=object_ids)
+
+    else:
+        err = "coordinate_type should be one of {'cartesian', 'keplerian', 'cometary'}"
+        raise ValueError(err)

--- a/adam_core/orbits/query/sbdb.py
+++ b/adam_core/orbits/query/sbdb.py
@@ -1,0 +1,186 @@
+from typing import List, OrderedDict
+
+import numpy as np
+import numpy.typing as npt
+from astropy.time import Time
+from astroquery.jplsbdb import SBDB
+
+from ...coordinates.cometary import CometaryCoordinates
+from ...coordinates.covariances import sigmas_to_covariance
+from ..orbits import Orbits
+
+
+def _convert_SBDB_covariances(
+    sbdb_covariances: npt.ArrayLike,
+) -> npt.ArrayLike:
+    """
+    Convert SBDB covariance matrices to Cometary covariance matrices.
+
+    Parameters
+    ----------
+    sbdb_covariances : `~numpy.ndarray` (N, 6, 6)
+        Covariance matrices pulled from JPL's Small Body Database Browser.
+
+    Returns
+    -------
+    covariances : `~numpy.ndarray` (N, 6, 6)
+        Cometary covariance matrices.
+    """
+    covariances = np.zeros_like(sbdb_covariances)
+    # sigma_q{x}
+    covariances[:, 0, 0] = sbdb_covariances[:, 1, 1]  # sigma_qq
+    covariances[:, 1, 0] = covariances[:, 0, 1] = sbdb_covariances[:, 0, 1]  # sigma_qe
+    covariances[:, 2, 0] = covariances[:, 0, 2] = sbdb_covariances[:, 5, 1]  # sigma_qi
+    covariances[:, 3, 0] = covariances[:, 0, 3] = sbdb_covariances[
+        :, 3, 1
+    ]  # sigma_qraan
+    covariances[:, 4, 0] = covariances[:, 0, 4] = sbdb_covariances[:, 4, 1]  # sigma_qap
+    covariances[:, 5, 0] = covariances[:, 0, 5] = sbdb_covariances[:, 2, 1]  # sigma_qtp
+
+    # sigma_e{x}
+    covariances[:, 1, 1] = sbdb_covariances[:, 0, 0]  # sigma_ee
+    covariances[:, 2, 1] = covariances[:, 1, 2] = sbdb_covariances[:, 5, 0]  # sigma_ei
+    covariances[:, 3, 1] = covariances[:, 1, 3] = sbdb_covariances[
+        :, 3, 0
+    ]  # sigma_eraan
+    covariances[:, 4, 1] = covariances[:, 1, 4] = sbdb_covariances[:, 4, 0]  # sigma_eap
+    covariances[:, 5, 1] = covariances[:, 1, 5] = sbdb_covariances[:, 2, 0]  # sigma_etp
+
+    # sigma_i{x}
+    covariances[:, 2, 2] = sbdb_covariances[:, 5, 5]  # sigma_ii
+    covariances[:, 3, 2] = covariances[:, 2, 3] = sbdb_covariances[
+        :, 3, 5
+    ]  # sigma_iraan
+    covariances[:, 4, 2] = covariances[:, 2, 4] = sbdb_covariances[:, 4, 5]  # sigma_iap
+    covariances[:, 5, 2] = covariances[:, 2, 5] = sbdb_covariances[:, 2, 5]  # sigma_itp
+
+    # sigma_raan{x}
+    covariances[:, 3, 3] = sbdb_covariances[:, 3, 3]  # sigma_raanraan
+    covariances[:, 4, 3] = covariances[:, 3, 4] = sbdb_covariances[
+        :, 4, 3
+    ]  # sigma_raanap
+    covariances[:, 5, 3] = covariances[:, 3, 5] = sbdb_covariances[
+        :, 2, 3
+    ]  # sigma_raantp
+
+    # sigma_ap{x}
+    covariances[:, 4, 4] = sbdb_covariances[:, 4, 4]  # sigma_apap
+    covariances[:, 5, 4] = covariances[:, 4, 5] = sbdb_covariances[
+        :, 2, 4
+    ]  # sigma_aptp
+
+    # sigma_tp{x}
+    covariances[:, 5, 5] = sbdb_covariances[:, 2, 2]  # sigma_tptp
+
+    return covariances
+
+
+def _get_sbdb_elements(obj_ids: List[str]) -> List[OrderedDict]:
+    """
+    Get orbital elements and other object properties
+    from JPL's Small Body Database Browser.
+
+    Parameters
+    ----------
+    obj_ids : List
+        Object IDs to query.
+
+    Returns
+    -------
+    results : List
+        List of dictionaries containing orbital elements and other object properties.
+    """
+    results = []
+    for obj_id in obj_ids:
+        result = SBDB.query(
+            obj_id,
+            covariance="mat",
+            id_type="search",
+            full_precision=True,
+            solution_epoch=False,
+        )
+        results.append(result)
+
+    return results
+
+
+def query_sbdb(ids: npt.ArrayLike) -> Orbits:
+    """
+    Query JPL's Small-Body Database (SBDB) for orbits. The epoch at
+    which the orbits are returned are near the epoch as published by the
+    Minor Planet Center.
+
+    By default, the orbit's covariance matrices are also queried for. If they
+    are not available, then the 1-sigma uncertainties are used to construct
+    the covariance matrices.
+
+    Parameters
+    ----------
+    ids : list
+        List of object IDs to query.
+
+    Returns
+    -------
+    orbits : `~adam_core.orbits.orbits.Orbits`
+        Orbits object containing the queried orbits.
+    """
+    results = _get_sbdb_elements(ids)
+
+    object_ids = []
+    classes = []
+    coords_cometary = np.zeros((len(results), 6), dtype=np.float64)
+    covariances_sbdb = np.zeros((len(results), 6, 6), dtype=np.float64)
+    times = np.zeros((len(results)), dtype=np.float64)
+
+    for i, result in enumerate(results):
+        object_ids.append(result["object"]["fullname"])
+        classes.append(result["object"]["orbit_class"]["code"])
+
+        if "covariance" in result["orbit"]:
+            result_i = result["orbit"]["covariance"]
+            covariances_sbdb[i, :, :] = result_i["data"]
+
+        else:
+            result_i = result["orbit"]
+            sigmas = np.array(
+                [
+                    [
+                        result_i["elements"]["e_sig"],
+                        result_i["elements"]["q_sig"].value,
+                        result_i["elements"]["tp_sig"].value,
+                        result_i["elements"]["om_sig"].value,
+                        result_i["elements"]["w_sig"].value,
+                        result_i["elements"]["i_sig"].value,
+                    ]
+                ]
+            )
+            covariances_sbdb[i, :, :] = sigmas_to_covariance(sigmas).filled()[0]
+
+        times[i] = result_i["epoch"].value
+        coords_cometary[i, 0] = result_i["elements"]["q"].value
+        coords_cometary[i, 1] = result_i["elements"]["e"]
+        coords_cometary[i, 2] = result_i["elements"]["i"].value
+        coords_cometary[i, 3] = result_i["elements"]["om"].value
+        coords_cometary[i, 4] = result_i["elements"]["w"].value
+        coords_cometary[i, 5] = Time(
+            result_i["elements"]["tp"].value, scale="tdb", format="jd"
+        ).mjd
+
+    covariances_cometary = _convert_SBDB_covariances(covariances_sbdb)
+    times = Time(times, scale="tdb", format="jd")
+
+    coordinates = CometaryCoordinates(
+        times=times,
+        q=coords_cometary[:, 0],
+        e=coords_cometary[:, 1],
+        i=coords_cometary[:, 2],
+        raan=coords_cometary[:, 3],
+        ap=coords_cometary[:, 4],
+        tp=coords_cometary[:, 5],
+        covariances=covariances_cometary,
+    )
+
+    object_ids = np.array(object_ids)
+    classes = np.array(classes)
+
+    return Orbits(coordinates, object_ids=object_ids)

--- a/adam_core/orbits/query/tests/__init__.py
+++ b/adam_core/orbits/query/tests/__init__.py
@@ -1,0 +1,43 @@
+import numpy as np
+import numpy.testing as npt
+
+from ..sbdb import _convert_SBDB_covariances
+
+
+def test_convert_SBDB_covariances():
+    sbdb_format = np.array(
+        [
+            ["e_e", "e_q", "e_tp", "e_raan", "e_ap", "e_i"],
+            ["q_e", "q_q", "q_tp", "q_raan", "q_ap", "q_i"],
+            ["tp_e", "tp_q", "tp_tp", "tp_raan", "tp_ap", "tp_i"],
+            ["raan_e", "raan_q", "raan_tp", "raan_raan", "raan_ap", "raan_i"],
+            ["ap_e", "ap_q", "ap_tp", "ap_raan", "ap_ap", "ap_i"],
+            ["i_e", "i_q", "i_tp", "i_raan", "i_ap", "i_i"],
+        ]
+    )
+    adam_format = np.array(
+        [
+            ["q_q", "q_e", "q_i", "q_raan", "q_ap", "q_tp"],
+            ["e_q", "e_e", "e_i", "e_raan", "e_ap", "e_tp"],
+            ["i_q", "i_e", "i_i", "i_raan", "i_ap", "i_tp"],
+            ["raan_q", "raan_e", "raan_i", "raan_raan", "raan_ap", "raan_tp"],
+            ["ap_q", "ap_e", "ap_i", "ap_raan", "ap_ap", "ap_tp"],
+            ["tp_q", "tp_e", "tp_i", "tp_raan", "tp_ap", "tp_tp"],
+        ]
+    )
+    sbdb_format = np.array([sbdb_format])
+    adam_format = np.array([adam_format])
+
+    cometary_covariances = _convert_SBDB_covariances(sbdb_format)
+    # Some of the symmetric terms will be in reverse format: for example
+    # q_e will be e_q where it should be q_e. So for places where
+    # the order is reversed, let's try to flip them around and then lets
+    # check for equality with the expected ADAM format.
+
+    flip_mask = np.where(cometary_covariances != adam_format)
+    for i, j, k in zip(*flip_mask):
+        cometary_covariances[i, j, k] = "_".join(
+            cometary_covariances[i, j, k].split("_")[::-1]
+        )
+
+    npt.assert_equal(cometary_covariances, adam_format)

--- a/adam_core/orbits/query/tests/test_sbdb.py
+++ b/adam_core/orbits/query/tests/test_sbdb.py
@@ -1,0 +1,43 @@
+import numpy as np
+import numpy.testing as npt
+
+from ..sbdb import _convert_SBDB_covariances
+
+
+def test__convert_SBDB_covariances():
+    sbdb_format = np.array(
+        [
+            ["e_e", "e_q", "e_tp", "e_raan", "e_ap", "e_i"],
+            ["q_e", "q_q", "q_tp", "q_raan", "q_ap", "q_i"],
+            ["tp_e", "tp_q", "tp_tp", "tp_raan", "tp_ap", "tp_i"],
+            ["raan_e", "raan_q", "raan_tp", "raan_raan", "raan_ap", "raan_i"],
+            ["ap_e", "ap_q", "ap_tp", "ap_raan", "ap_ap", "ap_i"],
+            ["i_e", "i_q", "i_tp", "i_raan", "i_ap", "i_i"],
+        ]
+    )
+    adam_core_format = np.array(
+        [
+            ["q_q", "q_e", "q_i", "q_raan", "q_ap", "q_tp"],
+            ["e_q", "e_e", "e_i", "e_raan", "e_ap", "e_tp"],
+            ["i_q", "i_e", "i_i", "i_raan", "i_ap", "i_tp"],
+            ["raan_q", "raan_e", "raan_i", "raan_raan", "raan_ap", "raan_tp"],
+            ["ap_q", "ap_e", "ap_i", "ap_raan", "ap_ap", "ap_tp"],
+            ["tp_q", "tp_e", "tp_i", "tp_raan", "tp_ap", "tp_tp"],
+        ]
+    )
+    sbdb_format = np.array([sbdb_format])
+    adam_core_format = np.array([adam_core_format])
+
+    cometary_covariances = _convert_SBDB_covariances(sbdb_format)
+    # Some of the symmetric terms will be in reverse format: for example
+    # q_e will be e_q where it should be q_e. So for places where
+    # the order is reversed, let's try to flip them around and then lets
+    # check for equality with the expected adam format.
+
+    flip_mask = np.where(cometary_covariances != adam_core_format)
+    for i, j, k in zip(*flip_mask):
+        cometary_covariances[i, j, k] = "_".join(
+            cometary_covariances[i, j, k].split("_")[::-1]
+        )
+
+    npt.assert_equal(cometary_covariances, adam_core_format)

--- a/adam_core/utils/indexable.py
+++ b/adam_core/utils/indexable.py
@@ -205,7 +205,7 @@ class Indexable:
         member_lengths = {
             len(v)
             for v in self.__dict__.values()
-            if isinstance(v, SLICEABLE_DATA_STRUCTURES)
+            if isinstance(v, SLICEABLE_DATA_STRUCTURES) or isinstance(v, Indexable)
         }
         if len(member_lengths) != 1:
             raise ValueError("All sliceable members must have the same length.")

--- a/adam_core/utils/indexable.py
+++ b/adam_core/utils/indexable.py
@@ -291,6 +291,28 @@ class Indexable:
 
         return
 
+    @staticmethod
+    def _convert_to_array(value):
+        """
+        Check the type of the value and convert it to a numpy array if it is not already.
+
+        This should be used when ingesting data into the class to ensure that the data is
+        in the correct format.
+        """
+        if isinstance(value, (int, float, str)):
+            logger.debug("Converting member to a numpy array.")
+            value = np.array([value])
+        elif isinstance(value, list):
+            logger.debug("Converting list to a numpy array.")
+            value = np.array(value)
+        elif isinstance(value, (np.ndarray, np.ma.masked_array)):
+            logger.debug("Member is already a numpy array.")
+        else:
+            err = "Member must be int, float, str, list, or numpy.ndarray to be converted to a numpy.ndarray"
+            raise ValueError(err)
+
+        return value
+
     def _query_index(
         self, class_ind: Union[int, slice, list, np.ndarray]
     ) -> np.ndarray:

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -206,6 +206,30 @@ def test__check_member_validity():
     assert member_length == N
 
 
+def test__convert_to_array():
+    # Test that the function correctly converts strings, floats, ints to an array
+    # as a single element in the array
+    value = "test str"
+    desired = np.array(["test str"])
+    np.testing.assert_equal(Indexable._convert_to_array(value), desired)
+
+    value = 23
+    desired = np.array([23])
+    np.testing.assert_equal(Indexable._convert_to_array(value), desired)
+
+    value = 3.14
+    desired = np.array([3.14])
+    np.testing.assert_equal(Indexable._convert_to_array(value), desired)
+
+    value = [3, 2, 1]
+    desired = np.array([3, 2, 1])
+    np.testing.assert_equal(Indexable._convert_to_array(value), desired)
+
+    value = np.array([1, 2, 3])
+    desired = np.array([1, 2, 3])
+    np.testing.assert_equal(Indexable._convert_to_array(value), desired)
+
+
 def test_Indexable__query_index_int():
     # Array is grouped and can be represented by slices
     indexable = DummyIndexable(np.array([0, 1, 2, 3, 4, 5]))


### PR DESCRIPTION
Adds the Orbits class from THOR along with two query utilities that allow orbits to be loaded from both JPL Horizons and SBDB. 

The README was updated with some example usage if anyone wants to give it a go. 

Few follow up items that could be useful in future PRs:
- Port MPC utilities from THOR: reading orbits from the MPCORB into the Orbits class. This doesn't cross a network boundary if the anticipated input is the filename so could be directly attached to the Orbits class. 
- Add PhotometricProperties class or similar that manages observed physical characteristics such as H magnitude and photometric slope. These could be added initially to the Orbits class. Will need to sketch this out. Low priority for now as it is non-critical for THOR and precovery. 