### PR TITLE
Add get_perturber_state

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,24 @@ propagated_orbits = propagator.propagate_orbits(
 )
 ```
 
+### Low-level APIs
+
+Getting the heliocentric ecliptic state vector of a DE440 body at a given set of times (in this case the barycenter of the Jovian system):
+```python
+import numpy as np
+from astropy.time import Time
+
+from adam_core.coordinates.origin import OriginCodes
+from adam_core.utils.spice import get_perturber_state
+
+states = get_perturber_state(
+    OriginCodes.JUPITER_BARYCENTER,
+    Time(np.arange(59000, 60000), format="mjd", scale="tdb"),
+    frame="ecliptic",
+    origin=OriginCodes.SUN,
+)
+```
+
 ## Package Structure
 
 ```bash

--- a/adam_core/utils/spice.py
+++ b/adam_core/utils/spice.py
@@ -1,0 +1,105 @@
+import os
+from typing import List, Literal
+
+import numpy as np
+import spiceypy as sp
+from astropy.time import Time
+from naif_de440 import de440
+from naif_leapseconds import leapseconds
+
+from ..constants import KM_P_AU, S_P_DAY
+from ..coordinates.cartesian import CartesianCoordinates
+from ..coordinates.origin import Origin, OriginCodes
+from ..coordinates.times import Times
+
+
+def setup_SPICE(kernels: List[str] = [leapseconds, de440], force: bool = False):
+    """
+    Load SPICE kernels.
+
+    This function checks to see if SPICE has already been initialized for the current process.
+    If it has, then it does nothing. If it has not, then it loads the desired kernels into SPICE.
+    If force is set to True, then the kernels will be loaded regardless of whether or not SPICE
+    has already been initialized. SPICE has a limit on the number of kernels that can be loaded
+    at once, so it is recommended to only load the kernels that are needed for the current
+    calculation (calling sp.furnsh multiple times will load the same kernel multiple times, which
+    will cause an error.)
+
+    Parameters
+    ----------
+    kernels : list of str
+        List of SPICE kernels to load into SPICE.
+    """
+    process_id = os.getpid()
+    env_var = f"ADAM_CORE_SPICE_INITIALIZED_{process_id}"
+    if env_var in os.environ and not force:
+        return
+
+    for kernel in kernels:
+        sp.furnsh(kernel)
+    os.environ[env_var] = "True"
+    return
+
+
+def get_perturber_state(
+    perturber: OriginCodes,
+    times: Time,
+    frame: Literal["ecliptic", "equatorial"],
+    origin: OriginCodes = OriginCodes.SUN,
+) -> CartesianCoordinates:
+    """
+    Query the JPL ephemeris files loaded in SPICE for the state vectors of desired perturbers.
+
+    Parameters
+    ----------
+    perturber : OriginCodes
+        The NAIF ID of the perturber.
+    times : `~astropy.time.core.Time` (N)
+        Times at which to get state vectors.
+    frame : {'equatorial', 'ecliptic'}
+        Return perturber state in the equatorial or ecliptic J2000 frames.
+    origin :  OriginCodes
+        The NAIF ID of the origin.
+
+    Returns
+    -------
+    states : CartesianCoordinates
+        The state vectors of the perturber in the desired frame
+        and measured from the desired origin.
+    """
+    if frame == "ecliptic":
+        frame_spice = "ECLIPJ2000"
+    elif frame == "equatorial":
+        frame_spice = "J2000"
+    else:
+        err = "frame should be one of {'equatorial', 'ecliptic'}"
+        raise ValueError(err)
+
+    # Make sure SPICE is ready to roll
+    setup_SPICE()
+
+    # Convert MJD epochs in TDB to ET in TDB
+    epochs_tdb = times.tdb
+    epochs_et = np.array([sp.str2et("JD {:.16f} TDB".format(i)) for i in epochs_tdb.jd])
+
+    # Get position of the body in km and km/s in the desired frame and measured from the desired origin
+    states = np.empty((len(epochs_et), 6), dtype=np.float64)
+    for i, epoch in enumerate(epochs_et):
+        state, lt = sp.spkez(perturber.value, epoch, frame_spice, "NONE", origin.value)
+        states[i, :] = state
+
+    # Convert to AU and AU per day
+    states = states / KM_P_AU
+    states[:, 3:] = states[:, 3:] * S_P_DAY
+
+    return CartesianCoordinates.from_kwargs(
+        times=Times.from_astropy(times),
+        x=states[:, 0],
+        y=states[:, 1],
+        z=states[:, 2],
+        vx=states[:, 3],
+        vy=states[:, 4],
+        vz=states[:, 5],
+        frame=frame,
+        origin=Origin.from_kwargs(code=[origin.name for i in range(len(states))]),
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,10 @@ install_requires =
     pandas
     requests
     scipy
+    spiceypy
     quivr>=0.4.1
+    naif-de440
+    naif-leapseconds
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
This function adds a low-level utility to get a perturber's state at a given time using `spiceypy`  and some of the newly created data packages.

For example:
```python
import numpy as np
from astropy.time import Time

from adam_core.coordinates.origin import OriginCodes
from adam_core.utils.spice import get_perturber_state

states = get_perturber_state(
    OriginCodes.JUPITER_BARYCENTER,
    Time(np.arange(59000, 60000), format="mjd", scale="tdb"),
    frame="ecliptic",
    origin=OriginCodes.SUN,
)
```
Then:
```python
states.to_dataframe(covariances=False)
```

```
times.jd1 | times.jd2 | x | y | z | vx | vy | vz | origin.code
-- | -- | -- | -- | -- | -- | -- | -- | --
2459000.0 | 0.5 | 1.625772 | -4.910007 | -0.015981 | 0.007080 | 0.002731 | -0.000170 | SUN
2459002.0 | -0.5 | 1.632850 | -4.907270 | -0.016151 | 0.007077 | 0.002741 | -0.000170 | SUN
2459002.0 | 0.5 | 1.639925 | -4.904524 | -0.016320 | 0.007073 | 0.002752 | -0.000170 | SUN
2459004.0 | -0.5 | 1.646996 | -4.901767 | -0.016490 | 0.007070 | 0.002762 | -0.000170 | SUN
2459004.0 | 0.5 | 1.654064 | -4.898999 | -0.016660 | 0.007066 | 0.002773 | -0.000170 | SUN
```
