### PR TITLE
Upgrade to quivr v0.6.2

### DIFF
--- a/adam_core/coordinates/cartesian.py
+++ b/adam_core/coordinates/cartesian.py
@@ -41,7 +41,7 @@ class CartesianCoordinates(Table):
     vz = Float64Column(nullable=True)
     time = Times.as_column(nullable=True)
     covariance = CoordinateCovariances.as_column(nullable=True)
-    origin = Origin.as_column(nullable=False)
+    origin = Origin.as_column()
     frame = StringAttribute()
 
     @property

--- a/adam_core/coordinates/cometary.py
+++ b/adam_core/coordinates/cometary.py
@@ -40,15 +40,15 @@ class CometaryCoordinates(Table):
     # grab the MJD column. That said, we would want to force it
     # the time scale to be in TDB..
 
-    q = Float64Column(nullable=False)
-    e = Float64Column(nullable=False)
-    i = Float64Column(nullable=False)
-    raan = Float64Column(nullable=False)
-    ap = Float64Column(nullable=False)
-    tp = Float64Column(nullable=False)
+    q = Float64Column()
+    e = Float64Column()
+    i = Float64Column()
+    raan = Float64Column()
+    ap = Float64Column()
+    tp = Float64Column()
     time = Times.as_column(nullable=True)
     covariance = CoordinateCovariances.as_column(nullable=True)
-    origin = Origin.as_column(nullable=False)
+    origin = Origin.as_column()
     frame = StringAttribute()
 
     @property

--- a/adam_core/coordinates/covariances.py
+++ b/adam_core/coordinates/covariances.py
@@ -58,7 +58,7 @@ class CoordinateCovariances(Table):
 
     # This is temporary while we await the implementation of
     # https://github.com/apache/arrow/issues/35599
-    values = FixedSizeListColumn(pa.float64(), list_size=36)
+    values = FixedSizeListColumn(pa.float64(), list_size=36, nullable=True)
     # When fixed, we should revert to:
     # values = Column(pa.fixed_shape_tensor(pa.float64(), (6, 6)))
 

--- a/adam_core/coordinates/keplerian.py
+++ b/adam_core/coordinates/keplerian.py
@@ -36,15 +36,15 @@ KEPLERIAN_UNITS["M"] = u.deg
 
 class KeplerianCoordinates(Table):
 
-    a = Float64Column(nullable=False)
-    e = Float64Column(nullable=False)
-    i = Float64Column(nullable=False)
-    raan = Float64Column(nullable=False)
-    ap = Float64Column(nullable=False)
-    M = Float64Column(nullable=False)
+    a = Float64Column()
+    e = Float64Column()
+    i = Float64Column()
+    raan = Float64Column()
+    ap = Float64Column()
+    M = Float64Column()
     time = Times.as_column(nullable=True)
     covariance = CoordinateCovariances.as_column(nullable=True)
-    origin = Origin.as_column(nullable=False)
+    origin = Origin.as_column()
     frame = StringAttribute()
 
     @property

--- a/adam_core/coordinates/origin.py
+++ b/adam_core/coordinates/origin.py
@@ -60,7 +60,7 @@ class OriginGravitationalParameters(float, Enum):
 #       Investigate whether this class is even necessary
 class Origin(Table):
 
-    code = StringColumn(nullable=False)
+    code = StringColumn()
 
     def __init__(self, table: pa.Table, mu: Optional[float] = None):
         super().__init__(table)

--- a/adam_core/coordinates/spherical.py
+++ b/adam_core/coordinates/spherical.py
@@ -44,7 +44,7 @@ class SphericalCoordinates(Table):
     vlat = Float64Column(nullable=True)
     time = Times.as_column(nullable=True)
     covariance = CoordinateCovariances.as_column(nullable=True)
-    origin = Origin.as_column(nullable=False)
+    origin = Origin.as_column()
     frame = StringAttribute()
 
     @property

--- a/adam_core/coordinates/times.py
+++ b/adam_core/coordinates/times.py
@@ -10,7 +10,7 @@ class Times(Table):
     # the fractional day-part.
     jd1 = Float64Column()
     jd2 = Float64Column()
-    scale = StringAttribute()
+    scale = StringAttribute(default="utc")
 
     @classmethod
     def from_astropy(cls, time: Time):

--- a/adam_core/coordinates/times.py
+++ b/adam_core/coordinates/times.py
@@ -8,8 +8,8 @@ class Times(Table):
     # Stores the time as a pair of float64 values in the same style as erfa/astropy:
     # The first one is the day-part of a Julian date, and the second is
     # the fractional day-part.
-    jd1 = Float64Column(nullable=False)
-    jd2 = Float64Column(nullable=False)
+    jd1 = Float64Column()
+    jd2 = Float64Column()
     scale = StringAttribute()
 
     @classmethod

--- a/adam_core/orbits/orbits.py
+++ b/adam_core/orbits/orbits.py
@@ -13,7 +13,7 @@ class Orbits(Table):
 
     orbit_id = StringColumn(nullable=True)
     object_id = StringColumn(nullable=True)
-    coordinates = CartesianCoordinates.as_column(nullable=False)
+    coordinates = CartesianCoordinates.as_column()
 
     def to_dataframe(self, sigmas: bool = False, covariances: bool = True):
         """

--- a/adam_core/propagator/tests/test_propagator.py
+++ b/adam_core/propagator/tests/test_propagator.py
@@ -16,7 +16,7 @@ class MockPropagator(Propagator):
             repeated_time = Time([t] * len(orbits))
             orbits.coordinates.time = coordinates.Times.from_astropy(
                 repeated_time
-            ).to_structarray()
+            )
             all_times.append(orbits)
 
         return quivr.concatenate(all_times)

--- a/adam_core/propagator/tests/test_utils.py
+++ b/adam_core/propagator/tests/test_utils.py
@@ -5,7 +5,7 @@ from ..utils import _iterate_chunks
 
 
 class SampleTable(Table):
-    a = Float64Column(nullable=False)
+    a = Float64Column()
 
 
 def test__iterate_chunks():

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ install_requires =
     requests
     scipy
     spiceypy
-    quivr>=0.5.0
+    quivr>=0.6.2
     mpc-obscodes
     naif-de440
     naif-leapseconds


### PR DESCRIPTION
Major changes are:
 - columns are non-nullable by default
 - schemas are checked *much* more rigorously when constructing Table instances (which was the cause of our grief and pain with nullable subtables)
 - columns support default values