### PR TITLE
Upgrade pyarrow and numpy versions

### DIFF
--- a/adam_core/coordinates/cartesian.py
+++ b/adam_core/coordinates/cartesian.py
@@ -46,14 +46,14 @@ class CartesianCoordinates(Table):
 
     @property
     def values(self) -> np.ndarray:
-        return np.array(self.table.select(["x", "y", "z", "vx", "vy", "vz"])).T
+        return np.array(self.table.select(["x", "y", "z", "vx", "vy", "vz"]))
 
     @property
     def r(self) -> np.ndarray:
         """
         Position vector.
         """
-        return np.array(self.table.select(["x", "y", "z"])).T
+        return np.array(self.table.select(["x", "y", "z"]))
 
     @property
     def r_mag(self) -> np.ndarray:
@@ -74,7 +74,7 @@ class CartesianCoordinates(Table):
         """
         Velocity vector.
         """
-        return np.array(self.table.select(["vx", "vy", "vz"])).T
+        return np.array(self.table.select(["vx", "vy", "vz"]))
 
     @property
     def v_mag(self) -> np.ndarray:

--- a/adam_core/coordinates/cometary.py
+++ b/adam_core/coordinates/cometary.py
@@ -53,7 +53,7 @@ class CometaryCoordinates(Table):
 
     @property
     def values(self) -> np.ndarray:
-        return np.array(self.table.select(["q", "e", "i", "raan", "ap", "tp"])).T
+        return np.array(self.table.select(["q", "e", "i", "raan", "ap", "tp"]))
 
     @property
     def sigma_q(self) -> np.ndarray:

--- a/adam_core/coordinates/covariances.py
+++ b/adam_core/coordinates/covariances.py
@@ -68,33 +68,41 @@ class CoordinateCovariances(Table):
         # return self.values.combine_chunks().to_numpy_ndarray()
         values = self.values.to_numpy(zero_copy_only=False)
 
-        # If all covariance matrices are None, then return a covariances
-        # filled with NaNs.
-        if np.all(values == None):  # noqa: E711
-            return np.full((len(self), 6, 6), np.nan)
+        # Try and see if all covariance matrices are None, if so return
+        # an array of NaNs.
+        try:
+            if np.all(values == None):  # noqa: E711
+                return np.full((len(self), 6, 6), np.nan)
 
-        else:
-            # Try to stack the values into a 3D array. If this works, then
-            # all covariance matrices are the same size and we can return
-            # the stacked matrices.
-            try:
-                cov = np.stack(values).reshape(-1, 6, 6)
+        except ValueError as e:
+            err_str = (
+                "The truth value of an array with more than one element is ambiguous."
+                " Use a.any() or a.all()"
+            )
+            if str(e) != err_str:
+                raise e
 
-            # If not then some of the arrays might be None. Lets loop through
-            # the values and fill in the arrays that are missing (None) with NaNs.
-            except ValueError as e:
-                # If we don't get the error we expect, then raise it.
-                if str(e) != "all input arrays must have the same shape":
-                    raise e
-                else:
-                    for i in range(len(values)):
-                        if values[i] is None:
-                            values[i] = np.full(36, np.nan)
+        # Try to stack the values into a 3D array. If this works, then
+        # all covariance matrices are the same size and we can return
+        # the stacked matrices.
+        try:
+            cov = np.stack(values).reshape(-1, 6, 6)
 
-                # Try stacking again
-                cov = np.stack(values).reshape(-1, 6, 6)
+        # If not then some of the arrays might be None. Lets loop through
+        # the values and fill in the arrays that are missing (None) with NaNs.
+        except ValueError as e:
+            # If we don't get the error we expect, then raise it.
+            if str(e) != "all input arrays must have the same shape":
+                raise e
+            else:
+                for i in range(len(values)):
+                    if values[i] is None:
+                        values[i] = np.full(36, np.nan)
 
-            return cov
+            # Try stacking again
+            cov = np.stack(values).reshape(-1, 6, 6)
+
+        return cov
 
     @classmethod
     def from_matrix(cls, covariances: np.ndarray) -> "CoordinateCovariances":

--- a/adam_core/coordinates/keplerian.py
+++ b/adam_core/coordinates/keplerian.py
@@ -49,7 +49,7 @@ class KeplerianCoordinates(Table):
 
     @property
     def values(self) -> np.ndarray:
-        return np.array(self.table.select(["a", "e", "i", "raan", "ap", "M"])).T
+        return np.array(self.table.select(["a", "e", "i", "raan", "ap", "M"]))
 
     @property
     def sigma_a(self) -> np.ndarray:

--- a/adam_core/coordinates/spherical.py
+++ b/adam_core/coordinates/spherical.py
@@ -51,7 +51,7 @@ class SphericalCoordinates(Table):
     def values(self) -> np.ndarray:
         return np.array(
             self.table.select(["rho", "lon", "lat", "vrho", "vlon", "vlat"])
-        ).T
+        )
 
     @property
     def sigma_rho(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ install_requires =
     healpy
     jax
     jaxlib
-    numba
     numpy
     pandas
     requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ install_requires =
     jax
     jaxlib
     numpy
+    pyarrow>=13.0.0
     pandas
     requests
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ install_requires =
     healpy
     jax
     jaxlib
-    numpy
+    numpy>=1.25.2
     pyarrow>=13.0.0
     pandas
     requests


### PR DESCRIPTION
Upstream updates to pyarrow and numpy have made breaking changes to some of the underlying behavior of functions used in adam_core.

This PR:
- Removes numba as a dependency (we don't use it anywhere currently)
- Upgrades pyarrow to 13.0.0 (released yesterday) 
- Upgrades numpy to 1.25.2 (released in the last three weeks)