### PR TITLE
Concurrent futures and a few propagation bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ propagated_orbits = propagator.propagate_orbits(
     orbits,
     times,
     chunk_size=100,
-    num_jobs=1,
+    max_processes=1,
 )
 ```
 

--- a/adam_core/coordinates/times.py
+++ b/adam_core/coordinates/times.py
@@ -14,7 +14,13 @@ class Times(Table):
 
     @classmethod
     def from_astropy(cls, time: Time):
-        return cls.from_kwargs(jd1=time.jd1, jd2=time.jd2, scale=time.scale)
+        if time.isscalar == 1:
+            jd1 = [time.jd1]
+            jd2 = [time.jd2]
+        else:
+            jd1 = time.jd1
+            jd2 = time.jd2
+        return cls.from_kwargs(jd1=jd1, jd2=jd2, scale=time.scale)
 
     def to_astropy(self, format: str = "jd") -> Time:
         t = Time(

--- a/adam_core/propagator/propagator.py
+++ b/adam_core/propagator/propagator.py
@@ -49,7 +49,7 @@ class Propagator(ABC):
         orbits: Orbits,
         times: Time,
         chunk_size: int = 100,
-        num_jobs: Optional[int] = 1,
+        max_processes: Optional[int] = 1,
     ) -> Orbits:
         """
         Propagate each orbit in orbits to each time in times.
@@ -62,9 +62,9 @@ class Propagator(ABC):
             Times to which to propagate orbits.
         chunk_size : int, optional
             Number of orbits to send to each job.
-        num_jobs : int or None, optional
-            Number of jobs to launch. If None then the number of
-            jobs will be equal to the number of cores on the machine. If 1
+        max_processes : int or None, optional
+            Maximum number of processes to launch. If None then the number of
+            processes will be equal to the number of cores on the machine. If 1
             then no multiprocessing will be used.
 
         Returns
@@ -72,8 +72,8 @@ class Propagator(ABC):
         propagated : `~adam_core.orbits.orbits.Orbits`
             Propagated orbits.
         """
-        if num_jobs is None or num_jobs > 1:
-            with concurrent.futures.ProcessPoolExecutor(max_workers=num_jobs) as executor:
+        if max_processes is None or max_processes > 1:
+            with concurrent.futures.ProcessPoolExecutor(max_workers=max_processes) as executor:
                 futures = []
                 for orbit_chunk in _iterate_chunks(orbits, chunk_size):
                     futures.append(executor.submit(propagation_worker, orbit_chunk, times, self))
@@ -105,7 +105,7 @@ class Propagator(ABC):
         orbits: Orbits,
         observers,
         chunk_size: int = 100,
-        num_jobs: Optional[int] = 1,
+        max_processes: Optional[int] = 1,
     ):
         """
         Generate ephemerides for each orbit in orbits as observed by each observer
@@ -120,9 +120,9 @@ class Propagator(ABC):
             orbit.
         chunk_size : int, optional
             Number of orbits to send to each job.
-        num_jobs : int or None, optional
-            Number of jobs to launch. If None then the number of
-            jobs will be equal to the number of cores on the machine. If 1
+        max_processes : int or None, optional
+            Number of processes to launch. If None then the number of
+            processes will be equal to the number of cores on the machine. If 1
             then no multiprocessing will be used.
 
         Returns
@@ -134,8 +134,8 @@ class Propagator(ABC):
         TODO: Add ephemeris class
         TODO: Add an observers class
         """
-        if num_jobs is None or num_jobs > 1:
-            with concurrent.futures.ProcessPoolExecutor(max_workers=num_jobs) as executor:
+        if max_processes is None or max_processes > 1:
+            with concurrent.futures.ProcessPoolExecutor(max_workers=max_processes) as executor:
                 futures = []
                 for orbit_chunk in _iterate_chunks(orbits, chunk_size):
                     futures.append(executor.submit(ephemeris_worker, orbit_chunk, observers, self))

--- a/adam_core/propagator/tests/test_propagator.py
+++ b/adam_core/propagator/tests/test_propagator.py
@@ -30,7 +30,7 @@ def test_propagator_single_worker():
     times = Time(["2020-01-01T00:00:00", "2020-01-01T00:00:01"])
 
     prop = MockPropagator()
-    have = prop.propagate_orbits(orbits, times, num_jobs=1)
+    have = prop.propagate_orbits(orbits, times, max_processes=1)
 
     assert len(have) == len(orbits) * len(times)
 
@@ -40,6 +40,6 @@ def test_propagator_multiple_workers():
     times = Time(["2020-01-01T00:00:00", "2020-01-01T00:00:01"])
 
     prop = MockPropagator()
-    have = prop.propagate_orbits(orbits, times, num_jobs=4)
+    have = prop.propagate_orbits(orbits, times, max_processes=4)
 
     assert len(have) == len(orbits) * len(times)

--- a/adam_core/propagator/tests/test_propagator.py
+++ b/adam_core/propagator/tests/test_propagator.py
@@ -1,0 +1,45 @@
+from astropy.time import Time
+from ...orbits import Orbits
+from ... import coordinates
+from ...utils.helpers.orbits import make_real_orbits
+from .. import Propagator
+
+import quivr
+import pyarrow as pa
+
+
+class MockPropagator(Propagator):
+    # MockPropagator propagates orbits by just setting the time of the orbits.
+    def _propagate_orbits(self, orbits: Orbits, times: Time) -> Orbits:
+        all_times = []
+        for t in times:
+            repeated_time = Time([t] * len(orbits))
+            orbits.coordinates.time = coordinates.Times.from_astropy(
+                repeated_time
+            ).to_structarray()
+            all_times.append(orbits)
+
+        return quivr.concatenate(all_times)
+
+    def _generate_ephemeris(self, orbits: Orbits, observers):
+        raise NotImplementedError("not impleemented")
+
+
+def test_propagator_single_worker():
+    orbits = make_real_orbits(10)
+    times = Time(["2020-01-01T00:00:00", "2020-01-01T00:00:01"])
+
+    prop = MockPropagator()
+    have = prop.propagate_orbits(orbits, times, num_jobs=1)
+
+    assert len(have) == len(orbits) * len(times)
+
+
+def test_propagator_multiple_workers():
+    orbits = make_real_orbits(10)
+    times = Time(["2020-01-01T00:00:00", "2020-01-01T00:00:01"])
+
+    prop = MockPropagator()
+    have = prop.propagate_orbits(orbits, times, num_jobs=4)
+
+    assert len(have) == len(orbits) * len(times)

--- a/adam_core/propagator/utils.py
+++ b/adam_core/propagator/utils.py
@@ -45,8 +45,8 @@ def sort_propagated_orbits(propagated_orbits: Orbits) -> Orbits:
     # Build table with orbit_ids, object_ids, and times
     table = pa.table(
         [
-            propagated_orbits.orbit_ids,
-            propagated_orbits.object_ids,
+            propagated_orbits.orbit_id,
+            propagated_orbits.object_id,
             pc.add(
                 pc.struct_field(
                     pc.struct_field(propagated_orbits.table["coordinates"], "time"),


### PR DESCRIPTION
Swapped out multiprocessing for concurrent.futures because it handles crashes better.

Fixed a little latent bug in orbit propagation, and added tests.

Also did a drive-by fixup of Times to let it be constructed from a scalar astropy.time.Time.