### PR TITLE
Add Associations table

### DIFF
--- a/adam_core/observations/__init__.py
+++ b/adam_core/observations/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa: F401
+from .associations import Associations
 from .detections import PointSourceDetections
 from .exposures import Exposures

--- a/adam_core/observations/associations.py
+++ b/adam_core/observations/associations.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+import pyarrow.compute as pc
+import quivr as qv
+
+from .detections import PointSourceDetections
+
+
+class Associations(qv.Table):
+
+    detection_id = qv.StringColumn()
+    object_id = qv.StringColumn(nullable=True)
+
+    # TODO: We may want to create a derivative class called "ProbabilisticAssociations" that
+    # includes residuals with respect to an orbit
+    # orbit_id = qv.StringColumn(nullable=True)
+    # residuals = Residuals.as_column(nullable=True) # from adam_core.coordinates.residuals import Residuals
+
+    def group_by_object(self) -> Iterator["Associations"]:
+        """
+        Returns an iterator of PointSourceDetections, each grouped by exposure_id.
+        """
+        # Gather unique exposure IDs
+        object_ids = self.object_id.unique()
+        sorted = self.table.sort_by("object_id")
+        for object_id in object_ids:
+            mask = pc.equal(sorted.column("object_id"), object_id)
+            table = sorted.filter(mask)
+            yield Associations(table)
+
+    def link_to_detections(
+        self, detections: PointSourceDetections
+    ) -> qv.Linkage[Associations, PointSourceDetections]:
+        """
+        Link the associations to a table of detections.
+
+        Parameters
+        ----------
+        detections : `~adam_core.observations.detections.PointSourceDetections`
+            Table of detections to link to.
+        """
+        # NOTE: Unsure if this is actually useful since its 1 to 1
+        return qv.Linkage(self, detections, self.detection_id, detections.id)

--- a/adam_core/observations/detections.py
+++ b/adam_core/observations/detections.py
@@ -47,7 +47,7 @@ class PointSourceDetections(qv.Table):
         exposure_ids = self.exposure_id.unique()
         sorted = self.table.sort_by("exposure_id")
         for exposure_id in exposure_ids:
-            mask = pyarrow.compute.equal(sorted.exposure_id, exposure_id)
+            mask = pyarrow.compute.equal(sorted.column("exposure_id"), exposure_id)
             table = sorted.filter(mask)
             yield PointSourceDetections(table)
 

--- a/adam_core/observations/tests/test_associations.py
+++ b/adam_core/observations/tests/test_associations.py
@@ -1,0 +1,47 @@
+from ..associations import Associations
+from ..detections import PointSourceDetections
+
+
+def test_associations_link_to_detections():
+    # Test that we can link associations to detections
+    detections = PointSourceDetections.from_kwargs(
+        id=["d1", "d2", "d3", "d4", "d5"],
+        exposure_id=["e1", "e1", "e2", "e1", "e2"],
+        time=None,
+        ra=[0, 1, 2, 3, 4],
+        dec=[5, 6, 7, 8, 9],
+        mag=[10, 11, 12, 13, 14],
+    )
+
+    associations = Associations.from_kwargs(
+        detection_id=["d1", "d2", "d3", "d4", "d5"],
+        object_id=["o1", "o1", "o2", "o2", None],
+    )
+
+    link = associations.link_to_detections(detections)
+    assert link.left_table == associations
+    assert link.right_table == detections
+
+    for i in range(5):
+        associations_i, detetections_i = link.select(f"d{i + 1}")
+        assert len(associations_i) == 1
+        assert len(detetections_i) == 1
+
+
+def test_associations_group_by_object():
+    # Test that we can group associations by object
+    associations = Associations.from_kwargs(
+        detection_id=["d1", "d2", "d3", "d4", "d5"],
+        object_id=["o1", "o1", "o2", "o2", None],
+    )
+
+    groups = list(associations.group_by_object())
+    assert len(groups) == 3
+    assert groups[0].object_id.to_pylist() == ["o1", "o1"]
+    assert groups[0].detection_id.to_pylist() == ["d1", "d2"]
+
+    assert groups[1].object_id.to_pylist() == ["o2", "o2"]
+    assert groups[1].detection_id.to_pylist() == ["d3", "d4"]
+
+    # What is the expected return here?
+    assert groups[2].object_id.to_pylist() == [None]

--- a/adam_core/observations/tests/test_detections.py
+++ b/adam_core/observations/tests/test_detections.py
@@ -94,3 +94,27 @@ def test_detection_group_by_healpixel():
     assert 3 in groups
     assert len(groups[3]) == 2
     assert groups[3].id.to_pylist() == ["d1", "d6"]
+
+
+def test_detections_group_by_exposure():
+    detections = PointSourceDetections.from_kwargs(
+        id=["d1", "d2", "d3", "d4", "d5"],
+        exposure_id=["e1", "e1", "e2", "e1", "e2"],
+        time=None,
+        ra=[0, 1, 2, 3, 4],
+        dec=[5, 6, 7, 8, 9],
+        mag=[10, 11, 12, 13, 14],
+    )
+
+    groups = list(detections.group_by_exposure())
+    assert len(groups) == 2
+
+    assert groups[0].id.to_pylist() == ["d1", "d2", "d4"]
+    assert groups[0].exposure_id.to_pylist() == ["e1", "e1", "e1"]
+    assert groups[0].ra.to_pylist() == [0, 1, 3]
+    assert groups[0].dec.to_pylist() == [5, 6, 8]
+
+    assert groups[1].id.to_pylist() == ["d3", "d5"]
+    assert groups[1].exposure_id.to_pylist() == ["e2", "e2"]
+    assert groups[1].ra.to_pylist() == [2, 4]
+    assert groups[1].dec.to_pylist() == [7, 9]

--- a/adam_core/tests/test_imports.py
+++ b/adam_core/tests/test_imports.py
@@ -32,7 +32,7 @@ def test_import_propagator():
 
 
 def test_import_observations():
-    from adam_core.observations import Exposures, PointSourceDetections
+    from adam_core.observations import Associations, Exposures, PointSourceDetections
 
 
 def test_import_utils():

--- a/adam_core/utils/helpers/tests/test_observations.py
+++ b/adam_core/utils/helpers/tests/test_observations.py
@@ -4,6 +4,7 @@ from ..observations import make_observations
 def test_make_observations():
     # Test that we get two tables from make observations are
     # the expected length
-    exposures, observations = make_observations()
+    exposures, observations, associations = make_observations()
     assert len(exposures) == 2412
     assert len(observations) == 2520
+    assert len(associations) == 2520


### PR DESCRIPTION
This PR also adds an Associations table that gets returned with `~adam_core.utils.helpers.observations.make_observations`. This isn't ready to be merged yet. 