### PR TITLE
Define __eq__ for Indexable and add tests

### DIFF
--- a/adam_core/orbits/tests/test_orbits.py
+++ b/adam_core/orbits/tests/test_orbits.py
@@ -27,3 +27,42 @@ def test_orbits__init__():
     assert orbits.keplerian.raan[0] == 50.0
     assert orbits.keplerian.ap[0] == 20.0
     assert orbits.keplerian.M[0] == 30.0
+
+
+def test_orbits__eq__():
+    keplerian_elements1 = KeplerianCoordinates(
+        times=Time(59000.0, scale="tdb", format="mjd"),
+        a=1.0,
+        e=0.002,
+        i=10.0,
+        raan=50.0,
+        ap=20.0,
+        M=30.0,
+    )
+    keplerian_elements2 = KeplerianCoordinates(
+        times=Time(59000.0, scale="tdb", format="mjd"),
+        a=1.0,
+        e=0.002,
+        i=10.0,
+        raan=50.0,
+        ap=20.0,
+        M=30.0,
+    )
+
+    orbits1 = Orbits(keplerian_elements1, orbit_ids=["1"], object_ids=["Test Orbit"])
+    orbits2 = Orbits(keplerian_elements2, orbit_ids=["1"], object_ids=["Test Orbit"])
+
+    assert orbits1 == orbits2
+
+    keplerian_elements3 = KeplerianCoordinates(
+        times=Time(59000.0, scale="tdb", format="mjd"),
+        a=0.0,
+        e=0.002,
+        i=10.0,
+        raan=50.0,
+        ap=20.0,
+        M=30.0,
+    )
+
+    orbits3 = Orbits(keplerian_elements3, orbit_ids=["1"], object_ids=["Test Orbit"])
+    assert orbits1 != orbits3

--- a/adam_core/utils/indexable.py
+++ b/adam_core/utils/indexable.py
@@ -13,7 +13,7 @@ __all__ = ["Indexable", "concatenate"]
 logger = logging.getLogger(__name__)
 
 SLICEABLE_DATA_STRUCTURES = (np.ndarray, np.ma.masked_array, Time)
-UNSLICEABLE_DATA_STRUCTURES = (str, int, float, dict, bool, set, OrderedDict)
+UNSLICEABLE_DATA_STRUCTURES = (str, int, float, dict, bool, set, tuple, OrderedDict)
 
 
 def _convert_grouped_array_to_slices(values: npt.ArrayLike) -> npt.NDArray[slice]:

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -365,6 +365,19 @@ def test_Indexable__eq__set():
     assert indexable_1 != indexable_3
 
 
+def test_Indexable__eq__tuple():
+    # Other types (tuple)
+    indexable_1 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_1.__dict__["test"] = (0, 1)
+    indexable_2 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_2.__dict__["test"] = (0, 1)
+    indexable_3 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_3.__dict__["test"] = (0, 2)
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+
+
 def test_Indexable__query_index_int():
     # Array is grouped and can be represented by slices
     indexable = DummyIndexable(np.array([0, 1, 2, 3, 4, 5]))

--- a/adam_core/utils/tests/test_indexable.py
+++ b/adam_core/utils/tests/test_indexable.py
@@ -230,6 +230,141 @@ def test__convert_to_array():
     np.testing.assert_equal(Indexable._convert_to_array(value), desired)
 
 
+def test_Indexable__eq__array():
+    # Numpy array
+    indexable_1 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_2 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_3 = DummyIndexable(np.array([0, 1, 3]))
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+
+
+def test_Indexable__eq__masked_array():
+    # Numpy masked array
+    values = np.ma.array([0, 1, 2])
+    values.mask = [True, False, True]
+    indexable_1 = DummyIndexable(values)
+    indexable_2 = DummyIndexable(values)
+    values3 = np.ma.array([0, 1, 3])
+    values3.mask = [True, False, True]
+    indexable_3 = DummyIndexable(values3)
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+
+    # Numpy masked array (same values but different mask)
+    values = np.ma.array([0, 1, 2])
+    values.mask = [True, False, True]
+    indexable_1 = DummyIndexable(values)
+    indexable_2 = DummyIndexable(values)
+    values3 = np.ma.array([0, 1, 2])
+    values3.mask = [True, True, True]
+    indexable_3 = DummyIndexable(values3)
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+
+
+def test_Indexable__eq__Time():
+    # Astropy Time object
+    indexable_1 = DummyIndexable(Time([59000.0, 59001.0, 59002.0], format="mjd"))
+    indexable_2 = DummyIndexable(Time([59000.0, 59001.0, 59002.0], format="mjd"))
+    indexable_3 = DummyIndexable(Time([59000.0, 59001.0, 59003.0], format="mjd"))
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+
+
+def test_Indexable__eq__Indexable():
+    # Other Indexable
+    indexable_1 = DummyIndexable(DummyIndexable(np.array([0, 1, 2])))
+    indexable_2 = DummyIndexable(DummyIndexable(np.array([0, 1, 2])))
+    indexable_3 = DummyIndexable(DummyIndexable(np.array([0, 1, 3])))
+    indexable_4 = DummyIndexable(DummyIndexable(np.array([0, 1, 2])))
+    indexable_4.__dict__["test"] = "test"
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+    assert indexable_1 != indexable_4
+
+
+def test_Indexable__eq__None():
+    # Other types (None)
+    indexable_1 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_1.__dict__["test"] = None
+    indexable_2 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_2.__dict__["test"] = None
+    indexable_3 = DummyIndexable(np.array([0, 1, 2]))
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+
+
+def test_Indexable__eq__str():
+    # Other types (str)
+    indexable_1 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_1.__dict__["test"] = "test"
+    indexable_2 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_2.__dict__["test"] = "test"
+    indexable_3 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_3.__dict__["test"] = "test2"
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+
+
+def test_Indexable__eq__dict():
+    # Other types (dict)
+    indexable_1 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_1.__dict__["test"] = {"a": 0, "b": "1"}
+    indexable_2 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_2.__dict__["test"] = {"a": 0, "b": "1"}
+    indexable_3 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_3.__dict__["test"] = {"a": 0, "b": "2"}
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+
+
+def test_Indexable__eq__float():
+    # Other types (float)
+    indexable_1 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_1.__dict__["test"] = 0.1
+    indexable_2 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_2.__dict__["test"] = 0.1
+    indexable_3 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_3.__dict__["test"] = 0.2
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+
+
+def test_Indexable__eq__int():
+    # Other types (int)
+    indexable_1 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_1.__dict__["test"] = 1
+    indexable_2 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_2.__dict__["test"] = 1
+    indexable_3 = DummyIndexable(np.array([0, 1, 2]))
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+
+
+def test_Indexable__eq__set():
+    # Other types (set)
+    indexable_1 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_1.__dict__["test"] = set([0, 1])
+    indexable_2 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_2.__dict__["test"] = set([0, 1])
+    indexable_3 = DummyIndexable(np.array([0, 1, 2]))
+    indexable_3.__dict__["test"] = set([0, 2])
+
+    assert indexable_1 == indexable_2
+    assert indexable_1 != indexable_3
+
+
 def test_Indexable__query_index_int():
     # Array is grouped and can be represented by slices
     indexable = DummyIndexable(np.array([0, 1, 2, 3, 4, 5]))


### PR DESCRIPTION
Define `__eq__` for Indexable. For each member, check if it exists in the comparison instance and if it does ensure they are equal. 

Also adds tuples as unsliceable structures and increases unit test coverage.