### PR TITLE
Add ephemeris generation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ ephemeris = propagator.generate_ephemeris(
     orbits,
     observers,
     chunk_size=100,
-    num_jobs=1
+    max_processes=1
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ spherical_elements = orbits.coordinates.to_spherical()
 The propagator class in `adam_core` provides a generalized interface to the supported orbit integrators and ephemeris generators. By default,
 `adam_core` ships with PYOORB.
 
+#### Propagation
 To propagate orbits with PYOORB (here we grab some orbits from Horizons first):
 ```python
 import numpy as np
@@ -156,7 +157,7 @@ from astropy import units as u
 from adam_core.orbits.query import query_horizons
 from adam_core.propagator import PYOORB
 
-# Get orbit to propagate
+# Get orbits to propagate
 initial_time = Time([60000.0], scale="tdb", format="mjd")
 object_ids = ["Duende", "Eros", "Ceres"]
 orbits = query_horizons(object_ids, initial_time)
@@ -176,6 +177,40 @@ propagated_orbits = propagator.propagate_orbits(
     max_processes=1,
 )
 ```
+
+#### Ephemeris Generation
+The propagator class can also be used to generate ephemerides for a set of orbits and observers.
+
+```python
+import numpy as np
+from astropy.time import Time
+from astropy import units as u
+from adam_core.orbits.query import query_horizons
+from adam_core.propagator import PYOORB
+from adam_core.observers import Observers
+
+# Get orbits to propagate
+initial_time = Time([60000.0], scale="tdb", format="mjd")
+object_ids = ["Duende", "Eros", "Ceres"]
+orbits = query_horizons(object_ids, initial_time)
+
+# Make sure PYOORB is ready
+propagator = PYOORB()
+
+# Define a set of observers and observation times
+times = initial_time + np.arange(0, 100) * u.d
+observers = Observers.from_code("I11", times)
+
+# Generate ephemerides! This function supports multiprocessing for large
+# propagation jobs.
+ephemeris = propagator.generate_ephemeris(
+    orbits,
+    observers,
+    chunk_size=100,
+    num_jobs=1
+)
+```
+
 
 ### Low-level APIs
 

--- a/adam_core/coordinates/cartesian.py
+++ b/adam_core/coordinates/cartesian.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Optional
 
 import numpy as np
 import pandas as pd
@@ -311,7 +311,7 @@ class CartesianCoordinates(Table):
         return spherical.to_cartesian()
 
     def to_dataframe(
-        self, sigmas: bool = False, covariances: bool = True
+        self, sigmas: Optional[bool] = None, covariances: Optional[bool] = None
     ) -> pd.DataFrame:
         """
         Convert coordinates to a pandas DataFrame.
@@ -319,10 +319,14 @@ class CartesianCoordinates(Table):
         Parameters
         ----------
         sigmas : bool, optional
-            If True, include 1-sigma uncertainties in the DataFrame.
+            If None, will only include sigmas if they are not null.
+            If True, include 1-sigma uncertainties in the DataFrame. If False, do not include
+            sigmas.
         covariances : bool, optional
+            If None, will only include covariances if they are not null.
             If True, include covariance matrices in the DataFrame. Covariance matrices
-            will be split into 21 columns, with the lower triangular elements stored.
+            will be split into 21 columns, with the lower triangular elements stored. If False,
+            do not include covariances.
 
         Returns
         -------

--- a/adam_core/coordinates/cometary.py
+++ b/adam_core/coordinates/cometary.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Optional
 
 import numpy as np
 import pandas as pd
@@ -325,7 +325,7 @@ class CometaryCoordinates(Table):
         return cls.from_cartesian(spherical_coordinates.to_cartesian())
 
     def to_dataframe(
-        self, sigmas: bool = False, covariances: bool = True
+        self, sigmas: Optional[bool] = None, covariances: Optional[bool] = None
     ) -> pd.DataFrame:
         """
         Convert coordinates to a pandas DataFrame.
@@ -333,10 +333,15 @@ class CometaryCoordinates(Table):
         Parameters
         ----------
         sigmas : bool, optional
-            If True, include 1-sigma uncertainties in the DataFrame.
+            If None, will only include sigmas if they are not null.
+            If True, include 1-sigma uncertainties in the DataFrame. If False, do not include
+            sigmas.
         covariances : bool, optional
+            If None, will only include covariances if they are not null.
             If True, include covariance matrices in the DataFrame. Covariance matrices
-            will be split into 21 columns, with the lower triangular elements stored.
+            will be split into 21 columns, with the lower triangular elements stored. If False,
+            do not include covariances.
+
 
         Returns
         -------

--- a/adam_core/coordinates/covariances.py
+++ b/adam_core/coordinates/covariances.py
@@ -198,7 +198,10 @@ class CoordinateCovariances(Table):
             sigmas = sigmas_from_df(df, coord_names=coord_names)
             covariances = sigmas_to_covariances(sigmas)
 
-        return cls.from_matrix(covariances)
+        if np.all(np.isnan(covariances)):
+            return cls.from_kwargs(values=[None for i in range(len(covariances))])
+        else:
+            return cls.from_matrix(covariances)
 
     def is_all_nan(self) -> bool:
         """

--- a/adam_core/coordinates/keplerian.py
+++ b/adam_core/coordinates/keplerian.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Optional
 
 import numpy as np
 import pandas as pd
@@ -302,7 +302,7 @@ class KeplerianCoordinates(Table):
         return cls.from_cartesian(spherical_coordinates.to_cartesian())
 
     def to_dataframe(
-        self, sigmas: bool = False, covariances: bool = True
+        self, sigmas: Optional[bool] = None, covariances: Optional[bool] = None
     ) -> pd.DataFrame:
         """
         Convert coordinates to a pandas DataFrame.
@@ -310,10 +310,14 @@ class KeplerianCoordinates(Table):
         Parameters
         ----------
         sigmas : bool, optional
-            If True, include 1-sigma uncertainties in the DataFrame.
+            If None, will only include sigmas if they are not null.
+            If True, include 1-sigma uncertainties in the DataFrame. If False, do not include
+            sigmas.
         covariances : bool, optional
+            If None, will only include covariances if they are not null.
             If True, include covariance matrices in the DataFrame. Covariance matrices
-            will be split into 21 columns, with the lower triangular elements stored.
+            will be split into 21 columns, with the lower triangular elements stored. If False,
+            do not include covariances.
 
         Returns
         -------

--- a/adam_core/coordinates/spherical.py
+++ b/adam_core/coordinates/spherical.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Optional
 
 import numpy as np
 import pandas as pd
@@ -249,7 +249,7 @@ class SphericalCoordinates(Table):
         return spherical_coordinates
 
     def to_dataframe(
-        self, sigmas: bool = False, covariances: bool = True
+        self, sigmas: Optional[bool] = None, covariances: Optional[bool] = None
     ) -> pd.DataFrame:
         """
         Convert coordinates to a pandas DataFrame.
@@ -257,10 +257,15 @@ class SphericalCoordinates(Table):
         Parameters
         ----------
         sigmas : bool, optional
-            If True, include 1-sigma uncertainties in the DataFrame.
+            If None, will only include sigmas if they are not null.
+            If True, include 1-sigma uncertainties in the DataFrame. If False, do not include
+            sigmas.
         covariances : bool, optional
+            If None, will only include covariances if they are not null.
             If True, include covariance matrices in the DataFrame. Covariance matrices
-            will be split into 21 columns, with the lower triangular elements stored.
+            will be split into 21 columns, with the lower triangular elements stored. If False,
+            do not include covariances.
+
 
         Returns
         -------

--- a/adam_core/coordinates/tests/test_times.py
+++ b/adam_core/coordinates/tests/test_times.py
@@ -18,3 +18,14 @@ def test_Times_to_from_astropy_roundtrip(scale):
 
     times_astropy_2 = times.to_astropy()
     np.testing.assert_equal(times_astropy_2.mjd, times_astropy.mjd)
+
+
+def test_Times_to_scale():
+    # Test that we can convert between time scales correctly
+    times_tdb = Time(np.arange(59000, 60000), scale="tdb", format="mjd")
+    times_tdb = Times.from_astropy(times_tdb)
+    assert times_tdb.scale == "tdb"
+
+    times_utc = times_tdb.to_scale("utc")
+    assert times_utc.scale == "utc"
+    np.testing.assert_equal(times_utc.to_astropy().mjd, times_tdb.to_astropy().utc.mjd)

--- a/adam_core/coordinates/times.py
+++ b/adam_core/coordinates/times.py
@@ -1,4 +1,6 @@
 import pandas as pd
+import pyarrow as pa
+import pyarrow.compute as pc
 import quivr as qv
 from astropy.time import Time
 from typing_extensions import Self
@@ -98,3 +100,25 @@ class Times(qv.Table):
             columns={col: col.split("_")[0] for col in df_filtered.columns}
         )
         return cls.from_kwargs(jd1=df_renamed.jd1, jd2=df_renamed.jd2, scale=scale)
+
+    def jd(self) -> pa.lib.DoubleArray:
+        """
+        Returns the times as a double-precision array of julian date values.
+
+        Returns
+        -------
+        jd : `~pyarrow.DoubleArray`
+            The times as a double-precision array of julian date values.
+        """
+        return pc.add(self.jd1, self.jd2)
+
+    def mjd(self) -> pa.lib.DoubleArray:
+        """
+        Returns the times as a double-precision array of modified julian date values.
+
+        Returns
+        -------
+        mjd : `~pyarrow.DoubleArray`
+            The times as a double-precision array of modified julian date values.
+        """
+        return pc.add(pc.add(self.jd1, -2400000.5), self.jd2)

--- a/adam_core/coordinates/times.py
+++ b/adam_core/coordinates/times.py
@@ -1,16 +1,17 @@
 import pandas as pd
+import quivr as qv
 from astropy.time import Time
-from quivr import Float64Column, StringAttribute, Table
+from typing_extensions import Self
 
 
-class Times(Table):
+class Times(qv.Table):
 
     # Stores the time as a pair of float64 values in the same style as erfa/astropy:
     # The first one is the day-part of a Julian date, and the second is
     # the fractional day-part.
-    jd1 = Float64Column()
-    jd2 = Float64Column()
-    scale = StringAttribute(default="utc")
+    jd1 = qv.Float64Column()
+    jd2 = qv.Float64Column()
+    scale = qv.StringAttribute(default="utc")
 
     @classmethod
     def from_astropy(cls, time: Time):
@@ -33,6 +34,24 @@ class Times(Table):
             return t
         t.format = format
         return t
+
+    def to_scale(self, scale: str) -> Self:
+        """
+        Convert to a different time scale.
+
+        Parameters
+        ----------
+        scale : str
+            The time scale to convert to.
+
+        Returns
+        -------
+        times : `~adam_core.coordinates.times.Times`
+            The times in the new scale.
+        """
+        time = self.to_astropy()
+        time._set_scale(scale)
+        return self.from_astropy(time)
 
     def to_dataframe(self, flatten: bool = True) -> pd.DataFrame:
         """

--- a/adam_core/observers/__init__.py
+++ b/adam_core/observers/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa: F401
+from .observers import Observers
 from .state import get_observer_state

--- a/adam_core/observers/observers.py
+++ b/adam_core/observers/observers.py
@@ -1,6 +1,10 @@
 import pandas as pd
+from astropy.time import Time
 from mpc_obscodes import mpc_obscodes
 from quivr import Float64Column, StringColumn, Table
+from typing_extensions import Self
+
+from ..coordinates.cartesian import CartesianCoordinates
 
 
 class ObservatoryGeodetics(Table):
@@ -29,3 +33,112 @@ OBSERVATORY_GEODETICS = ObservatoryGeodetics.from_kwargs(
 OBSERVATORY_CODES = {
     x for x in OBSERVATORY_GEODETICS.code.to_numpy(zero_copy_only=False)
 }
+
+
+class Observers(Table):
+    code = StringColumn(nullable=False)
+    coordinates = CartesianCoordinates.as_column()
+
+    @classmethod
+    def from_code(cls, code: str, times: Time) -> Self:
+        """
+        Instantiate an Observers table with a single code and multiple times.
+        Times do not need to be unique. The observer state will be calculated
+        for each time and correctly matched to the input times and replicated for
+        duplicate times.
+
+        To load multiple codes, use `from_code` and then concatenate the tables.
+
+        Parameters
+        ----------
+        code : str
+            MPC observatory code for which to find the states.
+        times : `~astropy.time.core.Time` (N)
+            Epochs for which to find the observatory locations.
+
+        Returns
+        -------
+        observers : `~adam_core.observers.observers.Observers` (N)
+            The observer and its state at each time.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from astropy.time import Time
+        >>> from adam_core.observers import Observers
+        >>> times = Time(np.arange(59000, 59000 + 100), scale="tdb", format="mjd")
+        >>> observers = Observers.from_code("X05", times)
+        """
+        from .state import get_observer_state
+
+        return cls.from_kwargs(
+            code=[code] * len(times),
+            coordinates=get_observer_state(code, times),
+        )
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """
+        Convert the Observers table to a pandas DataFrame.
+
+        Returns
+        -------
+        df : `~pandas.DataFrame`
+            The Observers table as a DataFrame.
+        """
+        df = self.coordinates.to_dataframe(
+            sigmas=False,
+            covariances=False,
+        )
+        df.rename(
+            columns={
+                "jd1_tdb": "obs_jd1_tdb",
+                "jd2_tdb": "obs_jd2_tdb",
+                "x": "obs_x",
+                "y": "obs_y",
+                "z": "obs_z",
+                "vx": "obs_vx",
+                "vy": "obs_vy",
+                "vz": "obs_vz",
+                "origin.code": "obs_origin.code",
+            },
+            inplace=True,
+        )
+        df.insert(0, "obs_code", self.code)
+        return df
+
+    @classmethod
+    def from_dataframe(cls, df: pd.DataFrame) -> Self:
+        """
+        Instantiate an Observers table from a pandas DataFrame.
+
+        Parameters
+        ----------
+        df : `~pandas.DataFrame`
+            The Observers table as a DataFrame.
+
+        Returns
+        -------
+        observers : `~adam_core.observers.observers.Observers`
+            The Observers table.
+        """
+        df_renamed = df.rename(
+            columns={
+                "obs_jd1_tdb": "jd1_tdb",
+                "obs_jd2_tdb": "jd2_tdb",
+                "obs_x": "x",
+                "obs_y": "y",
+                "obs_z": "z",
+                "obs_vx": "vx",
+                "obs_vy": "vy",
+                "obs_vz": "vz",
+                "obs_origin.code": "origin.code",
+            }
+        )
+        coordinates = CartesianCoordinates.from_dataframe(
+            df_renamed,
+            frame="ecliptic",
+        )
+        return cls.from_kwargs(
+            code=df["obs_code"].values,
+            coordinates=coordinates,
+        )

--- a/adam_core/observers/observers.py
+++ b/adam_core/observers/observers.py
@@ -98,7 +98,7 @@ class Observers(Table):
         observers : `~adam_core.observers.observers.Observers`
             The Observers table for this observer.
         """
-        for code in self.code.unique():
+        for code in self.code.unique().sort():
             yield code.as_py(), self.select("code", code)
 
     def to_dataframe(self) -> pd.DataFrame:

--- a/adam_core/observers/observers.py
+++ b/adam_core/observers/observers.py
@@ -76,6 +76,20 @@ class Observers(Table):
             coordinates=get_observer_state(code, times),
         )
 
+    def iterate_codes(self):
+        """
+        Iterate over the codes in the Observers table.
+
+        Yields
+        ------
+        code : str
+            The code for observer.
+        observers : `~adam_core.observers.observers.Observers`
+            The Observers table for this observer.
+        """
+        for code in self.code.unique():
+            yield code.as_py(), self.select("code", code)
+
     def to_dataframe(self) -> pd.DataFrame:
         """
         Convert the Observers table to a pandas DataFrame.

--- a/adam_core/observers/observers.py
+++ b/adam_core/observers/observers.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pandas as pd
 from astropy.time import Time
 from mpc_obscodes import mpc_obscodes
@@ -16,12 +18,21 @@ class ObservatoryGeodetics(Table):
 
 
 # Read MPC extended observatory codes file
-OBSCODES = pd.read_json(
-    mpc_obscodes,
-    orient="index",
-    dtype={"Longitude": float, "cos": float, "sin": float, "Name": str},
-)
-OBSCODES.reset_index(inplace=True, names=["code"])
+# Ignore warning about pandas deprecation
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message="The behavior of 'to_datetime' with 'unit' when parsing strings is deprecated",
+    )
+    OBSCODES = pd.read_json(
+        mpc_obscodes,
+        orient="index",
+        dtype={"Longitude": float, "cos": float, "sin": float, "Name": str},
+        encoding_errors="strict",
+        precise_float=True,
+    )
+    OBSCODES.reset_index(inplace=True, names=["code"])
+
 OBSERVATORY_GEODETICS = ObservatoryGeodetics.from_kwargs(
     code=OBSCODES["code"].values,
     longitude=OBSCODES["Longitude"].values,

--- a/adam_core/orbits/__init__.py
+++ b/adam_core/orbits/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa: F401
 from .classification import calc_orbit_class
+from .ephemeris import Ephemeris
 from .orbits import Orbits

--- a/adam_core/orbits/ephemeris.py
+++ b/adam_core/orbits/ephemeris.py
@@ -1,0 +1,33 @@
+from quivr import Float64Column, StringAttribute, StringColumn, Table
+
+from ..coordinates.origin import Origin
+from ..coordinates.spherical import SphericalCoordinates
+from ..coordinates.times import Times
+
+
+class Ephemeris(Table):
+
+    orbit_id = StringColumn(nullable=False)
+    object_id = StringColumn(nullable=False)
+    time = Times.as_column(nullable=False)
+    rho = Float64Column(nullable=False)
+    ra = Float64Column(nullable=False)
+    dec = Float64Column(nullable=False)
+    vrho = Float64Column(nullable=False)
+    vra = Float64Column(nullable=False)
+    vdec = Float64Column(nullable=False)
+    origin = Origin.as_column(nullable=False)
+    frame = StringAttribute()
+
+    def as_spherical_coordinates(self):
+        return SphericalCoordinates.from_kwargs(
+            rho=self.rho,
+            lon=self.ra,
+            lat=self.dec,
+            vrho=self.vrho,
+            vlon=self.vra,
+            vlat=self.vdec,
+            time=self.time,
+            origin=self.origin,
+            frame=self.frame,
+        )

--- a/adam_core/orbits/ephemeris.py
+++ b/adam_core/orbits/ephemeris.py
@@ -1,4 +1,6 @@
+import pandas as pd
 from quivr import Float64Column, StringAttribute, StringColumn, Table
+from typing_extensions import Self
 
 from ..coordinates.spherical import SphericalCoordinates
 from ..observers import Observers
@@ -7,17 +9,17 @@ from ..observers import Observers
 class Ephemeris(Table):
 
     orbit_id = StringColumn(nullable=False)
-    object_id = StringColumn(nullable=False)
-    observer = Observers.as_column(nullable=True)
-    rho = Float64Column(nullable=True)
+    object_id = StringColumn()
+    observer = Observers.as_column(nullable=False)
+    rho = Float64Column()
     ra = Float64Column(nullable=False)
     dec = Float64Column(nullable=False)
-    vrho = Float64Column(nullable=True)
-    vra = Float64Column(nullable=True)
-    vdec = Float64Column(nullable=True)
+    vrho = Float64Column()
+    vra = Float64Column()
+    vdec = Float64Column()
     frame = StringAttribute()
 
-    def as_spherical_coordinates(self):
+    def as_spherical_coordinates(self) -> SphericalCoordinates:
         return SphericalCoordinates.from_kwargs(
             rho=self.rho,
             lon=self.ra,
@@ -28,4 +30,80 @@ class Ephemeris(Table):
             time=self.observer.coordinates.time,
             origin=self.observer.code,
             frame=self.frame,
+        )
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """
+        Convert the Ephemeris table to a pandas DataFrame.
+
+        Returns
+        -------
+        df : `~pandas.DataFrame`
+            The Ephemeris table as a DataFrame.
+        """
+        df = pd.DataFrame()
+        df["orbit_id"] = self.orbit_id
+        df["object_id"] = self.object_id
+        df["ra"] = self.ra
+        df["dec"] = self.dec
+        df["vra"] = self.vra
+        df["vdec"] = self.vdec
+        df["rho"] = self.rho
+        df["vrho"] = self.vrho
+
+        df_obs = self.observer.to_dataframe()
+        df = pd.concat([df, df_obs], axis=1)
+
+        df = df[
+            [
+                "orbit_id",
+                "object_id",
+                "obs_code",
+                "obs_jd1_tdb",
+                "obs_jd2_tdb",
+                "ra",
+                "dec",
+                "rho",
+                "vra",
+                "vdec",
+                "vrho",
+                "obs_x",
+                "obs_y",
+                "obs_z",
+                "obs_vx",
+                "obs_vy",
+                "obs_vz",
+                "obs_origin.code",
+            ]
+        ]
+        return df
+
+    @classmethod
+    def from_dataframe(cls, df: pd.DataFrame) -> Self:
+        """
+        Instantiate an Ephemeris table from a pandas DataFrame.
+
+        Parameters
+        ----------
+        df : `~pandas.DataFrame`
+            The Ephemeris table as a DataFrame.
+
+        Returns
+        -------
+        ephemeris : `~adam_core.orbits.ephemeris.Ephemeris`
+            The Ephemeris table.
+        """
+        observers = Observers.from_dataframe(df)
+
+        return cls.from_kwargs(
+            orbit_id=df["orbit_id"],
+            object_id=df["object_id"],
+            observer=observers,
+            ra=df["ra"],
+            dec=df["dec"],
+            rho=df["rho"],
+            vra=df["vra"],
+            vdec=df["vdec"],
+            vrho=df["vrho"],
+            frame="equatorial",
         )

--- a/adam_core/orbits/ephemeris.py
+++ b/adam_core/orbits/ephemeris.py
@@ -1,22 +1,20 @@
 from quivr import Float64Column, StringAttribute, StringColumn, Table
 
-from ..coordinates.origin import Origin
 from ..coordinates.spherical import SphericalCoordinates
-from ..coordinates.times import Times
+from ..observers import Observers
 
 
 class Ephemeris(Table):
 
     orbit_id = StringColumn(nullable=False)
     object_id = StringColumn(nullable=False)
-    time = Times.as_column(nullable=False)
-    rho = Float64Column(nullable=False)
+    observer = Observers.as_column(nullable=True)
+    rho = Float64Column(nullable=True)
     ra = Float64Column(nullable=False)
     dec = Float64Column(nullable=False)
-    vrho = Float64Column(nullable=False)
-    vra = Float64Column(nullable=False)
-    vdec = Float64Column(nullable=False)
-    origin = Origin.as_column(nullable=False)
+    vrho = Float64Column(nullable=True)
+    vra = Float64Column(nullable=True)
+    vdec = Float64Column(nullable=True)
     frame = StringAttribute()
 
     def as_spherical_coordinates(self):
@@ -27,7 +25,7 @@ class Ephemeris(Table):
             vrho=self.vrho,
             vlon=self.vra,
             vlat=self.vdec,
-            time=self.time,
-            origin=self.origin,
+            time=self.observer.coordinates.time,
+            origin=self.observer.code,
             frame=self.frame,
         )

--- a/adam_core/propagator/pyoorb.py
+++ b/adam_core/propagator/pyoorb.py
@@ -444,20 +444,20 @@ class PYOORB(Propagator):
         # Concatenate ephemeris into single table
         ephemeris = qv.concatenate(ephemeris_list)
 
-        # We round jd2 to 10 digits or to within 8.64 microseconds to
-        # get around linking on floating point time numbers
+        # We use mjd as the time linking key because openorb uses
+        # mjd. If we try to use coordinates.time.jd1 and jd2 directly,
+        # we will get loss-of-precision issues, and the keys won't
+        # align.
         linkages = qv.MultiKeyLinkage(
             left_table=ephemeris,
             right_table=observers,
             left_keys={
                 "code": ephemeris.coordinates.origin.code,
-                "jd1": ephemeris.coordinates.time.jd1,
-                "jd2": pc.round(ephemeris.coordinates.time.jd2, ndigits=10),
+                "mjd": ephemeris.coordinates.time.mjd(),
             },
             right_keys={
                 "code": observers_utc.code,
-                "jd1": observers_utc.coordinates.time.jd1,
-                "jd2": pc.round(observers_utc.coordinates.time.jd2, ndigits=10),
+                "mjd": observers_utc.coordinates.time.mjd(),
             },
         )
 

--- a/adam_core/propagator/utils.py
+++ b/adam_core/propagator/utils.py
@@ -54,7 +54,7 @@ def _assert_times_almost_equal(
 
     diff = np.abs(have - want)
     if np.any(diff > tolerance_in_days):
-        raise ValueError(f"Times were not within {tolerance:.2f} ms of each other.")
+        raise ValueError(f"Times were not within {tolerance:.6f} ms of each other.")
 
 
 def sort_propagated_orbits(propagated_orbits: Orbits) -> Orbits:

--- a/adam_core/propagator/utils.py
+++ b/adam_core/propagator/utils.py
@@ -4,7 +4,8 @@ import numpy as np
 import pyarrow as pa
 from pyarrow import compute as pc
 
-from ..orbits import Orbits
+from ..orbits.ephemeris import Ephemeris
+from ..orbits.orbits import Orbits
 
 MILLISECOND_IN_DAYS = 1 / 86400 / 1000
 
@@ -31,18 +32,43 @@ def _iterate_chunks(iterable: Sequence, chunk_size: int) -> Iterable:
         yield iterable[i : i + chunk_size]
 
 
+def _assert_times_almost_equal(
+    have: np.ndarray, want: np.ndarray, tolerance: float = 0.1
+):
+    """
+    Raises a ValueError if the time arrays (in units of days such as MJD) are not within the
+    tolerance in milliseconds of each other.
+
+    Parameters
+    ----------
+    have : `~numpy.ndarray`
+        Times (in units of days) to check.
+    want : `~numpy.ndarray`
+        Times (in units of days) to check.
+
+    Raises
+    ------
+    ValueError: If the time arrays are not within the tolerance in milliseconds of each other.
+    """
+    tolerance_in_days = tolerance * MILLISECOND_IN_DAYS
+
+    diff = np.abs(have - want)
+    if np.any(diff > tolerance_in_days):
+        raise ValueError(f"Times were not within {tolerance:.2f} ms of each other.")
+
+
 def sort_propagated_orbits(propagated_orbits: Orbits) -> Orbits:
     """
     Sort propagated orbits by orbit_id, object_id, and time.
 
     Parameters
     ----------
-    propagated_orbits : Orbits
+    propagated_orbits : `~adam_core.orbits.orbits.Orbits`
         Orbits to sort.
 
     Returns
     -------
-    Orbits
+    Orbits : `~adam_core.orbits.orbits.Orbits`
         Sorted orbits.
     """
     # Build table with orbit_ids, object_ids, and times
@@ -75,26 +101,49 @@ def sort_propagated_orbits(propagated_orbits: Orbits) -> Orbits:
     return propagated_orbits.take(indices)
 
 
-def _assert_times_almost_equal(
-    have: np.ndarray, want: np.ndarray, tolerance: float = 0.1
-):
+def sort_ephemeris(ephemeris: Ephemeris) -> Ephemeris:
     """
-    Raises a ValueError if the time arrays (in units of days such as MJD) are not within the
-    tolerance in milliseconds of each other.
+    Sort ephemeris by orbit_id, object_id, time, and observatory code.
 
     Parameters
     ----------
-    have : `~numpy.ndarray`
-        Times (in units of days) to check.
-    want : `~numpy.ndarray`
-        Times (in units of days) to check.
+    ephemeris : `~adam_core.orbits.ephemeris.Ephemeris`
+        Ephemerides to sort.
 
-    Raises
-    ------
-    ValueError: If the time arrays are not within the tolerance in milliseconds of each other.
+    Returns
+    -------
+    ephemeris : `~adam_core.orbits.ephemeris.Ephemeris`
+        Sorted ephemerides.
     """
-    tolerance_in_days = tolerance * MILLISECOND_IN_DAYS
+    # Build table with orbit_ids, object_ids, times and observatory codes
+    coords_array = ephemeris.table["observer"].combine_chunks().field("coordinates")
 
-    diff = np.abs(have - want)
-    if np.any(diff > tolerance_in_days):
-        raise ValueError(f"Times were not within {tolerance:.2f} ms of each other.")
+    table = pa.table(
+        [
+            ephemeris.orbit_id,
+            ephemeris.object_id,
+            pc.add(
+                pc.struct_field(
+                    pc.struct_field(coords_array, "time"),
+                    "jd1",
+                ),
+                pc.struct_field(
+                    pc.struct_field(coords_array, "time"),
+                    "jd2",
+                ),
+            ),
+            ephemeris.observer.code,
+        ],
+        names=["orbit_id", "object_id", "time", "observatory_code"],
+    )
+
+    indices = pc.sort_indices(
+        table,
+        (
+            ("orbit_id", "ascending"),
+            ("object_id", "ascending"),
+            ("time", "ascending"),
+            ("observatory_code", "ascending"),
+        ),
+    )
+    return ephemeris.take(indices)


### PR DESCRIPTION
This PR adds an observer class, ephemeris class and then ephemeris generation with PYOORB. 

Snippet from the README to get a sense of the interface: 
```python
import numpy as np
from astropy.time import Time
from astropy import units as u
from adam_core.orbits.query import query_horizons
from adam_core.propagator import PYOORB
from adam_core.observers import Observers

# Get orbits to propagate
initial_time = Time([60000.0], scale="tdb", format="mjd")
object_ids = ["Duende", "Eros", "Ceres"]
orbits = query_horizons(object_ids, initial_time)

# Make sure PYOORB is ready
propagator = PYOORB()

# Define a set of observers and observation times
times = initial_time + np.arange(0, 100) * u.d
observers = Observers.from_code("I11", times)

# Generate ephemerides! This function supports multiprocessing for large
# propagation jobs.
ephemeris = propagator.generate_ephemeris(
    orbits,
    observers,
    chunk_size=100,
    num_jobs=1
)
```