### PR TITLE
Add unit tests for imports of key adam_core functions

### DIFF
--- a/adam_core/dynamics/__init__.py
+++ b/adam_core/dynamics/__init__.py
@@ -3,5 +3,6 @@ from .barker import solve_barker
 from .chi import calc_chi
 from .kepler import solve_kepler
 from .lagrange import apply_lagrange_coefficients, calc_lagrange_coefficients
+from .propagation import propagate_2body
 from .stumpff import calc_stumpff
 from .tisserand import calc_tisserand_parameter

--- a/adam_core/observations/__init__.py
+++ b/adam_core/observations/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa: F401
+from .detections import PointSourceDetections
+from .exposures import Exposures

--- a/adam_core/tests/test_imports.py
+++ b/adam_core/tests/test_imports.py
@@ -1,0 +1,35 @@
+# flake8: noqa: F401
+def test_import_observers():
+    from adam_core.observers import Observers, get_observer_state
+
+
+def test_import_orbits():
+    from adam_core.orbits import Ephemeris, Orbits, VariantOrbits
+    from adam_core.orbits.query import query_horizons, query_sbdb
+
+
+def test_import_dynamics():
+    from adam_core.dynamics import calc_chi, calc_stumpff, propagate_2body
+
+
+def test_import_coordinates():
+    from adam_core.coordinates import (
+        CartesianCoordinates,
+        CometaryCoordinates,
+        CoordinateCovariances,
+        KeplerianCoordinates,
+        Origin,
+        OriginCodes,
+        Residuals,
+        SphericalCoordinates,
+        Times,
+        transform_coordinates,
+    )
+
+
+def test_import_propagator():
+    from adam_core.propagator import PYOORB, Propagator
+
+
+def test_import_observations():
+    from adam_core.observations import Exposures, PointSourceDetections


### PR DESCRIPTION
I'm finding it fairly tedious to do module-level imports to avoid circular import errors. I'm hitting a lot of overlap with variable names in the existing code and the names of the modules. This isn't an issue on main at the moment but I have run into it a few times in feature branches. 

Example:
```python
from adam_core import observers

# Here we overwrite the module with the object
observers = observers.Observers.from_kwargs(...)
```

The cleanliness of the following seems a lot nicer:
```python
from adam_core.observers import Observers

observers = Observers.from_kwargs(...)
```

This PR adds a unit test to make sure that the main functions in adam_core can be imported as objects.