### PR TITLE
Make orbit IDs default as UUIDs

### DIFF
--- a/adam_core/orbits/orbits.py
+++ b/adam_core/orbits/orbits.py
@@ -1,18 +1,19 @@
 import logging
+import uuid
 from typing import Literal
 
 import pandas as pd
-from quivr import StringColumn, Table
+import quivr as qv
 
 from ..coordinates.cartesian import CartesianCoordinates
 
 logger = logging.getLogger(__name__)
 
 
-class Orbits(Table):
+class Orbits(qv.Table):
 
-    orbit_id = StringColumn(nullable=True)
-    object_id = StringColumn(nullable=True)
+    orbit_id = qv.StringColumn(default=lambda: uuid.uuid4().hex)
+    object_id = qv.StringColumn(nullable=True)
     coordinates = CartesianCoordinates.as_column()
 
     def to_dataframe(self, sigmas: bool = False, covariances: bool = True):

--- a/adam_core/propagator/tests/test_propagator.py
+++ b/adam_core/propagator/tests/test_propagator.py
@@ -13,9 +13,7 @@ class MockPropagator(Propagator):
         all_times = []
         for t in times:
             repeated_time = Time([t] * len(orbits))
-            orbits.coordinates.time = coordinates.Times.from_astropy(
-                repeated_time
-            )
+            orbits.coordinates.time = coordinates.Times.from_astropy(repeated_time)
             all_times.append(orbits)
 
         return quivr.concatenate(all_times)


### PR DESCRIPTION
I'm splitting up some of the ephemeris generation changes into smaller PRs. This one requires #33 to be merged. 