### PR TITLE
Add CoordinateCovariances.is_all_nan()

### DIFF
--- a/adam_core/coordinates/cometary.py
+++ b/adam_core/coordinates/cometary.py
@@ -212,8 +212,8 @@ class CometaryCoordinates(Table):
         )
         coords_cartesian = np.array(coords_cartesian)
 
-        cometary_covariances = self.covariance.to_matrix()
-        if not np.all(np.isnan(cometary_covariances)):
+        if not self.covariance.is_all_nan():
+            cometary_covariances = self.covariance.to_matrix()
             covariances_cartesian = transform_covariances_jacobian(
                 self.values,
                 cometary_covariances,
@@ -269,8 +269,8 @@ class CometaryCoordinates(Table):
         )
         coords_cometary = np.array(coords_cometary)
 
-        cartesian_covariances = cartesian.covariance.to_matrix()
-        if not np.all(np.isnan(cartesian_covariances)):
+        if not cartesian.covariance.is_all_nan():
+            cartesian_covariances = cartesian.covariance.to_matrix()
             covariances_cometary = transform_covariances_jacobian(
                 cartesian.values,
                 cartesian_covariances,

--- a/adam_core/coordinates/covariances.py
+++ b/adam_core/coordinates/covariances.py
@@ -177,6 +177,17 @@ class CoordinateCovariances(Table):
 
         return cls.from_matrix(covariances)
 
+    def is_all_nan(self) -> bool:
+        """
+        Check if all covariance matrix values are NaN.
+
+        Returns
+        -------
+        is_all_nan : bool
+            True if all covariance matrix elements are NaN, False otherwise.
+        """
+        return np.all(np.isnan(self.to_matrix()))
+
 
 def sample_covariance(
     mean: np.ndarray, cov: np.ndarray, num_samples: int = 100000

--- a/adam_core/coordinates/keplerian.py
+++ b/adam_core/coordinates/keplerian.py
@@ -199,8 +199,8 @@ class KeplerianCoordinates(Table):
         )
         coords_cartesian = np.array(coords_cartesian)
 
-        covariances_keplerian = self.covariance.to_matrix()
-        if not np.all(np.isnan(covariances_keplerian)):
+        if not self.covariance.is_all_nan():
+            covariances_keplerian = self.covariance.to_matrix()
             covariances_cartesian = transform_covariances_jacobian(
                 self.values,
                 covariances_keplerian,
@@ -247,8 +247,8 @@ class KeplerianCoordinates(Table):
         )
         coords_keplerian = np.array(coords_keplerian)
 
-        cartesian_covariances = cartesian.covariance.to_matrix()
-        if not np.all(np.isnan(cartesian_covariances)):
+        if not cartesian.covariance.is_all_nan():
+            cartesian_covariances = cartesian.covariance.to_matrix()
             covariances_keplerian = transform_covariances_jacobian(
                 cartesian.values,
                 cartesian_covariances,

--- a/adam_core/coordinates/spherical.py
+++ b/adam_core/coordinates/spherical.py
@@ -160,8 +160,8 @@ class SphericalCoordinates(Table):
         coords_cartesian = spherical_to_cartesian(self.values)
         coords_cartesian = np.array(coords_cartesian)
 
-        covariances_spherical = self.covariance.to_matrix()
-        if not np.all(np.isnan(covariances_spherical)):
+        if not self.covariance.is_all_nan():
+            covariances_spherical = self.covariance.to_matrix()
             covariances_cartesian = transform_covariances_jacobian(
                 self.values, covariances_spherical, _spherical_to_cartesian
             )
@@ -193,8 +193,8 @@ class SphericalCoordinates(Table):
         coords_spherical = cartesian_to_spherical(cartesian.values)
         coords_spherical = np.array(coords_spherical)
 
-        cartesian_covariances = cartesian.covariance.to_matrix()
-        if not np.all(np.isnan(cartesian_covariances)):
+        if not cartesian.covariance.is_all_nan():
+            cartesian_covariances = cartesian.covariance.to_matrix()
             covariances_spherical = transform_covariances_jacobian(
                 cartesian.values, cartesian_covariances, _cartesian_to_spherical
             )

--- a/adam_core/coordinates/tests/test_covariances.py
+++ b/adam_core/coordinates/tests/test_covariances.py
@@ -47,6 +47,19 @@ def test_CoordinateCovariances_to_from_matrix():
     cov = CoordinateCovariances.from_matrix(covariances)
     np.testing.assert_equal(cov.to_matrix(), covariances)
 
+    # Test when covariances are mixed with None and np.array
+    covariances = [None, np.ones((6, 6)).flatten()]
+    cov = CoordinateCovariances.from_kwargs(values=covariances)
+    cov_expected = np.ones((2, 6, 6))
+    cov_expected[0, :, :] = np.NaN
+    np.testing.assert_equal(cov.to_matrix(), cov_expected)
+
+    # Test when covariances are only None
+    covariances = [None, None]
+    cov = CoordinateCovariances.from_kwargs(values=covariances)
+    cov_expected = np.full((2, 6, 6), np.NaN)
+    np.testing.assert_equal(cov.to_matrix(), cov_expected)
+
 
 def test_CoordinateCovariances_to_dataframe():
     # Given an array of covariances test that the dataframe

--- a/adam_core/coordinates/tests/test_covariances.py
+++ b/adam_core/coordinates/tests/test_covariances.py
@@ -103,3 +103,27 @@ def test_CoordinateCovariances_to_dataframe():
     np.testing.assert_equal(df["sigma_vx"].values, np.sqrt(np.array([25.0, 36.0])))
     np.testing.assert_equal(df["sigma_vy"].values, np.sqrt(np.array([36.0, 49.0])))
     np.testing.assert_equal(df["sigma_vz"].values, np.sqrt(np.array([49.0, 64.0])))
+
+
+def test_CoordinateCovariances_is_all_nan():
+    # Test that all_nan convenience method works as intended
+    # No NaNs at all
+    covariances = np.ones((10, 6, 6))
+    cov = CoordinateCovariances.from_matrix(covariances)
+    assert not cov.is_all_nan()
+
+    # Single NaN value
+    covariances = np.ones((10, 6, 6))
+    covariances[0, 0, 0] = np.nan
+    cov = CoordinateCovariances.from_matrix(covariances)
+    assert not cov.is_all_nan()
+
+    # Null covariance (None)
+    covariances = [None, np.ones((6, 6)).flatten()]
+    cov = CoordinateCovariances.from_kwargs(values=covariances)
+    assert not cov.is_all_nan()
+
+    # All NaNs
+    covariances = np.ones((10, 6, 6)) * np.nan
+    cov = CoordinateCovariances.from_matrix(covariances)
+    assert cov.is_all_nan()

--- a/adam_core/dynamics/propagation.py
+++ b/adam_core/dynamics/propagation.py
@@ -128,8 +128,8 @@ def propagate_2body(
     )
     orbits_propagated = np.array(orbits_propagated)
 
-    cartesian_covariances = orbits.coordinates.covariance.to_matrix()
-    if not np.all(np.isnan(cartesian_covariances)):
+    if not orbits.coordinates.covariance.is_all_nan():
+        cartesian_covariances = orbits.coordinates.covariance.to_matrix()
         covariances_array_ = np.repeat(cartesian_covariances, n_times, axis=0)
 
         cartesian_covariances = transform_covariances_jacobian(


### PR DESCRIPTION
To avoid future mistakes when checking if all elements in a stack of covariance matrices are nan, this PR adds a convenience function to `CoordinateCovariances` that will return a boolean. 