### PR TITLE
Add VariantOrbits

### DIFF
--- a/adam_core/coordinates/__init__.py
+++ b/adam_core/coordinates/__init__.py
@@ -35,3 +35,4 @@ from .transform import (
     cometary_to_cartesian,
     transform_coordinates,
 )
+from .variants import create_coordinate_variants

--- a/adam_core/coordinates/__init__.py
+++ b/adam_core/coordinates/__init__.py
@@ -7,13 +7,14 @@ from .covariances import (
     covariances_from_df,
     covariances_to_df,
     covariances_to_table,
-    mean_and_covariance_from_weighted_samples,
     sample_covariance_random,
     sample_covariance_sigma_points,
     sigmas_from_df,
     sigmas_to_df,
     transform_covariances_jacobian,
     transform_covariances_sampling,
+    weighted_covariance,
+    weighted_mean,
 )
 from .io import coords_from_dataframe, coords_to_dataframe
 from .jacobian import calc_jacobian

--- a/adam_core/coordinates/covariances.py
+++ b/adam_core/coordinates/covariances.py
@@ -344,7 +344,11 @@ def mean_and_covariance_from_weighted_samples(samples, W, W_cov):
     mean = np.dot(W, samples)
 
     # Calculate the covariance matrix from the sigma points and weights
-    cov = np.cov(samples, aweights=W_cov, rowvar=False, bias=True)
+    # `~numpy.cov` does not support negative weights so we will calculate
+    # the covariance manually
+    # cov = np.cov(samples, aweights=W_cov, rowvar=False, bias=True)
+    residual = samples - mean
+    cov = (W_cov * residual.T) @ residual
     return mean, cov
 
 

