### PR TITLE
Add 2-body propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ from adam_core.coordinates import Origin
 from adam_core.orbits import Orbits
 
 keplerian_elements = KeplerianCoordinates.from_kwargs(
-    times=Times.from_astropy(
+    time=Times.from_astropy(
         Time([59000.0], scale="tdb", format="mjd")
     ),
     a=[1.0],
@@ -30,8 +30,8 @@ keplerian_elements = KeplerianCoordinates.from_kwargs(
     frame="ecliptic"
 )
 orbits = Orbits.from_kwargs(
-    orbit_ids=["1"],
-    object_ids=["Test Orbit"],
+    orbit_id=["1"],
+    object_id=["Test Orbit"],
     coordinates=keplerian_elements.to_cartesian(),
 )
 ```
@@ -49,7 +49,7 @@ from adam_core.coordinates import Origin
 from adam_core.orbits import Orbits
 
 keplerian_elements = KeplerianCoordinates.from_kwargs(
-    times=Times.from_astropy(
+    time=Times.from_astropy(
         Time([59000.0, 60000.0], scale="tdb", format="mjd")
     ),
     a=[1.0, 3.0],
@@ -62,8 +62,8 @@ keplerian_elements = KeplerianCoordinates.from_kwargs(
     frame="ecliptic"
 )
 orbits = Orbits.from_kwargs(
-    orbit_ids=["1", "2"],
-    object_ids=["Test Orbit 1", "Test Orbit 2"],
+    orbit_id=["1", "2"],
+    object_id=["Test Orbit 1", "Test Orbit 2"],
     coordinates=keplerian_elements.to_cartesian(),
 )
 ```
@@ -87,7 +87,7 @@ from adam_core.coordinates import CoordinateCovariances
 from adam_core.orbits import Orbits
 
 keplerian_elements = KeplerianCoordinates.from_kwargs(
-    times=Times.from_astropy(
+    time=Times.from_astropy(
         Time([59000.0], scale="tdb", format="mjd")
     ),
     a=[1.0],
@@ -96,7 +96,7 @@ keplerian_elements = KeplerianCoordinates.from_kwargs(
     raan=[50.0],
     ap=[20.0],
     M=[30.0],
-    covariances=CoordinateCovariances.from_sigmas(
+    covariance=CoordinateCovariances.from_sigmas(
         np.array([[0.002, 0.001, 0.01, 0.01, 0.1, 0.1]])
     ),
     origin=Origin.from_kwargs(code=["SUN"]),
@@ -104,8 +104,8 @@ keplerian_elements = KeplerianCoordinates.from_kwargs(
 )
 
 orbits = Orbits.from_kwargs(
-    orbit_ids=["1"],
-    object_ids=["Test Orbit with Uncertainties"],
+    orbit_id=["1"],
+    object_id=["Test Orbit with Uncertainties"],
     coordinates=keplerian_elements.to_cartesian(),
 )
 orbits.to_dataframe(sigmas=True)
@@ -179,6 +179,7 @@ propagated_orbits = propagator.propagate_orbits(
 
 ### Low-level APIs
 
+#### State Vectors from Development Ephemeris files
 Getting the heliocentric ecliptic state vector of a DE440 body at a given set of times (in this case the barycenter of the Jovian system):
 ```python
 import numpy as np
@@ -192,6 +193,29 @@ states = get_perturber_state(
     Time(np.arange(59000, 60000), format="mjd", scale="tdb"),
     frame="ecliptic",
     origin=OriginCodes.SUN,
+)
+```
+
+#### 2-body Propagation
+`adam_core` also has 2-body propagation functionality. To propagate any orbit with 2-body dynamics:
+```python
+import numpy as np
+from astropy.time import Time
+from astropy import units as u
+from adam_core.orbits.query import query_sbdb
+from adam_core.dynamics.propagation import propagate_2body
+
+# Get orbit to propagate
+object_ids = ["Duende", "Eros", "Ceres"]
+orbits = query_sbdb(object_ids)
+
+# Define propagation times
+times = Time(np.arange(59000, 60000), scale="tdb", format="mjd")
+
+# Propagate orbits with 2-body dynamics
+propagated_orbits = propagate_2body(
+    orbits,
+    times
 )
 ```
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -5,3 +5,6 @@
     Icarus, 166, 248–270. https://doi.org/10.1016/S0019-1035(03)00051-4
 * Curtis, H. D. (2014). Orbital Mechanics for Engineering Students. 3rd ed.,  
     Elsevier Ltd. ISBN-13: 978-0080977478
+* Danby, J. M. A. (1992). Fundamentals of Celestial Mechanics. 2nd ed.,
+    William-Bell, Inc. ISBN-13: 978-0943396200
+    Notes: of particular interest is Danby's fantastic chapter on universal variables (6.9)

--- a/adam_core/coordinates/cometary.py
+++ b/adam_core/coordinates/cometary.py
@@ -269,7 +269,7 @@ class CometaryCoordinates(Table):
         )
         coords_cometary = np.array(coords_cometary)
 
-        cartesian_covariances = cartesian.covariances.to_matrix()
+        cartesian_covariances = cartesian.covariance.to_matrix()
         if not np.all(np.isnan(cartesian_covariances)):
             covariances_cometary = transform_covariances_jacobian(
                 cartesian.values,

--- a/adam_core/coordinates/keplerian.py
+++ b/adam_core/coordinates/keplerian.py
@@ -247,7 +247,7 @@ class KeplerianCoordinates(Table):
         )
         coords_keplerian = np.array(coords_keplerian)
 
-        cartesian_covariances = cartesian.covariances.to_matrix()
+        cartesian_covariances = cartesian.covariance.to_matrix()
         if not np.all(np.isnan(cartesian_covariances)):
             covariances_keplerian = transform_covariances_jacobian(
                 cartesian.values,

--- a/adam_core/coordinates/spherical.py
+++ b/adam_core/coordinates/spherical.py
@@ -193,7 +193,7 @@ class SphericalCoordinates(Table):
         coords_spherical = cartesian_to_spherical(cartesian.values)
         coords_spherical = np.array(coords_spherical)
 
-        cartesian_covariances = cartesian.covariances.to_matrix()
+        cartesian_covariances = cartesian.covariance.to_matrix()
         if not np.all(np.isnan(cartesian_covariances)):
             covariances_spherical = transform_covariances_jacobian(
                 cartesian.values, cartesian_covariances, _cartesian_to_spherical

--- a/adam_core/coordinates/tests/test_benchmarks.py
+++ b/adam_core/coordinates/tests/test_benchmarks.py
@@ -1,39 +1,52 @@
-import astropy.time
 import numpy as np
 import pytest
+from astropy.time import Time
 
 from ..cartesian import CartesianCoordinates
+from ..cometary import CometaryCoordinates
+from ..keplerian import KeplerianCoordinates
+from ..origin import Origin, OriginCodes
+from ..spherical import SphericalCoordinates
+from ..times import Times
 from ..transform import transform_coordinates
 
 
 @pytest.mark.parametrize(
-    "representation", ["spherical", "keplerian", "cometary"], ids=lambda x: f"to={x},"
+    "representation",
+    [SphericalCoordinates, KeplerianCoordinates, CometaryCoordinates],
+    ids=lambda x: f"to={x.__name__},",
 )
 @pytest.mark.parametrize(
     "frame", ["equatorial", "ecliptic"], ids=lambda x: f"frame={x},"
 )
 @pytest.mark.parametrize(
-    "origin", ["heliocenter", "barycenter"], ids=lambda x: f"origin={x},"
+    "origin",
+    [OriginCodes.SUN, OriginCodes.SOLAR_SYSTEM_BARYCENTER],
+    ids=lambda x: f"origin={x.name},",
 )
 @pytest.mark.benchmark(group="coord_transforms")
 def test_benchmark_transform_cartesian_coordinates(
     benchmark, representation, frame, origin
 ):
-    if origin == "barycenter":
+    if origin == OriginCodes.SOLAR_SYSTEM_BARYCENTER:
         pytest.skip("barycenter transform not yet implemented")
-    from_coords = CartesianCoordinates(
+
+    from_coords = CartesianCoordinates.from_kwargs(
         x=np.array([1]),
         y=np.array([1]),
         z=np.array([1]),
         vx=np.array([1]),
         vy=np.array([1]),
         vz=np.array([1]),
-        times=astropy.time.Time(50000, format="mjd"),
+        time=Times.from_astropy(
+            Time([50000], format="mjd"),
+        ),
+        origin=Origin.from_kwargs(code=["SUN"]),
     )
     benchmark(
         transform_coordinates,
-        coords=from_coords,
-        representation_out=representation,
+        from_coords,
+        representation,
         frame_out=frame,
         origin_out=origin,
     )

--- a/adam_core/coordinates/transform.py
+++ b/adam_core/coordinates/transform.py
@@ -1327,7 +1327,7 @@ def transform_coordinates(
         if coord_frame == frame_out and np.all(coord_origin == origin_out.name):
             return coords
 
-    if type(coords) != CartesianCoordinates:
+    if not isinstance(coords, CartesianCoordinates):
         cartesian = coords.to_cartesian()
     else:
         cartesian = coords

--- a/adam_core/coordinates/transform.py
+++ b/adam_core/coordinates/transform.py
@@ -140,9 +140,11 @@ def _cartesian_to_spherical(
 
 
 # Vectorization Map: _cartesian_to_spherical
-_cartesian_to_spherical_vmap = vmap(
-    _cartesian_to_spherical,
-    in_axes=(0,),
+_cartesian_to_spherical_vmap = jit(
+    vmap(
+        _cartesian_to_spherical,
+        in_axes=(0,),
+    )
 )
 
 
@@ -253,9 +255,11 @@ def _spherical_to_cartesian(
 
 
 # Vectorization Map: _spherical_to_cartesian
-_spherical_to_cartesian_vmap = vmap(
-    _spherical_to_cartesian,
-    in_axes=(0,),
+_spherical_to_cartesian_vmap = jit(
+    vmap(
+        _spherical_to_cartesian,
+        in_axes=(0,),
+    )
 )
 
 
@@ -477,9 +481,11 @@ def _cartesian_to_keplerian(
 
 
 # Vectorization Map: _cartesian_to_keplerian
-_cartesian_to_keplerian_vmap = vmap(
-    _cartesian_to_keplerian,
-    in_axes=(0, 0, None),
+_cartesian_to_keplerian_vmap = jit(
+    vmap(
+        _cartesian_to_keplerian,
+        in_axes=(0, 0, None),
+    )
 )
 
 
@@ -694,9 +700,11 @@ def _keplerian_to_cartesian_p(
 
 
 # Vectorization Map: _keplerian_to_cartesian_p
-_keplerian_to_cartesian_p_vmap = vmap(
-    _keplerian_to_cartesian_p,
-    in_axes=(0, None, None, None),
+_keplerian_to_cartesian_p_vmap = jit(
+    vmap(
+        _keplerian_to_cartesian_p,
+        in_axes=(0, None, None, None),
+    )
 )
 
 
@@ -775,9 +783,11 @@ def _keplerian_to_cartesian_a(
 
 
 # Vectorization Map: _keplerian_to_cartesian_a
-_keplerian_to_cartesian_a_vmap = vmap(
-    _keplerian_to_cartesian_a,
-    in_axes=(0, None, None, None),
+_keplerian_to_cartesian_a_vmap = jit(
+    vmap(
+        _keplerian_to_cartesian_a,
+        in_axes=(0, None, None, None),
+    )
 )
 
 
@@ -856,9 +866,11 @@ def _keplerian_to_cartesian_q(
 
 
 # Vectorization Map: _keplerian_to_cartesian_q
-_keplerian_to_cartesian_q_vmap = vmap(
-    _keplerian_to_cartesian_q,
-    in_axes=(0, None, None, None),
+_keplerian_to_cartesian_q_vmap = jit(
+    vmap(
+        _keplerian_to_cartesian_q,
+        in_axes=(0, None, None, None),
+    )
 )
 
 
@@ -989,9 +1001,11 @@ def _cartesian_to_cometary(
 
 
 # Vectorization Map: _cartesian_to_cometary
-_cartesian_to_cometary_vmap = vmap(
-    _cartesian_to_cometary,
-    in_axes=(0, 0, None),
+_cartesian_to_cometary_vmap = jit(
+    vmap(
+        _cartesian_to_cometary,
+        in_axes=(0, 0, None),
+    )
 )
 
 
@@ -1132,9 +1146,11 @@ def _cometary_to_cartesian(
 
 
 # Vectorization Map: _cometary_to_cartesian
-_cometary_to_cartesian_vmap = vmap(
-    _cometary_to_cartesian,
-    in_axes=(0, 0, None, None, None),
+_cometary_to_cartesian_vmap = jit(
+    vmap(
+        _cometary_to_cartesian,
+        in_axes=(0, 0, None, None, None),
+    )
 )
 
 

--- a/adam_core/coordinates/transform.py
+++ b/adam_core/coordinates/transform.py
@@ -1308,13 +1308,16 @@ def transform_coordinates(
         origin_out = coord_origin
 
     if type(coords) == representation_out:
-        if coord_frame == frame_out and np.all(coord_origin == origin_out):
+        if coord_frame == frame_out and np.all(coord_origin == origin_out.name):
             return coords
 
-    cartesian = coords.to_cartesian()
+    if type(coords) != CartesianCoordinates:
+        cartesian = coords.to_cartesian()
+    else:
+        cartesian = coords
 
     # Translate coordinates to new origin (if different from current)
-    if np.all(cartesian.origin != origin_out):
+    if np.all(cartesian.origin != origin_out.name):
         cartesian = cartesian_to_origin(cartesian, origin_out)
 
     # Rotate coordinates to new frame (if different from current)

--- a/adam_core/dynamics/__init__.py
+++ b/adam_core/dynamics/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa: F401
 from .barker import solve_barker
+from .chi import calc_chi
 from .kepler import solve_kepler
 from .stumpff import calc_stumpff
 from .tisserand import calc_tisserand_parameter

--- a/adam_core/dynamics/__init__.py
+++ b/adam_core/dynamics/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa: F401
 from .barker import solve_barker
 from .kepler import solve_kepler
+from .stumpff import calc_stumpff
 from .tisserand import calc_tisserand_parameter

--- a/adam_core/dynamics/__init__.py
+++ b/adam_core/dynamics/__init__.py
@@ -2,5 +2,6 @@
 from .barker import solve_barker
 from .chi import calc_chi
 from .kepler import solve_kepler
+from .lagrange import apply_lagrange_coefficients, calc_lagrange_coefficients
 from .stumpff import calc_stumpff
 from .tisserand import calc_tisserand_parameter

--- a/adam_core/dynamics/chi.py
+++ b/adam_core/dynamics/chi.py
@@ -1,0 +1,134 @@
+from typing import Tuple
+
+import jax.numpy as jnp
+import numpy as np
+from jax import config, jit, lax
+
+from ..constants import Constants as c
+from .stumpff import calc_stumpff
+
+config.update("jax_enable_x64", True)
+
+MU = c.MU
+
+
+@jit
+def calc_chi(
+    r: jnp.ndarray,
+    v: jnp.ndarray,
+    dt: float,
+    mu: float = MU,
+    max_iter: int = 100,
+    tol: float = 1e-16,
+) -> Tuple[
+    np.float64, np.float64, np.float64, np.float64, np.float64, np.float64, np.float64
+]:
+    """
+    Calculate universal anomaly chi using Newton-Raphson.
+
+    Parameters
+    ----------
+    r : `~jax.numpy.ndarray` (3)
+        Position vector in au.
+    v : `~jax.numpy.ndarray` (3)
+        Velocity vector in au per day.
+    dt : float
+        Time from epoch to which calculate chi in units of decimal days.
+    mu : float
+        Gravitational parameter (GM) of the attracting body in units of
+        au**3 / d**2.
+    max_iter : int
+        Maximum number of iterations over which to converge. If number of iterations is
+        exceeded, will return the value of the universal anomaly at the last iteration.
+    tol : float
+        Numerical tolerance to which to compute chi using the Newtown-Raphson
+        method.
+
+    Returns
+    -------
+    chi : float
+        Universal anomaly.
+    c0, c1, c2, c3, c4, c5 : 6 x float
+        First six Stumpff functions.
+
+    References
+    ----------
+    [1] Curtis, H. D. (2014). Orbital Mechanics for Engineering Students. 3rd ed.,
+        Elsevier Ltd. ISBN-13: 978-0080977478
+    """
+    v_mag = jnp.linalg.norm(v)
+    r_mag = jnp.linalg.norm(r)
+    rv_mag = jnp.dot(r, v) / r_mag
+    sqrt_mu = jnp.sqrt(mu)
+
+    # Equations 3.48 and 3.50 in Curtis (2014) [1]
+    alpha = -(v_mag**2) / mu + 2 / r_mag
+
+    # Equation 3.66 in Curtis (2014) [1]
+    chi = sqrt_mu * jnp.abs(alpha) * dt
+
+    ratio = 1e15
+    iterations = 0
+    # Define parameters array (arguments that will be changing as
+    # the while loop iterates):
+    # chi, c0, c1, c2, c3, c4, c5, ratio, iterations
+    p = [chi, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, ratio, iterations]
+
+    # Define while loop body function
+    @jit
+    def _chi_newton_raphson(p):
+
+        chi = p[0]
+        ratio = p[-2]
+        iterations = p[-1]
+
+        chi2 = chi**2
+        psi = alpha * chi2
+        c0, c1, c2, c3, c4, c5 = calc_stumpff(psi)
+
+        # Newton-Raphson
+        # Equation 3.65 in Curtis (2014) [1]
+        f = (
+            r_mag * rv_mag / sqrt_mu * chi2 * c2
+            + (1 - alpha * r_mag) * chi**3 * c3
+            + r_mag * chi
+            - sqrt_mu * dt
+        )
+        fp = (
+            r_mag * rv_mag / sqrt_mu * chi * (1 - alpha * chi2 * c3)
+            + (1 - alpha * r_mag) * chi2 * c2
+            + r_mag
+        )
+
+        ratio = f / fp
+        chi -= ratio
+        iterations += 1
+
+        p[0] = chi
+        p[1] = c0
+        p[2] = c1
+        p[3] = c2
+        p[4] = c3
+        p[5] = c4
+        p[6] = c5
+        p[7] = ratio
+        p[8] = iterations
+        return p
+
+    # Define while loop condition function
+    @jit
+    def _while_condition(p):
+        ratio = p[-2]
+        iterations = p[-1]
+        return (jnp.abs(ratio) > tol) & (iterations <= max_iter)
+
+    p = lax.while_loop(_while_condition, _chi_newton_raphson, p)
+    chi = p[0]
+    c0 = p[1]
+    c1 = p[2]
+    c2 = p[3]
+    c3 = p[4]
+    c4 = p[5]
+    c5 = p[6]
+
+    return chi, c0, c1, c2, c3, c4, c5

--- a/adam_core/dynamics/lagrange.py
+++ b/adam_core/dynamics/lagrange.py
@@ -1,0 +1,128 @@
+from typing import Tuple
+
+import jax.numpy as jnp
+from jax import config, jit
+
+from ..constants import Constants as C
+from .chi import calc_chi
+from .stumpff import STUMPFF_TYPES
+
+config.update("jax_enable_x64", True)
+
+
+MU = C.MU
+LAGRANGE_TYPES = Tuple[jnp.float64, jnp.float64, jnp.float64, jnp.float64]
+
+
+@jit
+def calc_lagrange_coefficients(
+    r: jnp.ndarray,
+    v: jnp.ndarray,
+    dt: float,
+    mu: float = MU,
+    max_iter: int = 100,
+    tol: float = 1e-16,
+) -> Tuple[LAGRANGE_TYPES, STUMPFF_TYPES, jnp.float64]:
+    """
+    Calculate the exact Lagrange coefficients given an initial state defined at t0,
+    and the change in time from t0 to t1 (dt = t1 - t0).
+
+    Parameters
+    ----------
+    r : `~jax.numpy.ndarray` (3)
+        Position vector in au.
+    v : `~jax.numpy.ndarray` (3)
+        Velocity vector in au per day.
+    dt : float
+        Time from epoch to which calculate chi in units of decimal days.
+    mu : float
+        Gravitational parameter (GM) of the attracting body in units of
+        au**3 / d**2.
+    max_iter : int
+        Maximum number of iterations over which to converge. If number of iterations is
+        exceeded, will return the value of the universal anomaly at the last iteration.
+    tol : float
+        Numerical tolerance to which to compute chi using the Newtown-Raphson
+        method.
+
+    Returns
+    -------
+    lagrange_coeffs : (float x 4)
+        f : float
+            Langrange f coefficient.
+        g : float
+            Langrange g coefficient.
+        f_dot : float
+            Time deriviative of the Langrange f coefficient.
+        g_dot : float
+            Time deriviative of the Langrange g coefficient.
+    stumpff_coeffs : (float x 6)
+        First six Stumpff functions (c0, c1, c2, c3, c4, c5)
+    chi : float
+        Universal anomaly.
+
+    References
+    ----------
+    [1] Curtis, H. D. (2014). Orbital Mechanics for Engineering Students. 3rd ed.,
+        Elsevier Ltd. ISBN-13: 978-0080977478
+    """
+    sqrt_mu = jnp.sqrt(mu)
+    chi, c0, c1, c2, c3, c4, c5 = calc_chi(r, v, dt, mu=mu, max_iter=max_iter, tol=tol)
+    stumpff_coeffs = (c0, c1, c2, c3, c4, c5)
+    chi2 = chi**2
+
+    r_mag = jnp.linalg.norm(r)
+    v_mag = jnp.linalg.norm(v)
+
+    # Equations 3.48 and 3.50 in Curtis (2014) [1]
+    alpha = -(v_mag**2) / mu + 2 / r_mag
+
+    # Equations 3.69a and 3.69b in Curtis (2014) [1]
+    f = 1 - chi**2 / r_mag * c2
+    g = dt - 1 / sqrt_mu * chi**3 * c3
+
+    r_new = f * r + g * v
+    r_new_mag = jnp.linalg.norm(r_new)
+
+    # Equations 3.69c and 3.69d in Curtis (2014) [1]
+    f_dot = sqrt_mu / (r_mag * r_new_mag) * (alpha * chi**3 * c3 - chi)
+    g_dot = 1 - chi2 / r_new_mag * c2
+
+    lagrange_coeffs = (f, g, f_dot, g_dot)
+
+    return lagrange_coeffs, stumpff_coeffs, chi
+
+
+@jit
+def apply_lagrange_coefficients(
+    r: jnp.ndarray, v: jnp.ndarray, f: float, g: float, f_dot: float, g_dot: float
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    """
+    Apply the Lagrange coefficients to r and v.
+
+    Parameters
+    ----------
+    r : `~jax.numpy.ndarray` (3)
+        Position vector in au.
+    v : `~jax.numpy.ndarray` (3)
+        Velocity vector in au per day.
+    f : float
+        Langrange f coefficient.
+    g : float
+        Langrange g coefficient.
+    f_dot : float
+        Time deriviative of the Langrange f coefficient.
+    g_dot : float
+        Time deriviative of the Langrange g coefficient.
+
+    Returns
+    -------
+    r_new : `~jax.numpy.ndarray` (3)
+        New position vector in au propagated with the Lagrange coefficients.
+    v_new : `~jax.numpy.ndarray` (3)
+        New velocity vector in au per day propagated with the Lagrange coefficients.
+    """
+    r_new = f * r + g * v
+    v_new = f_dot * r + g_dot * v
+
+    return r_new, v_new

--- a/adam_core/dynamics/propagation.py
+++ b/adam_core/dynamics/propagation.py
@@ -117,18 +117,11 @@ def propagate_2body(
     # and then pass this to the vectorized map version of _propagate_2body
     n_orbits = cartesian_orbits.shape[0]
     n_times = len(times)
-    m = n_orbits * n_times
-    orbit_ids_ = np.empty(m, dtype=str)
-    object_ids_ = np.empty(m, dtype=str)
-    orbits_array_ = np.empty((m, 6), dtype=float)
-    t0_ = np.empty(m, dtype=float)
-    t1_ = np.empty(m, dtype=float)
-    for i in range(n_orbits):
-        orbit_ids_[i * n_times : (i + 1) * n_times] = orbit_ids[i]
-        object_ids_[i * n_times : (i + 1) * n_times] = object_ids[i]
-        orbits_array_[i * n_times : (i + 1) * n_times] = cartesian_orbits[i]
-        t0_[i * n_times : (i + 1) * n_times] = t0[i]
-        t1_[i * n_times : (i + 1) * n_times] = t1
+    orbit_ids_ = np.repeat(orbit_ids, n_times)
+    object_ids_ = np.repeat(object_ids, n_times)
+    orbits_array_ = np.repeat(cartesian_orbits, n_times, axis=0)
+    t0_ = np.repeat(t0, n_times)
+    t1_ = np.tile(t1, n_orbits)
 
     orbits_propagated = _propagate_2body_vmap(
         orbits_array_, t0_, t1_, mu, max_iter, tol
@@ -137,11 +130,7 @@ def propagate_2body(
 
     cartesian_covariances = orbits.coordinates.covariance.to_matrix()
     if not np.all(np.isnan(cartesian_covariances)):
-        covariances_array_ = np.empty((m, 6, 6), dtype=float)
-        for i in range(n_orbits):
-            covariances_array_[i * n_times : (i + 1) * n_times] = cartesian_covariances[
-                i
-            ]
+        covariances_array_ = np.repeat(cartesian_covariances, n_times, axis=0)
 
         cartesian_covariances = transform_covariances_jacobian(
             orbits_array_,

--- a/adam_core/dynamics/propagation.py
+++ b/adam_core/dynamics/propagation.py
@@ -1,0 +1,58 @@
+import jax.numpy as jnp
+from jax import config, jit
+
+from ..constants import Constants as c
+from .lagrange import apply_lagrange_coefficients, calc_lagrange_coefficients
+
+config.update("jax_enable_x64", True)
+
+
+MU = c.MU
+
+
+@jit
+def _propagate_2body(
+    orbit: jnp.ndarray,
+    t0: float,
+    t1: float,
+    mu: float = MU,
+    max_iter: int = 1000,
+    tol: float = 1e-14,
+) -> jnp.ndarray:
+    """
+    Propagate an orbit from t0 to t1.
+
+    Parameters
+    ----------
+    orbit : `~jax.numpy.ndarray` (6)
+        Cartesian orbit with position in units of au and velocity in units of au per day.
+    t0 : float (1)
+        Epoch in MJD at which the orbit are defined.
+    t1 : float (N)
+        Epochs to which to propagate the given orbit.
+    mu : float, optional
+        Gravitational parameter (GM) of the attracting body in units of
+        au**3 / d**2.
+    max_iter : int, optional
+        Maximum number of iterations over which to converge. If number of iterations is
+        exceeded, will return the value of the universal anomaly at the last iteration.
+    tol : float, optional
+        Numerical tolerance to which to compute universal anomaly using the Newtown-Raphson
+        method.
+
+    Returns
+    -------
+    orbits : `~jax.numpy.ndarray` (N, 6)
+        Orbit propagated to each MJD with position in units of au and velocity in units
+        of au per day.
+    """
+    r = orbit[0:3]
+    v = orbit[3:6]
+    dt = t1 - t0
+
+    lagrange_coeffs, stumpff_coeffs, chi = calc_lagrange_coefficients(
+        r, v, dt, mu=mu, max_iter=max_iter, tol=tol
+    )
+    r_new, v_new = apply_lagrange_coefficients(r, v, *lagrange_coeffs)
+
+    return jnp.array([r_new[0], r_new[1], r_new[2], v_new[0], v_new[1], v_new[2]])

--- a/adam_core/dynamics/propagation.py
+++ b/adam_core/dynamics/propagation.py
@@ -69,8 +69,8 @@ def _propagate_2body(
 
 
 # Vectorization Map: _propagate_2body
-_propagate_2body_vmap = vmap(
-    _propagate_2body, in_axes=(0, 0, 0, None, None, None), out_axes=(0)
+_propagate_2body_vmap = jit(
+    vmap(_propagate_2body, in_axes=(0, 0, 0, None, None, None), out_axes=(0))
 )
 
 

--- a/adam_core/dynamics/stumpff.py
+++ b/adam_core/dynamics/stumpff.py
@@ -1,0 +1,89 @@
+from typing import Tuple
+
+import jax.numpy as jnp
+from jax import config, jit, lax
+
+config.update("jax_enable_x64", True)
+
+STUMPFF_TYPES = Tuple[
+    jnp.float64, jnp.float64, jnp.float64, jnp.float64, jnp.float64, jnp.float64
+]
+
+
+@jit
+def _positive_psi(psi: jnp.float64) -> STUMPFF_TYPES:
+    # Equation 6.9.15 in Danby (1992) [1]
+    sqrt_psi = jnp.sqrt(psi)
+    c0 = jnp.cos(sqrt_psi)
+    c1 = jnp.sin(sqrt_psi) / sqrt_psi
+
+    # Equation 6.9.16 in Danby (1992) [1]
+    # states the recursion relation for higher
+    # order Stumpff functions
+    c2 = (1.0 - c0) / psi
+    c3 = (1.0 - c1) / psi
+    c4 = (1 / 2.0 - c2) / psi
+    c5 = (1 / 6.0 - c3) / psi
+
+    return c0, c1, c2, c3, c4, c5
+
+
+@jit
+def _negative_psi(psi: jnp.float64) -> STUMPFF_TYPES:
+    # Equation 6.9.15 in Danby (1992) [1]
+    sqrt_npsi = jnp.sqrt(-psi)
+    c0 = jnp.cosh(sqrt_npsi)
+    c1 = jnp.sinh(sqrt_npsi) / sqrt_npsi
+
+    # Equation 6.9.16 in Danby (1992) [1]
+    # states the recursion relation for higher
+    # order Stumpff functions
+    c2 = (1.0 - c0) / psi
+    c3 = (1.0 - c1) / psi
+    c4 = (1 / 2.0 - c2) / psi
+    c5 = (1 / 6.0 - c3) / psi
+
+    return c0, c1, c2, c3, c4, c5
+
+
+@jit
+def _null_psi(psi: jnp.float64) -> STUMPFF_TYPES:
+    # Equation 6.9.14 in Danby (1992) [1]
+    c0 = 1.0
+    c1 = 1.0
+    c2 = 1 / 2.0
+    c3 = 1 / 6.0
+    c4 = 1 / 24.0
+    c5 = 1 / 120.0
+
+    return c0, c1, c2, c3, c4, c5
+
+
+@jit
+def calc_stumpff(psi: jnp.float64) -> STUMPFF_TYPES:
+    """
+    Calculate the first 6 Stumpff functions for variable psi.
+
+    Parameters
+    ----------
+    psi : float
+        Dimensionless parameter at which to evaluate the Stumpff functions (equivalent to alpha * chi**2).
+
+    Returns
+    -------
+    c0, c1, c2, c3, c4, c5 : 6 x float
+        First six Stumpff functions.
+
+    References
+    ----------
+    [1] Danby, J. M. A. (1992). Fundamentals of Celestial Mechanics. 2nd ed.,
+        William-Bell, Inc. ISBN-13: 978-0943396200
+        Notes: of particular interest is Danby's fantastic chapter on universal variables (6.9)
+    """
+    c0, c1, c2, c3, c4, c5 = lax.cond(
+        psi > 0.0,
+        _positive_psi,
+        lambda psi: lax.cond(psi < 0.0, _negative_psi, _null_psi, psi),
+        psi,
+    )
+    return c0, c1, c2, c3, c4, c5

--- a/adam_core/dynamics/tests/test_propagation.py
+++ b/adam_core/dynamics/tests/test_propagation.py
@@ -1,9 +1,14 @@
 import numpy as np
 import spiceypy as sp
 from astropy import units as u
+from astropy.time import Time
 
 from ...constants import Constants as c
-from ..propagation import _propagate_2body
+from ...coordinates.cartesian import CartesianCoordinates
+from ...coordinates.origin import Origin
+from ...coordinates.times import Times
+from ...orbits import Orbits
+from ..propagation import _propagate_2body, propagate_2body
 
 MU = c.MU
 
@@ -70,3 +75,149 @@ def test__propagate_2body_against_spice_hyperbolic(orbital_elements):
         np.testing.assert_array_less(r_diff, 10)
         # Assert velocities are to within 1 mm/s
         np.testing.assert_array_less(v_diff, 1)
+
+
+def test_propagate_2body_against_spice_elliptical(orbital_elements):
+    # Test propagation against SPICE for elliptical orbits.
+
+    orbital_elements = orbital_elements[orbital_elements["e"] < 1.0]
+    cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
+    t0 = orbital_elements["mjd_tdb"].values
+
+    # Create orbits object
+    orbits = Orbits.from_kwargs(
+        orbit_id=orbital_elements["targetname"].values,
+        object_id=orbital_elements["targetname"].values,
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=cartesian_elements[:, 0],
+            y=cartesian_elements[:, 1],
+            z=cartesian_elements[:, 2],
+            vx=cartesian_elements[:, 3],
+            vy=cartesian_elements[:, 4],
+            vz=cartesian_elements[:, 5],
+            time=Times.from_astropy(
+                Time(
+                    t0,
+                    format="mjd",
+                    scale="tdb",
+                )
+            ),
+            origin=Origin.from_kwargs(
+                code=["SUN" for i in range(len(cartesian_elements))]
+            ),
+            frame="ecliptic",
+        ),
+    )
+
+    # Set propagation times (same for all orbits)
+    times = Time(
+        t0.min() + np.arange(0, 10000, 10),
+        format="mjd",
+        scale="tdb",
+    )
+
+    # Propagate orbits with SPICE and accumulate results
+    spice_propagated = []
+    for i, cartesian_i in enumerate(cartesian_elements):
+
+        # Calculate dts from t0 for this orbit (each orbit's t0 is different)
+        # but the final times we are propagating to are the same for all orbits
+        dts = times.tdb.mjd - t0[i]
+        spice_propagated_i = np.empty((len(dts), 6))
+        for j, dt_i in enumerate(dts):
+            spice_propagated_i[j] = sp.prop2b(
+                MU, np.ascontiguousarray(cartesian_i), dt_i
+            )
+
+        spice_propagated.append(spice_propagated_i)
+
+    spice_propagated = np.vstack(spice_propagated)
+
+    # Propagate orbits with adam_core
+    orbits_propagated = propagate_2body(orbits, times)
+
+    # Calculate difference between SPICE and adam_core
+    diff = orbits_propagated.coordinates.values - spice_propagated
+
+    # Calculate offset in position in cm
+    r_diff = np.linalg.norm(diff[:, :3], axis=1) * u.au.to(u.cm)
+    # Calculate offset in velocity in mm/s
+    v_diff = np.linalg.norm(diff[:, 3:], axis=1) * (u.au / u.d).to(u.mm / u.s)
+
+    # Assert positions are to within 10 cm
+    np.testing.assert_array_less(r_diff, 10)
+    # Assert velocities are to within 1 mm/s
+    np.testing.assert_array_less(v_diff, 1)
+
+
+def test_propagate_2body_against_spice_hyperbolic(orbital_elements):
+    # Test propagation against SPICE for hyperbolic orbits.
+
+    orbital_elements = orbital_elements[orbital_elements["e"] > 1.0]
+    cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
+    t0 = orbital_elements["mjd_tdb"].values
+
+    # Create orbits object
+    orbits = Orbits.from_kwargs(
+        orbit_id=orbital_elements["targetname"].values,
+        object_id=orbital_elements["targetname"].values,
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=cartesian_elements[:, 0],
+            y=cartesian_elements[:, 1],
+            z=cartesian_elements[:, 2],
+            vx=cartesian_elements[:, 3],
+            vy=cartesian_elements[:, 4],
+            vz=cartesian_elements[:, 5],
+            time=Times.from_astropy(
+                Time(
+                    t0,
+                    format="mjd",
+                    scale="tdb",
+                )
+            ),
+            origin=Origin.from_kwargs(
+                code=["SUN" for i in range(len(cartesian_elements))]
+            ),
+            frame="ecliptic",
+        ),
+    )
+
+    # Set propagation times (same for all orbits)
+    times = Time(
+        t0.min() + np.arange(0, 10000, 10),
+        format="mjd",
+        scale="tdb",
+    )
+
+    # Propagate orbits with SPICE and accumulate results
+    spice_propagated = []
+    for i, cartesian_i in enumerate(cartesian_elements):
+
+        # Calculate dts from t0 for this orbit (each orbit's t0 is different)
+        # but the final times we are propagating to are the same for all orbits
+        dts = times.tdb.mjd - t0[i]
+        spice_propagated_i = np.empty((len(dts), 6))
+        for j, dt_i in enumerate(dts):
+            spice_propagated_i[j] = sp.prop2b(
+                MU, np.ascontiguousarray(cartesian_i), dt_i
+            )
+
+        spice_propagated.append(spice_propagated_i)
+
+    spice_propagated = np.vstack(spice_propagated)
+
+    # Propagate orbits with adam_core
+    orbits_propagated = propagate_2body(orbits, times)
+
+    # Calculate difference between SPICE and adam_core
+    diff = orbits_propagated.coordinates.values - spice_propagated
+
+    # Calculate offset in position in cm
+    r_diff = np.linalg.norm(diff[:, :3], axis=1) * u.au.to(u.cm)
+    # Calculate offset in velocity in mm/s
+    v_diff = np.linalg.norm(diff[:, 3:], axis=1) * (u.au / u.d).to(u.mm / u.s)
+
+    # Assert positions are to within 10 cm
+    np.testing.assert_array_less(r_diff, 10)
+    # Assert velocities are to within 1 mm/s
+    np.testing.assert_array_less(v_diff, 1)

--- a/adam_core/dynamics/tests/test_propagation.py
+++ b/adam_core/dynamics/tests/test_propagation.py
@@ -253,8 +253,8 @@ def test_benchmark_propagate_2body(benchmark, orbital_elements):
         ),
     )
     times = Time(
-        t0.min() + np.arange(0, 100, 10),
+        [t0.min() + 1],
         format="mjd",
         scale="tdb",
     )
-    benchmark(propagate_2body, orbits, times=times)
+    benchmark(propagate_2body, orbits[0], times=times)

--- a/adam_core/dynamics/tests/test_propagation.py
+++ b/adam_core/dynamics/tests/test_propagation.py
@@ -1,0 +1,72 @@
+import numpy as np
+import spiceypy as sp
+from astropy import units as u
+
+from ...constants import Constants as c
+from ..propagation import _propagate_2body
+
+MU = c.MU
+
+
+def test__propagate_2body_against_spice_elliptical(orbital_elements):
+    # Test propagation against SPICE for elliptical orbits.
+
+    orbital_elements = orbital_elements[orbital_elements["e"] < 1.0]
+    cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
+    t0 = orbital_elements["mjd_tdb"].values
+
+    dts = np.arange(0, 10000, 10)
+    for t0_i, cartesian_i in zip(t0, cartesian_elements):
+
+        spice_propagated = np.empty((len(dts), 6))
+        cartesian_propagated = np.empty((len(dts), 6))
+
+        for j, dt_i in enumerate(dts):
+
+            spice_propagated[j] = sp.prop2b(MU, np.ascontiguousarray(cartesian_i), dt_i)
+            cartesian_propagated[j] = _propagate_2body(cartesian_i, t0_i, t0_i + dt_i)
+
+        # Calculate difference between SPICE and adam_core
+        diff = cartesian_propagated - spice_propagated
+
+        # Calculate offset in position in cm
+        r_diff = np.linalg.norm(diff[:, :3], axis=1) * u.au.to(u.cm)
+        # Calculate offset in velocity in mm/s
+        v_diff = np.linalg.norm(diff[:, 3:], axis=1) * (u.au / u.d).to(u.mm / u.s)
+
+        # Assert positions are to within 10 cm
+        np.testing.assert_array_less(r_diff, 10)
+        # Assert velocities are to within 1 mm/s
+        np.testing.assert_array_less(v_diff, 1)
+
+
+def test__propagate_2body_against_spice_hyperbolic(orbital_elements):
+    # Test propagation against SPICE for hyperbolic orbits.
+
+    orbital_elements = orbital_elements[orbital_elements["e"] > 1.0]
+    cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
+    t0 = orbital_elements["mjd_tdb"].values
+
+    dts = np.arange(0, 10000, 10)
+    for t0_i, cartesian_i in zip(t0, cartesian_elements):
+
+        spice_propagated = np.empty((len(dts), 6))
+        cartesian_propagated = np.empty((len(dts), 6))
+
+        for j, dt_i in enumerate(dts):
+
+            spice_propagated[j] = sp.prop2b(MU, np.ascontiguousarray(cartesian_i), dt_i)
+            cartesian_propagated[j] = _propagate_2body(cartesian_i, t0_i, t0_i + dt_i)
+
+        # Calculate difference between SPICE and adam_core
+        diff = cartesian_propagated - spice_propagated
+
+        # Calculate offset in position in cm
+        r_diff = np.linalg.norm(diff[:, :3], axis=1) * u.au.to(u.cm)
+        # Calculate offset in velocity in mm/s
+        v_diff = np.linalg.norm(diff[:, 3:], axis=1) * (u.au / u.d).to(u.mm / u.s)
+
+        # Assert positions are to within 10 cm
+        np.testing.assert_array_less(r_diff, 10)
+        # Assert velocities are to within 1 mm/s
+        np.testing.assert_array_less(v_diff, 1)

--- a/adam_core/orbits/tests/test_benchmarks.py
+++ b/adam_core/orbits/tests/test_benchmarks.py
@@ -11,8 +11,8 @@ def test_benchmark_iterate_real_orbits(benchmark):
     benchmark(noop_iterate, orbits)
 
 
-def test_benchmark_iterate_real_orbits_df(benchmark):
-    orbits = make_real_orbits(27).to_df().iterrows()
+def test_benchmark_iterate_real_orbits_dataframe(benchmark):
+    orbits = make_real_orbits(27).to_dataframe().itterrows()
 
     def noop_iterate(iterator):
         for _ in iterator:


### PR DESCRIPTION
Ports some of the dynamics modules and 2-body propagation code from THOR to adam_core. 

Our agreement with SPICE is excellent: 2-body propagator agrees with `spiceypy` 2-body propagations to within 10 cm in position and 1 mm/s in velocity

Here is a snippet from the README:

```python
import numpy as np
from astropy.time import Time
from astropy import units as u
from adam_core.orbits.query import query_sbdb
from adam_core.dynamics.propagation import propagate_2body

# Get orbit to propagate
object_ids = ["Duende", "Eros", "Ceres"]
orbits = query_sbdb(object_ids)

# Define propagation times
times = Time(np.arange(59000, 60000), scale="tdb", format="mjd")

# Propagate orbits with 2-body dynamics
propagated_orbits = propagate_2body(
    orbits,
    times
)
```

Note that covariances are also propagated with `jax`. :) 