### PR TITLE
Add Backend class [ADAM-107] 

### DIFF
--- a/.github/workflows/docker-build-lint-test.yml
+++ b/.github/workflows/docker-build-lint-test.yml
@@ -17,8 +17,12 @@ jobs:
       - uses: jpribyl/action-docker-layer-caching@v0.1.0
         # Ignore the failure of a step and avoid terminating the job.
         continue-on-error: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
       - name: Build and Install
-        run: docker build -t adam-core:$IMAGE_TAG .
+        run: docker build --load -t adam-core:$IMAGE_TAG .
       - name: Lint
         run:  docker run -i adam-core:$IMAGE_TAG pre-commit run --all-files
       - name: Test

--- a/.github/workflows/docker-build-lint-test.yml
+++ b/.github/workflows/docker-build-lint-test.yml
@@ -1,4 +1,4 @@
-name: docker - Build, Lint, and Test
+name: docker - Build Lint and Test
 
 on:
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:jammy
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \ 
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update \
     && apt-get upgrade -y \
     && apt-get install libcurl4-openssl-dev libssl-dev git curl unzip python3.11 pip -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,26 @@
 FROM ubuntu:jammy
 
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \ 
+    apt-get update \
     && apt-get upgrade -y \
-    && apt-get install libcurl4-openssl-dev libssl-dev git python3.11 pip -y
+    && apt-get install libcurl4-openssl-dev libssl-dev git curl unzip python3.11 pip -y
+
+# Install pyoorb from B612's fork, which includes a patch to handle fortran errors better
+ENV OORB_TAG=v1.2.1a1.dev2
+ENV OORB_VERSION="pyoorb-1.2.1a1.dev2+66b7753.dirty"
+
+# Install oorb data
+RUN curl -fL -o /tmp/oorb_data.zip \
+    "https://github.com/B612-Asteroid-Institute/oorb/releases/download/${OORB_TAG}/oorb_data.zip"
+RUN unzip -d /opt/oorb_data /tmp/oorb_data.zip
+ENV OORB_DATA=/opt/oorb_data
+
+# Install pyoorb
+RUN --mount=type=cache,target=/root/.cache/pip \
+    export WHEEL_NAME="${OORB_VERSION}-cp310-cp310-manylinux_2_17_$(uname -m).manylinux2014_$(uname -m).whl" && \
+    pip install "https://github.com/B612-Asteroid-Institute/oorb/releases/download/${OORB_TAG}/${WHEEL_NAME}"
+
 
 # Upgrade pip to the latest version and install pre-commit
 RUN pip install --upgrade pip pre-commit

--- a/README.md
+++ b/README.md
@@ -127,6 +127,35 @@ orbits.cartesian
 orbits.spherical
 ```
 
+### Propagator
+The propagator class in `adam_core` provides a generalized interface to the supported orbit integrators and ephemeris generators. By default,
+`adam_core` ships with PYOORB.
+
+To propagate orbits with PYOORB (here we grab some orbits from Horizons first):
+```python
+import numpy as np
+from astropy.time import Time
+from astropy import units as u
+from adam_core.orbits.query import query_horizons
+from adam_core.propagator import PYOORB
+# Get orbit to propagate
+initial_time = Time([60000.0], scale="tdb", format="mjd")
+object_ids = ["Duende", "Eros", "Ceres"]
+orbits = query_horizons(object_ids, initial_time)
+# Make sure PYOORB is ready
+propagator = PYOORB()
+# Define propagation times
+times = initial_time + np.arange(0, 100) * u.d
+# Propagate orbits! This function supports multiprocessing for large
+# propagation jobs.
+propagated_orbits = propagator.propagate_orbits(
+    orbits,
+    times,
+    chunk_size=100,
+    num_jobs=1,
+)
+```
+
 ### Lower Level Classes
 These classes are designed more for developers interested in building codes derived from utilities
 in this package.

--- a/README.md
+++ b/README.md
@@ -12,84 +12,105 @@ To define an orbit:
 ```python
 from astropy.time import Time
 from adam_core.coordinates import KeplerianCoordinates
+from adam_core.coordinates import Times
+from adam_core.coordinates import Origin
 from adam_core.orbits import Orbits
 
