### PR TITLE
Make CoordinateCovariances a fixed_shape_tensor

### DIFF
--- a/adam_core/coordinates/tests/test_benchmarks.py
+++ b/adam_core/coordinates/tests/test_benchmarks.py
@@ -4,6 +4,7 @@ from astropy.time import Time
 
 from ..cartesian import CartesianCoordinates
 from ..cometary import CometaryCoordinates
+from ..covariances import CoordinateCovariances
 from ..keplerian import KeplerianCoordinates
 from ..origin import Origin, OriginCodes
 from ..spherical import SphericalCoordinates
@@ -50,3 +51,22 @@ def test_benchmark_transform_cartesian_coordinates(
         frame_out=frame,
         origin_out=origin,
     )
+
+
+@pytest.mark.benchmark(group="coordinate_covariances")
+def test_benchmark_CoordinateCovariances_to_matrix(benchmark):
+
+    covariances_filled = [np.random.random(36) for _ in range(500)]
+    covariances_missing = [None for _ in range(500)]
+    coordinate_covariances = CoordinateCovariances.from_kwargs(
+        values=covariances_filled + covariances_missing
+    )
+    benchmark(coordinate_covariances.to_matrix)
+
+
+@pytest.mark.benchmark(group="coordinate_covariances")
+def test_benchmark_CoordinateCovariances_from_matrix(benchmark):
+
+    covariances = np.random.random((1000, 6, 6))
+    covariances[500:, :, :] = np.nan
+    benchmark(CoordinateCovariances.from_matrix, covariances)


### PR DESCRIPTION
I was originally going to address @spenczar's excellent comments on #30 and use pyarrow's compute functionality to make `CoordinateCovariances.to_matrix` more efficient. However, it turns out that issue [35599](https://github.com/apache/arrow/issues/35599) has been resolved on the pyarrow side and so now CoordinateCovariances can actually be stored as fixed shape tensors. 

Note that I added benchmarking too. Here are the results before the PR:
![Screenshot from 2023-08-04 13-25-35](https://github.com/B612-Asteroid-Institute/adam_core/assets/4206654/e29e52a5-ac94-45b8-9f44-ac840c3eca4e)

After the swap to the tensor backed covariance:
![Screenshot from 2023-08-04 13-26-00](https://github.com/B612-Asteroid-Institute/adam_core/assets/4206654/b398b47f-6d97-4be9-b671-a1a10d2e9c1f)
