### PR TITLE
Add sort_by to support common sorts

### DIFF
--- a/adam_core/observers/tests/test_observers.py
+++ b/adam_core/observers/tests/test_observers.py
@@ -1,0 +1,50 @@
+import numpy as np
+import quivr as qv
+from astropy.time import Time
+
+from ..observers import Observers
+
+
+def test_observers_sort_by():
+    # Test that Observers.sort_by works for both
+    # ascending and descending order and different
+    # order of columns.
+    observers = qv.concatenate(
+        [
+            Observers.from_code(
+                "X05", Time([59001, 59002, 59003], scale="tdb", format="mjd")
+            ),
+            Observers.from_code(
+                "I41", Time([59003, 59004, 59005], scale="tdb", format="mjd")
+            ),
+        ]
+    )
+    observers_sorted = observers.sort_by(by=["time", "code"], ascending=True)
+    np.testing.assert_equal(
+        observers_sorted.code.to_numpy(zero_copy_only=False),
+        np.array(["X05", "X05", "I41", "X05", "I41", "I41"]),
+    )
+    np.testing.assert_almost_equal(
+        observers_sorted.coordinates.time.mjd(),
+        np.array([59001, 59002, 59003, 59003, 59004, 59005]),
+    )
+
+    observers_sorted = observers.sort_by(by=["time", "code"], ascending=False)
+    np.testing.assert_equal(
+        observers_sorted.code.to_numpy(zero_copy_only=False),
+        np.array(["I41", "I41", "X05", "I41", "X05", "X05"]),
+    )
+    np.testing.assert_almost_equal(
+        observers_sorted.coordinates.time.mjd(),
+        np.array([59005, 59004, 59003, 59003, 59002, 59001]),
+    )
+
+    observers_sorted = observers.sort_by(by=["code", "time"], ascending=True)
+    np.testing.assert_equal(
+        observers_sorted.code.to_numpy(zero_copy_only=False),
+        np.array(["I41", "I41", "I41", "X05", "X05", "X05"]),
+    )
+    np.testing.assert_almost_equal(
+        observers_sorted.coordinates.time.mjd(),
+        np.array([59003, 59004, 59005, 59001, 59002, 59003]),
+    )

--- a/adam_core/orbits/ephemeris.py
+++ b/adam_core/orbits/ephemeris.py
@@ -1,3 +1,7 @@
+from typing import List
+
+import pyarrow as pa
+import pyarrow.compute as pc
 from quivr import StringColumn, Table
 
 from ..coordinates.cartesian import CartesianCoordinates
@@ -17,3 +21,53 @@ class Ephemeris(Table):
     # Aberrated coordinates are coordinates that account for the light travel time
     # from the time of emission/reflection to the time of observation
     aberrated_coordinates = CartesianCoordinates.as_column(nullable=True)
+
+    def sort_by(
+        self, by: List[str] = ["orbit_id", "time", "code"], ascending: bool = True
+    ) -> "Ephemeris":
+        """
+        Sort the Ephemeris table the desired columns.
+        Column options are "orbit_id", "object_id", "time", and "code".
+
+        Parameters
+        ----------
+        by : List[str], optional
+            The column(s) to sort by. Default is ["orbit_id", "time", "code"].
+        ascending : bool, optional
+            Whether to sort in ascending or descending order.
+
+        Returns
+        -------
+        ephemeris : `~adam_core.orbits.ephemeris.Ephemeris`
+            The sorted ephemeris table.
+
+        Raises
+        ------
+        ValueError: If an invalid column is passed.
+        """
+        values = []
+        names = []
+        for col in by:
+            if col == "orbit_id":
+                values.append(self.orbit_id)
+            elif col == "object_id":
+                values.append(self.object_id)
+            elif col == "time":
+                values.append(self.coordinates.time.mjd())
+            elif col == "code":
+                values.append(self.coordinates.origin.code)
+            else:
+                raise ValueError(
+                    f"Invalid column {col}. Valid columns are 'orbit_id', 'object_id', 'time' and 'code'"
+                )
+
+            names.append(col)
+
+        table = pa.table(values, names=names)
+        if ascending:
+            order = [(name, "ascending") for name in names]
+        else:
+            order = [(name, "descending") for name in names]
+
+        sort_indices = pc.sort_indices(table, order)
+        return self.take(sort_indices)

--- a/adam_core/propagator/propagator.py
+++ b/adam_core/propagator/propagator.py
@@ -8,7 +8,7 @@ from astropy.time import Time
 
 from ..observers import Observers
 from ..orbits import Ephemeris, Orbits, VariantOrbits
-from .utils import _iterate_chunks, sort_propagated_orbits
+from .utils import _iterate_chunks
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +138,7 @@ class Propagator(ABC):
             else:
                 propagated_variants = None
 
-        propagated = sort_propagated_orbits(propagated)
+        propagated = propagated.sort_by(by=["orbit_id", "time"], ascending=True)
 
         if propagated_variants is not None:
             propagated = propagated_variants.collapse(propagated)

--- a/adam_core/propagator/utils.py
+++ b/adam_core/propagator/utils.py
@@ -1,10 +1,6 @@
 from typing import Iterable, Sequence
 
 import numpy as np
-import pyarrow as pa
-from pyarrow import compute as pc
-
-from ..orbits.orbits import Orbits
 
 MILLISECOND_IN_DAYS = 1 / 86400 / 1000
 
@@ -54,47 +50,3 @@ def _assert_times_almost_equal(
     diff = np.abs(have - want)
     if np.any(diff > tolerance_in_days):
         raise ValueError(f"Times were not within {tolerance:.6f} ms of each other.")
-
-
-def sort_propagated_orbits(propagated_orbits: Orbits) -> Orbits:
-    """
-    Sort propagated orbits by orbit_id, object_id, and time.
-
-    Parameters
-    ----------
-    propagated_orbits : `~adam_core.orbits.orbits.Orbits`
-        Orbits to sort.
-
-    Returns
-    -------
-    Orbits : `~adam_core.orbits.orbits.Orbits`
-        Sorted orbits.
-    """
-    # Build table with orbit_ids, object_ids, and times
-    table = pa.table(
-        [
-            propagated_orbits.orbit_id,
-            propagated_orbits.object_id,
-            pc.add(
-                pc.struct_field(
-                    pc.struct_field(propagated_orbits.table["coordinates"], "time"),
-                    "jd1",
-                ),
-                pc.struct_field(
-                    pc.struct_field(propagated_orbits.table["coordinates"], "time"),
-                    "jd2",
-                ),
-            ),
-        ],
-        names=["orbit_id", "object_id", "time"],
-    )
-
-    indices = pc.sort_indices(
-        table,
-        (
-            ("orbit_id", "ascending"),
-            ("object_id", "ascending"),
-            ("time", "ascending"),
-        ),
-    )
-    return propagated_orbits.take(indices)


### PR DESCRIPTION
While working on THOR v2.0, I'm finding myself doing a lot of sorts, especially involving time. This PR adds a `sort_by` function to a couple of the Tables that I'm sorting the most frequently. Note that when sorting by time we need to create a composite column that adds jd1 and jd2, hence why quivr's sort_by doesn't work out of the box here. 