-keplerian_elements = KeplerianCoordinates(
-    times=Time(59000.0, scale="tdb", format="mjd"),
-    a=1.0,
-    e=0.002,
-    i=10.,
-    raan=50.0,
-    ap=20.0,
-    M=30.0,
+keplerian_elements = KeplerianCoordinates.from_kwargs(
+    times=Times.from_astropy(
+        Time([59000.0], scale="tdb", format="mjd")
+    ),
+    a=[1.0],
+    e=[0.002],
+    i=[10.],
+    raan=[50.0],
+    ap=[20.0],
+    M=[30.0],
+    origin=Origin.from_kwargs(code=["SUN"]),
+    frame="ecliptic"
 )
-orbits = Orbits(
-    keplerian_elements,
-    orbit_ids="1",
-    object_ids="Test Orbit"
+orbits = Orbits.from_kwargs(
+    orbit_ids=["1"],
+    object_ids=["Test Orbit"],
+    coordinates=keplerian_elements.to_cartesian(),
 )
 ```
+Note that internally, all orbits are stored in Cartesian coordinates. Cartesian coordinates do not have any
+singularities and are thus more robust for numerical integration. Any orbital element conversions to Cartesian
+can be done on demand by calling `to_cartesian()` on the coordinates object.
+
 The underlying orbits class is 2 dimensional and can store elements and covariances for multiple orbits.
 
 ```python
 from astropy.time import Time
 from adam_core.coordinates import KeplerianCoordinates
+from adam_core.coordinates import Times
+from adam_core.coordinates import Origin
 from adam_core.orbits import Orbits
 
-keplerian_elements = KeplerianCoordinates(
-    times=Time([59000.0, 60000.0], scale="tdb", format="mjd"),
+keplerian_elements = KeplerianCoordinates.from_kwargs(
+    times=Times.from_astropy(
+        Time([59000.0, 60000.0], scale="tdb", format="mjd")
+    ),
     a=[1.0, 3.0],
     e=[0.002, 0.0],
     i=[10., 30.],
     raan=[50.0, 32.0],
     ap=[20.0, 94.0],
     M=[30.0, 159.0],
+    origin=Origin.from_kwargs(code=["SUN", "SUN"]),
+    frame="ecliptic"
 )
-orbits = Orbits(
-    keplerian_elements,
+orbits = Orbits.from_kwargs(
     orbit_ids=["1", "2"],
-    object_ids=["Test Orbit 1", "Test Orbit 2"]
+    object_ids=["Test Orbit 1", "Test Orbit 2"],
+    coordinates=keplerian_elements.to_cartesian(),
 )
 ```
 
 Orbits can be easily converted to a pandas DataFrame:
 ```python
-orbits.to_df()
-  orbit_id     object_id  mjd_tdb    a      e     i  raan    ap      M       origin     frame
-0        1  Test Orbit 1  59000.0  1.0  0.002  10.0  50.0  20.0   30.0  heliocenter  ecliptic
-1        2  Test Orbit 2  60000.0  3.0  0.000  30.0  32.0  94.0  159.0  heliocenter  ecliptic
+orbits.to_dataframe()
+ orbit_ids	object_ids	times.jd1	times.jd2	x	y	z	vx	vy	vz	...	cov_vy_y	cov_vy_z	cov_vy_vx	cov_vy_vy	cov_vz_x	cov_vz_y	cov_vz_z	cov_vz_vx	cov_vz_vy	cov_vz_vz
+0	1	Test Orbit 1	2459000.0	0.5	-0.166403	0.975273	0.133015	-0.016838	-0.003117	0.001921	...	NaN	NaN	NaN	NaN	NaN	NaN	NaN	NaN	NaN	NaN
+1	2	Test Orbit 2	2460000.0	0.5	0.572777	-2.571820	-1.434457	0.009387	0.002900	-0.001452	...	NaN	NaN	NaN	NaN	NaN	NaN	NaN	NaN	NaN	NaN
 ```
 
 Orbits can also be defined with uncertainties.
 ```python
+import numpy as np
 from astropy.time import Time
 from adam_core.coordinates import KeplerianCoordinates
+from adam_core.coordinates import Times
+from adam_core.coordinates import Origin
+from adam_core.coordinates import CoordinateCovariances
 from adam_core.orbits import Orbits
 
-keplerian_elements = KeplerianCoordinates(
-    times=Time(59000.0, scale="tdb", format="mjd"),
-    a=1.0,
-    e=0.002,
-    i=10.,
-    raan=50.0,
-    ap=20.0,
-    M=30.0,
-    sigma_a=0.002,
-    sigma_e=0.001,
-    sigma_i=0.01,
-    sigma_raan=0.01,
-    sigma_ap=0.1,
-    sigma_M=0.1,
+keplerian_elements = KeplerianCoordinates.from_kwargs(
+    times=Times.from_astropy(
+        Time([59000.0], scale="tdb", format="mjd")
+    ),
+    a=[1.0],
+    e=[0.002],
+    i=[10.],
+    raan=[50.0],
+    ap=[20.0],
+    M=[30.0],
+    covariances=CoordinateCovariances.from_sigmas(
+        np.array([[0.002, 0.001, 0.01, 0.01, 0.1, 0.1]])
+    ),
+    origin=Origin.from_kwargs(code=["SUN"]),
+    frame="ecliptic"
 )
 
-orbits = Orbits(
-    keplerian_elements,
+orbits = Orbits.from_kwargs(
     orbit_ids=["1"],
-    object_ids=["Test Orbit with Uncertainties"]
+    object_ids=["Test Orbit with Uncertainties"],
+    coordinates=keplerian_elements.to_cartesian(),
 )
-orbits.to_df(sigmas=True)
-  orbit_id                      object_id  mjd_tdb    a  ...  sigma_ap  sigma_M       origin     frame
-0        1  Test Orbit with Uncertainties  59000.0  1.0  ...       0.1      0.1  heliocenter  ecliptic
+orbits.to_dataframe(sigmas=True)
+ orbit_ids	object_ids	times.jd1	times.jd2	x	y	z	vx	vy	vz	...	cov_vy_y	cov_vy_z	cov_vy_vx	cov_vy_vy	cov_vz_x	cov_vz_y	cov_vz_z	cov_vz_vx	cov_vz_vy	cov_vz_vz
+0	1	Test Orbit with Uncertainties	2459000.0	0.5	-0.166403	0.975273	0.133015	-0.016838	-0.003117	0.001921	...	3.625729e-08	-1.059731e-08	-9.691716e-11	1.872922e-09	1.392222e-08	-1.759744e-09	-1.821839e-09	-7.865582e-11	2.237521e-10	3.971297e-11
 ```
 
 To query orbits from JPL Horizons:
@@ -114,17 +135,13 @@ orbits = query_sbdb(object_ids)
 Orbital elements can be accessed via the corresponding attribute. All conversions, including covariances, are done on demand and stored.
 
 ```python
-# Keplerian Elements
-orbits.keplerian
-
-# Cometary Elements
-orbits.cometary
-
 # Cartesian Elements
-orbits.cartesian
+orbits.coordinates
 
-# Spherical Elements
-orbits.spherical
+# To convert to other representations
+cometary_elements = orbits.coordinates.to_cometary()
+keplerian_elements = orbits.coordinates.to_keplerian()
+spherical_elements = orbits.coordinates.to_spherical()
 ```
 
 ### Propagator
@@ -138,14 +155,18 @@ from astropy.time import Time
 from astropy import units as u
 from adam_core.orbits.query import query_horizons
 from adam_core.propagator import PYOORB
+
 # Get orbit to propagate
 initial_time = Time([60000.0], scale="tdb", format="mjd")
 object_ids = ["Duende", "Eros", "Ceres"]
 orbits = query_horizons(object_ids, initial_time)
+
 # Make sure PYOORB is ready
 propagator = PYOORB()
+
 # Define propagation times
 times = initial_time + np.arange(0, 100) * u.d
+
 # Propagate orbits! This function supports multiprocessing for large
 # propagation jobs.
 propagated_orbits = propagator.propagate_orbits(
@@ -155,44 +176,6 @@ propagated_orbits = propagator.propagate_orbits(
     num_jobs=1,
 )
 ```
-
-### Lower Level Classes
-These classes are designed more for developers interested in building codes derived from utilities
-in this package.
-
-#### Coordinates
-
-```python
-from astropy.time import Time
-from adam_core.coordinates import CartesianCoordinates, transform_coordinates
-
-# Instantiate a Cartesian coordinate
-time = Time(
-    [cartesian.mjd_tdb],
-    scale="tdb",
-    format="mjd",
-)
-cartesian_coordinates = CartesianCoordinates(
-    x=np.array([cartesian.x]),
-    y=np.array([cartesian.y]),
-    z=np.array([cartesian.z]),
-    vx=np.array([cartesian.vx]),
-    vy=np.array([cartesian.vy]),
-    vz=np.array([cartesian.vz]),
-    times=time,
-    origin="heliocenter",
-    frame="ecliptic",
-)
-
-keplerian_coordinates = transform_coordinates(
-    cartesian_coordinates,
-    representation_out="keplerian",
-    frame_out="ecliptic"
-)
-
-print(keplerian_coordinates)
-```
-
 
 ## Package Structure
 

--- a/adam_core/coordinates/__init__.py
+++ b/adam_core/coordinates/__init__.py
@@ -3,6 +3,7 @@ from .cartesian import CARTESIAN_COLS, CARTESIAN_UNITS, CartesianCoordinates
 from .cometary import COMETARY_COLS, COMETARY_UNITS, CometaryCoordinates
 from .conversions import convert_coordinates
 from .covariances import (
+    CoordinateCovariances,
     covariances_from_df,
     covariances_to_df,
     covariances_to_table,

--- a/adam_core/orbits/query/horizons.py
+++ b/adam_core/orbits/query/horizons.py
@@ -171,9 +171,7 @@ def query_horizons(
         )
         object_ids = vectors["targetname"].values
 
-        return Orbits.from_kwargs(
-            object_ids=object_ids, coordinates=coordinates.to_cartesian()
-        )
+        return Orbits.from_kwargs(object_ids=object_ids, coordinates=coordinates)
 
     elif coordinate_type == "keplerian":
         elements = _get_horizons_elements(

--- a/adam_core/propagator/__init__.py
+++ b/adam_core/propagator/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa: F401
 from .propagator import Propagator
+from .pyoorb import PYOORB

--- a/adam_core/propagator/__init__.py
+++ b/adam_core/propagator/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa: F401
 from .propagator import Propagator
 from .pyoorb import PYOORB
+from .utils import _iterate_chunks

--- a/adam_core/propagator/__init__.py
+++ b/adam_core/propagator/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa: F401
+from .propagator import Propagator

--- a/adam_core/propagator/propagator.py
+++ b/adam_core/propagator/propagator.py
@@ -1,0 +1,173 @@
+import logging
+import multiprocessing as mp
+from abc import ABC, abstractmethod
+from itertools import repeat
+from typing import Optional
+
+from astropy.time import Time
+
+from ..orbits import Orbits
+from ..utils.indexable import concatenate
+
+logger = logging.getLogger(__name__)
+
+
+def propagation_worker(orbits: Orbits, times: Time, propagator: "Propagator") -> Orbits:
+    propagated = propagator._propagate_orbits(orbits, times)
+    return propagated
+
+
+def ephemeris_worker(orbits: Orbits, observers, propagator: "Propagator"):
+    ephemeris = propagator._generate_ephemeris(orbits, observers)
+    return ephemeris
+
+
+class Propagator(ABC):
+    """
+    Class for propagating orbits and generating ephemerides. Subclasses
+    should implement the _propagate_orbits and _generate_ephemeris methods.
+
+    Important: subclasses should be pickleable! As this class uses multiprocessing
+    to parallelize propagation and ephemeris generation. This means that
+    subclasses should not have any unpickleable attributes.
+
+
+    """
+
+    @abstractmethod
+    def _propagate_orbits(self, orbits: Orbits, times: Time) -> Orbits:
+        """
+        Propagate orbits to times.
+
+        THIS FUNCTION SHOULD BE DEFINED BY THE USER.
+        """
+        pass
+
+    def propagate_orbits(
+        self,
+        orbits: Orbits,
+        times: Time,
+        chunk_size: int = 100,
+        num_jobs: Optional[int] = 1,
+    ) -> Orbits:
+        """
+        Propagate each orbit in orbits to each time in times.
+
+        Parameters
+        ----------
+        orbits : `~adam_core.orbits.orbits.Orbits` (N)
+            Orbits to propagate.
+        times : `~astropy.time.core.Time` (M)
+            Times to which to propagate orbits.
+        chunk_size : int, optional
+            Number of orbits to send to each job.
+        num_jobs : int or None, optional
+            Number of jobs to launch. If None then the number of
+            jobs will be equal to the number of cores on the machine. If 1
+            then no multiprocessing will be used.
+
+        Returns
+        -------
+        propagated : `~adam_core.orbits.orbits.Orbits`
+            Propagated orbits.
+        """
+        if num_jobs is None or num_jobs > 1:
+            orbits_split = list(orbits.yield_chunks(chunk_size))
+
+            p = mp.Pool(
+                processes=num_jobs,
+            )
+
+            propagated_list = p.starmap(
+                propagation_worker,
+                zip(
+                    orbits_split,
+                    repeat(times),
+                    repeat(self),
+                ),
+            )
+            p.close()
+            p.join()
+
+            propagated = concatenate(propagated_list)
+        else:
+            propagated = self._propagate_orbits(orbits, times)
+
+        propagated.sort_values(
+            by=["orbit_ids", "times"], ascending=[True, True], inplace=True
+        )
+
+        return propagated
+
+    @abstractmethod
+    def _generate_ephemeris(self, orbits: Orbits, observers):
+        """
+        Generate ephemerides for the given orbits as observed by
+        the observers.
+
+        THIS FUNCTION SHOULD BE DEFINED BY THE USER.
+        """
+        pass
+
+    def generate_ephemeris(
+        self,
+        orbits: Orbits,
+        observers,
+        chunk_size: int = 100,
+        num_jobs: Optional[int] = 1,
+    ):
+        """
+        Generate ephemerides for each orbit in orbits as observed by each observer
+        in observers.
+
+        Parameters
+        ----------
+        orbits : `~adam_core.orbits.orbits.Orbits` (N)
+            Orbits for which to generate ephemerides.
+        observers : (M)
+            Observers for which to generate the ephemerides of each
+            orbit.
+        chunk_size : int, optional
+            Number of orbits to send to each job.
+        num_jobs : int or None, optional
+            Number of jobs to launch. If None then the number of
+            jobs will be equal to the number of cores on the machine. If 1
+            then no multiprocessing will be used.
+
+        Returns
+        -------
+        ephemeris : (N * M)
+            Predicted ephemerides for each orbit observed by each
+            observer.
+
+        TODO: Add ephemeris class
+        TODO: Add an observers class
+        """
+        if num_jobs is None or num_jobs > 1:
+            orbits_split = list(orbits.yield_chunks(chunk_size))
+
+            p = mp.Pool(
+                processes=num_jobs,
+            )
+
+            ephemeris_list = p.starmap(
+                ephemeris_worker,
+                zip(
+                    orbits_split,
+                    repeat(observers),
+                    repeat(self),
+                ),
+            )
+            p.close()
+            p.join()
+
+            ephemeris = concatenate(ephemeris_list)
+
+        else:
+            ephemeris = self._generate_ephemeris(orbits, observers)
+
+        ephemeris.sort_values(
+            by=["orbit_ids", "origin", "times"],
+            inplace=True,
+        )
+        return ephemeris

--- a/adam_core/propagator/pyoorb.py
+++ b/adam_core/propagator/pyoorb.py
@@ -1,0 +1,312 @@
+try:
+    import pyoorb as oo
+except ImportError:
+    raise ImportError("PYOORB is not installed.")
+
+import os
+import warnings
+from typing import Optional
+
+import numpy as np
+from astropy.time import Time
+
+from ..coordinates.cartesian import CartesianCoordinates
+from ..orbits.orbits import Orbits
+from .propagator import Propagator
+
+PYOORB_CONFIG = {"dynamical_model": "N", "ephemeris_file": "de430.dat"}
+
+
+class PYOORB(Propagator):
+    def __init__(self, **kwargs):
+        # Make sure only the correct kwargs are passed to the constructor
+        allowed_kwargs = PYOORB_CONFIG.keys()
+        for k in kwargs:
+            if k not in allowed_kwargs:
+                warnings.warn(
+                    f"Invalid argument {k} passed to PYOORB propagator. Ignoring..."
+                )
+
+        # If an allowed kwarg is missing, add the default
+        for k in allowed_kwargs:
+            if k not in kwargs:
+                kwargs[k] = PYOORB_CONFIG[k]
+
+        self.dynamical_model = kwargs["dynamical_model"]
+        self.ephemeris_file = kwargs["ephemeris_file"]
+
+        env_var = "ADAM_CORE_PYOORB_INITIALIZED"
+        if env_var in os.environ.keys() and os.environ[env_var] == "True":
+            pass
+        else:
+            if os.environ.get("OORB_DATA") is None:
+                if os.environ.get("CONDA_PREFIX") is None:
+                    raise RuntimeError(
+                        "Cannot find OORB_DATA directory. Please set the OORB_DATA environment variable."
+                    )
+                else:
+                    os.environ["OORB_DATA"] = os.path.join(
+                        os.environ["CONDA_PREFIX"], "share/openorb"
+                    )
+
+            # Prepare pyoorb
+            ephfile = os.path.join(os.getenv("OORB_DATA"), self.ephemeris_file)
+            err = oo.pyoorb.oorb_init(ephfile)
+            if err == 0:
+                os.environ[env_var] = "True"
+            else:
+                warnings.warn(f"PYOORB returned error code: {err}")
+
+        return
+
+    @staticmethod
+    def _configure_orbits(
+        orbits: np.ndarray,
+        t0: np.ndarray,
+        orbit_type: str,
+        time_scale: str,
+        magnitude: Optional[float] = None,
+        slope: Optional[float] = None,
+    ) -> np.ndarray:
+        """
+        Convert an array of orbits into the format expected by PYOORB.
+
+        Parameters
+        ----------
+        orbits : `~numpy.ndarray` (N, 6)
+            Orbits to convert. See orbit_type for expected input format.
+        t0 : `~numpy.ndarray` (N)
+            Epoch in MJD at which the orbits are defined.
+        orbit_type : {'cartesian', 'keplerian', 'cometary'}, optional
+            Orbital element representation of the provided orbits.
+            If cartesian:
+                x : heliocentric ecliptic J2000 x position in AU
+                y : heliocentric ecliptic J2000 y position in AU
+                z : heliocentric ecliptic J2000 z position in AU
+                vx : heliocentric ecliptic J2000 x velocity in AU per day
+                vy : heliocentric ecliptic J2000 y velocity in AU per day
+                vz : heliocentric ecliptic J2000 z velocity in AU per day
+            If keplerian:
+                a : semi-major axis in AU
+                e : eccentricity in degrees
+                i : inclination in degrees
+                Omega : longitude of the ascending node in degrees
+                omega : argument of periapsis in degrees
+                M0 : mean anomaly in degrees
+            If cometary:
+                p : perihelion distance in AU
+                e : eccentricity in degrees
+                i : inclination in degrees
+                Omega : longitude of the ascending node in degrees
+                omega : argument of periapsis in degrees
+                T0 : time of perihelion passage in MJD
+        time_scale : {'UTC', 'UT1', 'TT', 'TAI'}, optional
+            Time scale of the MJD epochs.
+        magnitude : float or `~numpy.ndarray` (N), optional
+            Absolute H-magnitude or M1 magnitude.
+        slope : float or `~numpy.ndarray` (N), optional
+            Photometric slope parameter G or K1.
+
+        Returns
+        -------
+        orbits_pyoorb : `~numpy.ndarray` (N, 12)
+            Orbits formatted in the format expected by PYOORB.
+                orbit_id : index of input orbits
+                elements x6: orbital elements of propagated orbits
+                orbit_type : orbit type
+                epoch_mjd : epoch of the propagate orbit
+                time_scale : time scale of output epochs
+                H/M1 : absolute magnitude
+                G/K1 : photometric slope parameter
+        """
+        orbits_ = orbits.copy()
+        num_orbits = orbits_.shape[0]
+
+        if orbit_type == "cartesian":
+            orbit_type_ = np.array([1 for i in range(num_orbits)])
+        elif orbit_type == "cometary":
+            orbit_type_ = np.array([2 for i in range(num_orbits)])
+            # H = M1
+            # G = K1
+            orbits_[:, 1:5] = np.radians(orbits_[:, 1:5])
+        elif orbit_type == "keplerian":
+            orbit_type_ = np.array([3 for i in range(num_orbits)])
+            orbits_[:, 1:] = np.radians(orbits_[:, 1:])
+        else:
+            raise ValueError(
+                "orbit_type should be one of {'cartesian', 'keplerian', 'cometary'}"
+            )
+
+        if time_scale == "UTC":
+            time_scale_ = np.array([1 for i in range(num_orbits)])
+        elif time_scale == "UT1":
+            time_scale_ = np.array([2 for i in range(num_orbits)])
+        elif time_scale == "TT":
+            time_scale_ = np.array([3 for i in range(num_orbits)])
+        elif time_scale == "TAI":
+            time_scale_ = np.array([4 for i in range(num_orbits)])
+        else:
+            raise ValueError("time_scale should be one of {'UTC', 'UT1', 'TT', 'TAI'}")
+
+        if isinstance(slope, (float, int)):
+            slope_ = np.array([slope for i in range(num_orbits)])
+        elif isinstance(slope, list):
+            slope_ = np.array(slope)
+        elif isinstance(slope, np.ndarray):
+            slope_ = slope
+        else:
+            slope_ = np.array([0.15 for i in range(num_orbits)])
+
+        if isinstance(magnitude, (float, int)):
+            magnitude_ = np.array([magnitude for i in range(num_orbits)])
+        elif isinstance(magnitude, list):
+            magnitude_ = np.array(magnitude)
+        elif isinstance(magnitude, np.ndarray):
+            magnitude_ = magnitude
+        else:
+            magnitude_ = np.array([20.0 for i in range(num_orbits)])
+
+        ids = np.array([i for i in range(num_orbits)])
+
+        orbits_pyoorb = np.zeros((num_orbits, 12), dtype=np.double, order="F")
+        orbits_pyoorb[:, 0] = ids
+        orbits_pyoorb[:, 1:7] = orbits_
+        orbits_pyoorb[:, 7] = orbit_type_
+        orbits_pyoorb[:, 8] = t0
+        orbits_pyoorb[:, 9] = time_scale_
+        orbits_pyoorb[:, 10] = magnitude_
+        orbits_pyoorb[:, 11] = slope_
+
+        return orbits_pyoorb
+
+    @staticmethod
+    def _configure_epochs(epochs: np.ndarray, time_scale: str) -> np.ndarray:
+        """
+        Convert an array of orbits into the format expected by PYOORB.
+
+        Parameters
+        ----------
+        epochs : `~numpy.ndarray` (N)
+            Epoch in MJD to convert.
+        time_scale : {'UTC', 'UT1', 'TT', 'TAI'}
+            Time scale of the MJD epochs.
+
+        Returns
+        -------
+        epochs_pyoorb : `~numpy.ndarray` (N, 2)
+            Epochs converted into the PYOORB format.
+        """
+        num_times = len(epochs)
+        if time_scale == "UTC":
+            time_scale_list = [1 for i in range(num_times)]
+        elif time_scale == "UT1":
+            time_scale_list = [2 for i in range(num_times)]
+        elif time_scale == "TT":
+            time_scale_list = [3 for i in range(num_times)]
+        elif time_scale == "TAI":
+            time_scale_list = [4 for i in range(num_times)]
+        else:
+            raise ValueError("time_scale should be one of {'UTC', 'UT1', 'TT', 'TAI'}")
+
+        epochs_pyoorb = np.array(
+            list(np.vstack([epochs, time_scale_list]).T), dtype=np.double, order="F"
+        )
+        return epochs_pyoorb
+
+    def _propagate_orbits(self, orbits: Orbits, times: Time) -> Orbits:
+        """
+        Propagate orbits using PYOORB.
+
+        Parameters
+        ----------
+        orbits : `~adam_core.orbits.orbits.Orbits` (N)
+            Orbits to propagate.
+        times : `~astropy.time.core.Time` (M)
+            Times to which to propagate orbits.
+
+        Returns
+        -------
+        propagated : `~adam_core.orbits.orbits.Orbits` (N * M)
+            Orbits propagated to each time in times.
+        """
+        # Convert orbits into PYOORB format
+        orbits_pyoorb = self._configure_orbits(
+            orbits.cartesian.values.filled(),
+            orbits.cartesian.times.tt.mjd,
+            "cartesian",
+            "TT",
+            magnitude=None,
+            slope=None,
+        )
+
+        # Convert epochs into PYOORB format
+        epochs_pyoorb = self._configure_epochs(times.tt.mjd, "TT")
+
+        # Propagate orbits to each epoch and append to list
+        # of new states
+        states_list = []
+        orbits_pyoorb_i = orbits_pyoorb.copy()
+        for epoch in epochs_pyoorb:
+            orbits_pyoorb_i, err = oo.pyoorb.oorb_propagation(
+                in_orbits=orbits_pyoorb_i,
+                in_epoch=epoch,
+                in_dynmodel=self.dynamical_model,
+            )
+            states_list.append(orbits_pyoorb_i)
+
+        # Convert list of new states into a pandas data frame
+        # These states at the moment will always be return as cartesian
+        # state vectors
+        # elements = ["x", "y", "z", "vx", "vy", "vz"]
+        # Other PYOORB state vector representations:
+        # "keplerian":
+        #    elements = ["a", "e", "i", "Omega", "omega", "M0"]
+        # "cometary":
+        #    elements = ["q", "e", "i", "Omega", "omega", "T0"]
+        states = np.concatenate(states_list)
+
+        # Extract cartesian states from PYOORB results
+        orbit_ids_ = states[:, 0].astype(int)
+        x = states[:, 1]
+        y = states[:, 2]
+        z = states[:, 3]
+        vx = states[:, 4]
+        vy = states[:, 5]
+        vz = states[:, 6]
+        mjd_tt = states[:, 8]
+
+        # Convert output epochs to TDB
+        times_ = Time(mjd_tt, format="mjd", scale="tt")
+        times_ = times_.tdb
+
+        if orbits.object_ids is not None:
+            object_ids = orbits.object_ids[orbit_ids_]
+        else:
+            object_ids = None
+
+        if orbits.orbit_ids is not None:
+            orbit_ids = orbits.orbit_ids[orbit_ids_]
+        else:
+            orbit_ids = None
+
+        propagated_orbits = Orbits(
+            CartesianCoordinates(
+                x=x,
+                y=y,
+                z=z,
+                vx=vx,
+                vy=vy,
+                vz=vz,
+                times=times_,
+                origin="heliocenter",
+                frame="ecliptic",
+            ),
+            orbit_ids=orbit_ids,
+            object_ids=object_ids,
+        )
+        return propagated_orbits
+
+    def _generate_ephemeris(self, orbits: Orbits, observers):
+        raise NotImplementedError(
+            "Ephemeris generation is not yet implemented for PYOORB."
+        )

--- a/adam_core/propagator/pyoorb.py
+++ b/adam_core/propagator/pyoorb.py
@@ -14,26 +14,14 @@ from ..coordinates.cartesian import CartesianCoordinates
 from ..orbits.orbits import Orbits
 from .propagator import Propagator
 
-PYOORB_CONFIG = {"dynamical_model": "N", "ephemeris_file": "de430.dat"}
-
 
 class PYOORB(Propagator):
-    def __init__(self, **kwargs):
-        # Make sure only the correct kwargs are passed to the constructor
-        allowed_kwargs = PYOORB_CONFIG.keys()
-        for k in kwargs:
-            if k not in allowed_kwargs:
-                warnings.warn(
-                    f"Invalid argument {k} passed to PYOORB propagator. Ignoring..."
-                )
+    def __init__(
+        self, *, dynamical_model: str = "N", ephemeris_file: str = "de430.dat"
+    ):
 
-        # If an allowed kwarg is missing, add the default
-        for k in allowed_kwargs:
-            if k not in kwargs:
-                kwargs[k] = PYOORB_CONFIG[k]
-
-        self.dynamical_model = kwargs["dynamical_model"]
-        self.ephemeris_file = kwargs["ephemeris_file"]
+        self.dynamical_model = dynamical_model
+        self.ephemeris_file = ephemeris_file
 
         env_var = "ADAM_CORE_PYOORB_INITIALIZED"
         if env_var in os.environ.keys() and os.environ[env_var] == "True":

--- a/adam_core/propagator/tests/test_utils.py
+++ b/adam_core/propagator/tests/test_utils.py
@@ -1,0 +1,36 @@
+import numpy as np
+from quivr import Float64Column, Table
+
+from ..utils import _iterate_chunks
+
+
+class SampleTable(Table):
+    a = Float64Column(nullable=False)
+
+
+def test__iterate_chunks():
+    # Test that _iterate_chunks works with numpy arrays and lists
+    a = np.arange(0, 10)
+    for chunk in _iterate_chunks(a, 2):
+        assert len(chunk) == 2
+
+    a = [i for i in range(10)]
+    for chunk in _iterate_chunks(a, 2):
+        assert len(chunk) == 2
+
+
+def test__iterate_chunks_table():
+    # Test that _iterate_chunks works with quivr tables
+    table = SampleTable.from_kwargs(a=np.arange(0, 11))
+    chunks = list(_iterate_chunks(table, 2))
+    assert len(chunks) == 6
+
+    for i, chunk in enumerate(chunks):
+        if i != 5:
+            assert len(chunk) == 2
+            assert isinstance(chunk, SampleTable)
+            np.testing.assert_equal(chunk.a.to_numpy(), np.arange(i * 2, i * 2 + 2))
+        else:
+            assert len(chunk) == 1
+            assert isinstance(chunk, SampleTable)
+            np.testing.assert_equal(chunk.a.to_numpy(), np.arange(i * 2, i * 2 + 1))

--- a/adam_core/propagator/utils.py
+++ b/adam_core/propagator/utils.py
@@ -1,5 +1,10 @@
 from typing import Iterable, Sequence
 
+import pyarrow as pa
+from pyarrow import compute as pc
+
+from ..orbits import Orbits
+
 
 def _iterate_chunks(iterable: Sequence, chunk_size: int) -> Iterable:
     """
@@ -21,3 +26,47 @@ def _iterate_chunks(iterable: Sequence, chunk_size: int) -> Iterable:
     N = len(iterable)
     for i in range(0, N, chunk_size):
         yield iterable[i : i + chunk_size]
+
+
+def sort_propagated_orbits(propagated_orbits: Orbits) -> Orbits:
+    """
+    Sort propagated orbits by orbit_id, object_id, and time.
+
+    Parameters
+    ----------
+    propagated_orbits : Orbits
+        Orbits to sort.
+
+    Returns
+    -------
+    Orbits
+        Sorted orbits.
+    """
+    # Build table with orbit_ids, object_ids, and times
+    table = pa.table(
+        [
+            propagated_orbits.orbit_ids,
+            propagated_orbits.object_ids,
+            pc.add(
+                pc.struct_field(
+                    pc.struct_field(propagated_orbits.table["coordinates"], "times"),
+                    "jd1",
+                ),
+                pc.struct_field(
+                    pc.struct_field(propagated_orbits.table["coordinates"], "times"),
+                    "jd2",
+                ),
+            ),
+        ],
+        names=["orbit_ids", "object_ids", "times"],
+    )
+
+    indices = pc.sort_indices(
+        table,
+        (
+            ("orbit_ids", "ascending"),
+            ("object_ids", "ascending"),
+            ("times", "ascending"),
+        ),
+    )
+    return propagated_orbits.take(indices)

--- a/adam_core/propagator/utils.py
+++ b/adam_core/propagator/utils.py
@@ -1,0 +1,23 @@
+from typing import Iterable, Sequence
+
+
+def _iterate_chunks(iterable: Sequence, chunk_size: int) -> Iterable:
+    """
+    Generator that yields chunks of size chunk_size from sized iterable
+    (Sequence).
+
+    Parameters
+    ----------
+    iterable : Sequence
+        Iterable to chunk.
+    chunk_size : int
+        Size of chunks.
+
+    Yields
+    ------
+    chunk : iterable
+        Chunk of size chunk_size from iterable.
+    """
+    N = len(iterable)
+    for i in range(0, N, chunk_size):
+        yield iterable[i : i + chunk_size]


### PR DESCRIPTION
This PR is branched off of #7, so requires that to be merged first. 

This PR introduces a new "Backend" class that has several abstract methods that need to be defined by subclasses. Once implemented, the Backend class can then distribute those methods as multiple processes per chunk of orbits. 

One important change is that we make PYOORB the default integrator that comes with `adam_core` which I think is reasonable.  

Here is an example from the README:
```python
import numpy as np
from astropy.time import Time
from astropy import units as u
from adam_core.orbits.query import query_horizons
from adam_core.backend import PYOORB

# Get orbit to propagate
initial_time = Time([60000.0], scale="tdb", format="mjd")
object_ids = ["Duende", "Eros", "Ceres"]
orbits = query_horizons(object_ids, initial_time)

# Make sure PYOORB is ready
backend = PYOORB()

# Define propagation times
times = initial_time + np.arange(0, 100) * u.d

# Propagate orbits! This function supports multiprocessing for large
# propagation jobs. 
propagated_orbits = backend.propagate_orbits(
    orbits,
    times,
    chunk_size=100,
    num_jobs=1,
)
```

Additional action items to be addressed in future PRs:
- [ ] Add observers class 
  - [ ] Add spiceypy utility to get observer coordinates
  - [ ] Add code to manage SPICE "kernel" files
- [ ] Add ephemeris class
- [ ] Add PYOORB ephemeris generation 