--- a/adam_core/coordinates/covariances.py
+++ b/adam_core/coordinates/covariances.py
@@ -204,7 +204,7 @@ class CoordinateCovariances(Table):
 
 
 def sample_covariance_random(
-    mean: np.ndarray, cov: np.ndarray, num_samples: int = 100000
+    mean: np.ndarray, cov: np.ndarray, num_samples: int = 10000
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Sample a multivariate Gaussian distribution with given
@@ -241,7 +241,11 @@ def sample_covariance_random(
 
 
 def sample_covariance_sigma_points(
-    mean: np.ndarray, cov: np.ndarray, alpha: float = 1, kappa: float = 0.0
+    mean: np.ndarray,
+    cov: np.ndarray,
+    alpha: float = 1,
+    beta: float = 0.0,
+    kappa: float = 0.0,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Create sigma-point samples of a multivariate Gaussian distribution
@@ -255,6 +259,8 @@ def sample_covariance_sigma_points(
         Multivariate variance-covariance matrix of the Gaussian distribution.
     alpha : float, optional
         Spread of the sigma points between 1e^-2 and 1.
+    beta : float, optional
+        Prior knowledge of the distribution usually set to 2 for a Gaussian.
     kappa : float, optional
         Secondary scaling parameter usually set to 0.
 
@@ -293,7 +299,6 @@ def sample_covariance_sigma_points(
     # If the distribution is a well-constrained Gaussian, beta = 2 is optimal
     # but lets set beta to 0 for now which has the effect of not weighting the mean state
     # with 0 for the covariance matrix. This is generally better for more distributions.
-    beta = 0
     # Calculate the weights for mean and the covariance matrix
     # Weight are used to reconstruct the mean and covariance matrix from the sigma points
     W[0] = lambd / (D + lambd)

--- a/adam_core/coordinates/covariances.py
+++ b/adam_core/coordinates/covariances.py
@@ -319,37 +319,55 @@ def sample_covariance_sigma_points(
     return sigma_points, W, W_cov
 
 
-def mean_and_covariance_from_weighted_samples(samples, W, W_cov):
+def weighted_mean(samples: np.ndarray, W: np.ndarray) -> np.ndarray:
     """
-    Calculate a covariance matrix from samples and their corresponding weights.
+    Calculate the weighted mean of a set of samples.
 
     Parameters
     ----------
-    samples : `~numpy.ndarray` (2 * D + 1, D)
+    samples : `~numpy.ndarray` (N, D)
         Samples drawn from the distribution (these can be randomly drawn
         or sigma points)
-    W: `~numpy.ndarray` (2 * D + 1)
+    W: `~numpy.ndarray` (N)
         Weights of the samples.
-    W_cov: `~numpy.ndarray` (2 * D + 1)
-        Weights of the samples to reconstruct covariance matrix.
 
     Returns
     -------
     mean : `~numpy.ndarray` (D)
         Mean calculated from the samples and weights.
+    """
+    return np.dot(W, samples)
+
+
+def weighted_covariance(
+    mean: np.ndarray, samples: np.ndarray, W_cov: np.ndarray
+) -> np.ndarray:
+    """
+    Calculate a covariance matrix from samples and their corresponding weights.
+
+    Parameters
+    ----------
+    mean : `~numpy.ndarray` (D)
+        Mean calculated from the samples and weights.
+        See `~adam_core.coordinates.covariances.weighted_mean`.
+    samples : `~numpy.ndarray` (N, D)
+        Samples drawn from the distribution (these can be randomly drawn
+        or sigma points)
+    W_cov: `~numpy.ndarray` (N)
+        Weights of the samples to reconstruct covariance matrix.
+
+    Returns
+    -------
     cov : `~numpy.ndarray` (D, D)
         Covariance matrix calculated from the samples and weights.
     """
-    # Calculate the mean from the sigma points and weights
-    mean = np.dot(W, samples)
-
     # Calculate the covariance matrix from the sigma points and weights
     # `~numpy.cov` does not support negative weights so we will calculate
     # the covariance manually
     # cov = np.cov(samples, aweights=W_cov, rowvar=False, bias=True)
     residual = samples - mean
     cov = (W_cov * residual.T) @ residual
-    return mean, cov
+    return cov
 
 
 def transform_covariances_sampling(

--- a/adam_core/coordinates/tests/test_covariances.py
+++ b/adam_core/coordinates/tests/test_covariances.py
@@ -3,9 +3,10 @@ import numpy as np
 from ...utils.helpers.orbits import make_real_orbits
 from ..covariances import (
     CoordinateCovariances,
-    mean_and_covariance_from_weighted_samples,
     sample_covariance_random,
     sample_covariance_sigma_points,
+    weighted_covariance,
+    weighted_mean,
 )
 
 
@@ -35,9 +36,9 @@ def test_sample_covariance_sigma_points():
 
         # Reconstruct the mean and covariance and test that they match
         # the original inputs to within 1e-14
-        mean_sg, covariance_sg = mean_and_covariance_from_weighted_samples(
-            samples, W, W_cov
-        )
+        mean_sg = weighted_mean(samples, W)
+        covariance_sg = weighted_covariance(mean, samples, W_cov)
+
         np.testing.assert_allclose(mean_sg, mean, rtol=0, atol=1e-14)
         np.testing.assert_allclose(covariance_sg, covariance, rtol=0, atol=1e-14)
 
@@ -61,9 +62,9 @@ def test_sample_covariance_random():
 
         # Reconstruct the mean and covariance and test that they match
         # the original inputs to within 1e-8 and 1e-14 respectively
-        mean_rs, covariance_rs = mean_and_covariance_from_weighted_samples(
-            samples, W, W_cov
-        )
+        mean_rs = weighted_mean(samples, W)
+        covariance_rs = weighted_covariance(mean, samples, W_cov)
+
         # Note how many samples are needed to get the covariance to
         # match to within 1e-14... (the same tolerance as sigma point sampling)
         np.testing.assert_allclose(mean_rs, mean, rtol=0, atol=1e-8)

--- a/adam_core/coordinates/variants.py
+++ b/adam_core/coordinates/variants.py
@@ -1,0 +1,215 @@
+from typing import Literal, Tuple, Union
+
+import numpy as np
+import quivr as qv
+
+from .cartesian import CartesianCoordinates
+from .cometary import CometaryCoordinates
+from .covariances import (
+    mean_and_covariance_from_weighted_samples,
+    sample_covariance_random,
+    sample_covariance_sigma_points,
+)
+from .keplerian import KeplerianCoordinates
+from .spherical import SphericalCoordinates
+
+CoordinateType = Union[
+    CartesianCoordinates,
+    KeplerianCoordinates,
+    CometaryCoordinates,
+    SphericalCoordinates,
+]
+
+
+def create_coordinate_variants(
+    coordinates: CoordinateType, method: Literal["auto", "sigma-point", "monte-carlo"]
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, CoordinateType]:
+    """
+    Sample and create variants for the given coordinates by sampling the covariance matrices.
+    There are three supported methods:
+    - sigma-point: Sample the covariance matrix using sigma points. This is the fastest method,
+      but can be inaccurate if the covariance matrix is not well behaved.
+    - monte-carlo: Sample the covariance matrix using a monte carlo method.
+      This is the slowest method, but is the most accurate.
+    - auto: Automatically select the best method based on the covariance matrix.
+      If the covariance matrix is well behaved then sigma-point sampling will be used.
+      If the covariance matrix is not well behaved then monte-carlo sampling will be used.
+
+    When sampling with monte-carlo, 10k samples are drawn. Sigma-point sampling draws 13 samples
+    for 6-dimensional coordinates.
+
+    TODO:
+        This function does not yet handle sampling of covariances and coordinates with missing values.
+
+    Parameters
+    ----------
+    coordinates : {'~adam_core.coordinates.cartesian.CartesianCoordinates',
+                   '~adam_core.coordinates.keplerian.KeplerianCoordinates',
+                   '~adam_core.coordinates.cometary.CometaryCoordinates',
+                   '~adam_core.coordinates.spherical.SphericalCoordinates'}
+        The coordinates to sample.
+    method : {'sigma-point', 'monte-carlo', 'auto'}, optional
+        The method to use for sampling the covariance matrix. If 'auto' is selected then the method
+        will be automatically selected based on the covariance matrix. The default is 'auto'.
+
+    Returns
+    -------
+    idx : '~numpy.ndarray'
+        The index of the coordinate that each sample belongs to.
+    weights : '~numpy.ndarray'
+        Weights of each sample.
+    cov_weights : '~numpy.ndarray'
+        Weights of the samples to reconstruct covariance matrix.
+    samples : {'~adam_core.coordinates.cartesian.CartesianCoordinates',
+                     '~adam_core.coordinates.keplerian.KeplerianCoordinates',
+                     '~adam_core.coordinates.cometary.CometaryCoordinates',
+                     '~adam_core.coordinates.spherical.SphericalCoordinates'}
+        The samples drawn from the coordinate covariance matrices.
+
+    Raises
+    ------
+    ValueError:
+        If the covariance matrices are all undefined.
+        If the input coordinates are not supported.
+    """
+    idx_list = []
+    samples_list = []
+    weights_list = []
+    cov_weights_list = []
+    origins_list = []
+    times_list = []
+
+    if coordinates.covariance.is_all_nan():
+        raise ValueError(
+            "Cannot sample coordinate covariances when covariances are all undefined."
+        )
+
+    for i, coordinate_i in enumerate(coordinates):
+
+        mean = coordinate_i.values[0]
+        cov = coordinate_i.covariance.to_matrix()[0]
+
+        if np.any(np.isnan(cov)):
+            raise ValueError(
+                "Cannot sample coordinate covariances when some covariance elements are undefined."
+            )
+        if np.any(np.isnan(mean)):
+            raise ValueError(
+                "Cannot sample coordinate covariances when some coordinate dimensions are undefined."
+            )
+
+        if method == "sigma-point":
+            samples, W, W_cov = sample_covariance_sigma_points(mean, cov)
+
+        elif method == "monte-carlo":
+            samples, W, W_cov = sample_covariance_random(mean, cov, 10000)
+
+        elif method == "auto":
+            # Sample with sigma points
+            samples, W, W_cov = sample_covariance_sigma_points(mean, cov)
+
+            # Check if the sigma point sampling is good enough by seeing if we can
+            # recover the mean and covariance from the sigma points
+            mean_sg, cov_sg = mean_and_covariance_from_weighted_samples(
+                samples, W, W_cov
+            )
+
+            # If the sigma point sampling is not good enough, then sample with monte carlo
+            # Though it is not guaranteed that monte carlo will actually be better
+            diff_mean = np.abs(mean_sg - mean)
+            diff_cov = np.abs(cov_sg - cov)
+            if np.any(diff_mean >= 1e-12) or np.any(diff_cov >= 1e-12):
+                samples, W, W_cov = sample_covariance_random(mean, cov, 10000)
+
+        else:
+            raise ValueError(f"Unknown coordinate covariance sampling method: {method}")
+
+        origins_list += [coordinate_i.origin for i in range(len(samples))]
+        times_list += [coordinate_i.time for i in range(len(samples))]
+        samples_list.append(samples)
+        weights_list.append(W)
+        cov_weights_list.append(W_cov)
+        idx_list.append(np.full(len(samples), i))
+
+    samples = np.concatenate(samples_list)
+    idx = np.concatenate(idx_list)
+    weights = np.concatenate(weights_list)
+    cov_weights = np.concatenate(cov_weights_list)
+    origins = qv.concatenate(origins_list)
+    times = qv.concatenate(times_list)
+
+    if isinstance(coordinates, CartesianCoordinates):
+        return (
+            idx,
+            weights,
+            cov_weights,
+            CartesianCoordinates.from_kwargs(
+                x=samples[:, 0],
+                y=samples[:, 1],
+                z=samples[:, 2],
+                vx=samples[:, 3],
+                vy=samples[:, 4],
+                vz=samples[:, 5],
+                time=times,
+                covariance=None,
+                origin=origins,
+                frame=coordinates.frame,
+            ),
+        )
+    elif isinstance(coordinates, SphericalCoordinates):
+        return (
+            idx,
+            weights,
+            cov_weights,
+            SphericalCoordinates.from_kwargs(
+                rho=samples[:, 0],
+                lon=samples[:, 1],
+                lat=samples[:, 2],
+                vrho=samples[:, 3],
+                vlon=samples[:, 4],
+                vlat=samples[:, 5],
+                time=times,
+                covariance=None,
+                origin=origins,
+                frame=coordinates.frame,
+            ),
+        )
+    elif isinstance(coordinates, KeplerianCoordinates):
+        return (
+            idx,
+            weights,
+            cov_weights,
+            KeplerianCoordinates.from_kwargs(
+                a=samples[:, 0],
+                e=samples[:, 1],
+                i=samples[:, 2],
+                raan=samples[:, 3],
+                ap=samples[:, 4],
+                M=samples[:, 5],
+                time=times,
+                covariance=None,
+                origin=origins,
+                frame=coordinates.frame,
+            ),
+        )
+    elif isinstance(coordinates, CometaryCoordinates):
+        return (
+            idx,
+            weights,
+            cov_weights,
+            CometaryCoordinates.from_kwargs(
+                q=samples[:, 0],
+                e=samples[:, 1],
+                i=samples[:, 2],
+                raan=samples[:, 3],
+                ap=samples[:, 4],
+                tp=samples[:, 5],
+                time=times,
+                covariance=None,
+                origin=origins,
+                frame=coordinates.frame,
+            ),
+        )
+
+    else:
+        raise ValueError(f"Unsupported coordinate type: {type(coordinates)}")

--- a/adam_core/coordinates/variants.py
+++ b/adam_core/coordinates/variants.py
@@ -6,9 +6,10 @@ import quivr as qv
 from .cartesian import CartesianCoordinates
 from .cometary import CometaryCoordinates
 from .covariances import (
-    mean_and_covariance_from_weighted_samples,
     sample_covariance_random,
     sample_covariance_sigma_points,
+    weighted_covariance,
+    weighted_mean,
 )
 from .keplerian import KeplerianCoordinates
 from .spherical import SphericalCoordinates
@@ -110,9 +111,8 @@ def create_coordinate_variants(
 
             # Check if the sigma point sampling is good enough by seeing if we can
             # recover the mean and covariance from the sigma points
-            mean_sg, cov_sg = mean_and_covariance_from_weighted_samples(
-                samples, W, W_cov
-            )
+            mean_sg = weighted_mean(samples, W)
+            cov_sg = weighted_covariance(mean_sg, samples, W_cov)
 
             # If the sigma point sampling is not good enough, then sample with monte carlo
             # Though it is not guaranteed that monte carlo will actually be better

--- a/adam_core/observations/exposures.py
+++ b/adam_core/observations/exposures.py
@@ -8,7 +8,7 @@ import pyarrow.compute as pc
 import quivr as qv
 from quivr.validators import and_, ge, le
 
-from ..coordinates import cartesian, origin, times
+from ..coordinates import origin, times
 from ..observers import observers, state
 
 

--- a/adam_core/orbits/__init__.py
+++ b/adam_core/orbits/__init__.py
@@ -2,3 +2,4 @@
 from .classification import calc_orbit_class
 from .ephemeris import Ephemeris
 from .orbits import Orbits
+from .variants import VariantOrbits

--- a/adam_core/orbits/tests/test_variants.py
+++ b/adam_core/orbits/tests/test_variants.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from ...utils.helpers.orbits import make_real_orbits
+from ..variants import VariantOrbits
+
+
+def test_VariantOrbits():
+
+    # Get a sample of real orbits
+    orbits = make_real_orbits(10)
+
+    # Create a variant orbits object (expands the covariance matrix)
+    # around the mean state
+    variant_orbits = VariantOrbits.create(orbits)
+
+    # For these 10 orbits this will select sigma-points so lets
+    # check that the number of sigma-points is correct
+    assert len(variant_orbits) == len(orbits) * 13
+
+    # Now lets collapse the sigma-points back and see if we can reconstruct
+    # the input covairance matrix
+    collapsed_orbits = variant_orbits.collapse(orbits)
+
+    # Check that the covariance matrices are close
+    np.testing.assert_allclose(
+        collapsed_orbits.coordinates.covariance.to_matrix(),
+        orbits.coordinates.covariance.to_matrix(),
+        rtol=0,
+        atol=1e-14,
+    )
+
+    # Check that the orbit ids are the same
+    np.testing.assert_equal(
+        collapsed_orbits.orbit_id.to_numpy(zero_copy_only=False),
+        orbits.orbit_id.to_numpy(zero_copy_only=False),
+    )

--- a/adam_core/orbits/variants.py
+++ b/adam_core/orbits/variants.py
@@ -133,21 +133,8 @@ class VariantOrbits(qv.Table):
                 samples, variants.weights.to_numpy(), variants.weights_cov.to_numpy()
             )
 
-            orbit_collapsed = Orbits.from_kwargs(
-                orbit_id=orbit.orbit_id,
-                object_id=orbit.object_id,
-                coordinates=CartesianCoordinates.from_kwargs(
-                    time=orbit.coordinates.time,
-                    x=orbit.coordinates.x,
-                    y=orbit.coordinates.y,
-                    z=orbit.coordinates.z,
-                    vx=orbit.coordinates.vx,
-                    vy=orbit.coordinates.vy,
-                    vz=orbit.coordinates.vz,
-                    covariance=CoordinateCovariances.from_matrix(covariance),
-                    frame=orbit.coordinates.frame,
-                    origin=orbit.coordinates.origin,
-                ),
+            orbit_collapsed = orbit.set_column(
+                "coordinates.covariance", CoordinateCovariances.from_matrix(covariance)
             )
 
             orbits_list.append(orbit_collapsed)

--- a/adam_core/orbits/variants.py
+++ b/adam_core/orbits/variants.py
@@ -1,0 +1,62 @@
+import uuid
+from typing import Literal
+
+import pyarrow.compute as pc
+import quivr as qv
+
+from ..coordinates.cartesian import CartesianCoordinates
+from ..coordinates.variants import create_coordinate_variants
+from .orbits import Orbits
+
+
+class VariantOrbits(qv.Table):
+
+    orbit_id = qv.StringColumn(default=lambda: uuid.uuid4().hex)
+    object_id = qv.StringColumn(nullable=True)
+    weights = qv.Float64Column(nullable=True, validator=qv.and_(qv.ge(0), qv.le(1)))
+    weights_cov = qv.Float64Column(nullable=True, validator=qv.and_(qv.ge(0), qv.le(1)))
+    coordinates = CartesianCoordinates.as_column()
+
+    @classmethod
+    def create(
+        cls,
+        orbits: Orbits,
+        method: Literal["auto", "sigma-point", "monte-carlo"] = "auto",
+    ) -> "VariantOrbits":
+        """
+        Sample and create variants for the given orbits by sampling the covariance matrices.
+        There are three supported methods:
+        - sigma-point: Sample the covariance matrix using sigma points. This is the fastest method,
+        but can be inaccurate if the covariance matrix is not well behaved.
+        - monte-carlo: Sample the covariance matrix using a monte carlo method.
+        This is the slowest method, but is the most accurate. 10k samples are drawn.
+        - auto: Automatically select the best method based on the covariance matrix.
+        If the covariance matrix is well behaved then sigma-point sampling will be used.
+        If the covariance matrix is not well behaved then monte-carlo sampling will be used.
+
+        When sampling with monte-carlo, 10k samples are drawn. Sigma-point sampling draws 13 samples
+        for 6-dimensional coordinates.
+
+        Parameters
+        ----------
+        orbits : '~adam_core.orbits.orbits.Orbits'
+            The orbits for which to create variant orbits.
+        method : {'sigma-point', 'monte-carlo', 'auto'}, optional
+            The method to use for sampling the covariance matrix. If 'auto' is selected then the method
+            will be automatically selected based on the covariance matrix. The default is 'auto'.
+
+        Returns
+        -------
+        variants_orbits : '~adam_core.orbits.variants.VariantOrbits'
+            The variant orbits.
+        """
+        idx, W, W_cov, variant_coordinates = create_coordinate_variants(
+            orbits.coordinates, method=method
+        )
+        return cls.from_kwargs(
+            orbit_id=pc.take(orbits.orbit_id, idx),
+            object_id=pc.take(orbits.object_id, idx),
+            weights=W,
+            weights_cov=W_cov,
+            coordinates=variant_coordinates,
+        )

--- a/adam_core/orbits/variants.py
+++ b/adam_core/orbits/variants.py
@@ -8,7 +8,7 @@ import quivr as qv
 
 from ..coordinates.cartesian import CartesianCoordinates
 from ..coordinates.covariances import CoordinateCovariances, weighted_covariance
-from ..coordinates.variants import create_coordinate_variants
+from ..coordinates.variants import VariantCoordinatesTable, create_coordinate_variants
 from .orbits import Orbits
 
 
@@ -65,7 +65,7 @@ class VariantOrbits(qv.Table):
         variants_orbits : '~adam_core.orbits.variants.VariantOrbits'
             The variant orbits.
         """
-        idx, W, W_cov, variant_coordinates = create_coordinate_variants(
+        variant_coordinates: VariantCoordinatesTable = create_coordinate_variants(
             orbits.coordinates,
             method=method,
             num_samples=num_samples,
@@ -74,11 +74,11 @@ class VariantOrbits(qv.Table):
             kappa=kappa,
         )
         return cls.from_kwargs(
-            orbit_id=pc.take(orbits.orbit_id, idx),
-            object_id=pc.take(orbits.object_id, idx),
-            weights=W,
-            weights_cov=W_cov,
-            coordinates=variant_coordinates,
+            orbit_id=pc.take(orbits.orbit_id, variant_coordinates.index),
+            object_id=pc.take(orbits.object_id, variant_coordinates.index),
+            weights=variant_coordinates.weight,
+            weights_cov=variant_coordinates.weight_cov,
+            coordinates=variant_coordinates.sample,
         )
 
     def link_to_orbits(

--- a/adam_core/orbits/variants.py
+++ b/adam_core/orbits/variants.py
@@ -7,10 +7,7 @@ import pyarrow.compute as pc
 import quivr as qv
 
 from ..coordinates.cartesian import CartesianCoordinates
-from ..coordinates.covariances import (
-    CoordinateCovariances,
-    mean_and_covariance_from_weighted_samples,
-)
+from ..coordinates.covariances import CoordinateCovariances, weighted_covariance
 from ..coordinates.variants import create_coordinate_variants
 from .orbits import Orbits
 
@@ -129,8 +126,9 @@ class VariantOrbits(qv.Table):
             assert len(orbit) == 1
 
             samples = variants.coordinates.values
-            mean_state, covariance = mean_and_covariance_from_weighted_samples(
-                samples, variants.weights.to_numpy(), variants.weights_cov.to_numpy()
+            mean = orbit.coordinates.values[0]
+            covariance = weighted_covariance(
+                mean, samples, variants.weights_cov.to_numpy()
             )
 
             orbit_collapsed = orbit.set_column(

--- a/adam_core/orbits/variants.py
+++ b/adam_core/orbits/variants.py
@@ -19,8 +19,8 @@ class VariantOrbits(qv.Table):
 
     orbit_id = qv.StringColumn(default=lambda: uuid.uuid4().hex)
     object_id = qv.StringColumn(nullable=True)
-    weights = qv.Float64Column(nullable=True, validator=qv.and_(qv.ge(0), qv.le(1)))
-    weights_cov = qv.Float64Column(nullable=True, validator=qv.and_(qv.ge(0), qv.le(1)))
+    weights = qv.Float64Column(nullable=True)
+    weights_cov = qv.Float64Column(nullable=True)
     coordinates = CartesianCoordinates.as_column()
 
     @classmethod

--- a/adam_core/orbits/variants.py
+++ b/adam_core/orbits/variants.py
@@ -25,6 +25,10 @@ class VariantOrbits(qv.Table):
         cls,
         orbits: Orbits,
         method: Literal["auto", "sigma-point", "monte-carlo"] = "auto",
+        num_samples: int = 10000,
+        alpha: float = 1,
+        beta: float = 0,
+        kappa: float = 0,
     ) -> "VariantOrbits":
         """
         Sample and create variants for the given orbits by sampling the covariance matrices.
@@ -47,6 +51,14 @@ class VariantOrbits(qv.Table):
         method : {'sigma-point', 'monte-carlo', 'auto'}, optional
             The method to use for sampling the covariance matrix. If 'auto' is selected then the method
             will be automatically selected based on the covariance matrix. The default is 'auto'.
+        num_samples : int, optional
+            The number of samples to draw when sampling with monte-carlo.
+        alpha : float, optional
+            Spread of the sigma points between 1e^-2 and 1.
+        beta : float, optional
+            Prior knowledge of the distribution when generating sigma points usually set to 2 for a Gaussian.
+        kappa : float, optional
+            Secondary scaling parameter when generating sigma points usually set to 0.
 
         Returns
         -------
@@ -54,7 +66,12 @@ class VariantOrbits(qv.Table):
             The variant orbits.
         """
         idx, W, W_cov, variant_coordinates = create_coordinate_variants(
-            orbits.coordinates, method=method
+            orbits.coordinates,
+            method=method,
+            num_samples=num_samples,
+            alpha=alpha,
+            beta=beta,
+            kappa=kappa,
         )
         return cls.from_kwargs(
             orbit_id=pc.take(orbits.orbit_id, idx),

--- a/adam_core/orbits/variants.py
+++ b/adam_core/orbits/variants.py
@@ -60,3 +60,38 @@ class VariantOrbits(qv.Table):
             weights_cov=W_cov,
             coordinates=variant_coordinates,
         )
+
+    def link_to_orbits(
+        self, orbits: Orbits
+    ) -> qv.MultiKeyLinkage[Orbits, "VariantOrbits"]:
+        """
+        Link variants to the orbits from which they were generated.
+
+        Parameters
+        ----------
+        orbits : `~adam_core.orbits.orbits.Orbits`
+            Orbits from which the variants were generated.
+
+        Returns
+        -------
+        linkage : `~quivr.MultiKeyLinkage[Orbits, VariantOrbits]`
+            Linkage between variants and orbits.
+        """
+        assert orbits.coordinates.time.scale == self.coordinates.time.scale
+
+        # We might want to replace linking on jd1 and jd2 with just linking on mjd
+        # once the changes have been merged
+        return qv.MultiKeyLinkage(
+            orbits,
+            self,
+            left_keys={
+                "orbit_id": orbits.orbit_id,
+                "jd1": orbits.coordinates.time.jd1,
+                "jd2": orbits.coordinates.time.jd2,
+            },
+            right_keys={
+                "orbit_id": self.orbit_id,
+                "jd1": self.coordinates.time.jd1,
+                "jd2": self.coordinates.time.jd2,
+            },
+        )


### PR DESCRIPTION
VariantOrbits are orbits sampled from an orbit's covariance matrix either via monte-carlo (random) or sigma-point sampling. The idea is that these orbits can then be propagated with a propagator to a desired set of times, and at each time for each unique input orbit the covariance matrix can be reconstruct by "collapsing" the orbits down. 

Here is an example without propagation (as that support will be added in a future PR):
```python
from adam_core.orbits.query import query_sbdb
from adam_core.orbits.variants import VariantOrbits

orbits = query_sbdb(["Duende", "Eros"]) # Length 2 orbits class with covariances
variants = VariantOrbits.create(orbits, method="auto") # Length 26 orbits class with variant orbits (13 sigma points per input orbit)
collapsed_orbits = variants.collapse(orbits) # Length 2 orbits with reconstructed covariance matrix
```

This PR needs #38 to be merged. 