### PR TITLE
Unpin numpy from 1.25.2 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ install_requires =
     healpy
     jax
     jaxlib
-    numpy>=1.25.2
+    numpy==1.24.4
     pyarrow>=13.0.0
     pandas
     requests


### PR DESCRIPTION
Our downstream codes need numba but it doesn't yet support numpy 1.25.2.