### PR TITLE
Port over the logic for dataframe conversions to stuff time scales into DFs

### DIFF
--- a/adam_core/time/tests/test_time.py
+++ b/adam_core/time/tests/test_time.py
@@ -437,3 +437,38 @@ class TestTimeMath:
             86400_000_000_000 - 199,
             86400_000_000_000 - 298,
         ]
+
+
+def test_dataframe_roundtrip():
+    t1 = Timestamp.from_kwargs(
+        days=[50000, 60000, 70000],
+        nanos=[0, 1, 2],
+        scale="tdb",
+    )
+
+    df = t1.to_dataframe()
+
+    t2 = Timestamp.from_dataframe(df)
+
+    assert t1 == t2
+
+
+@pytest.mark.xfail(
+    reason="wrapper classes do not use custom from_dataframe for subcolumns"
+)
+def test_dataframe_roundtrip_nested():
+    t1 = Timestamp.from_kwargs(
+        days=[50000, 60000, 70000],
+        nanos=[0, 1, 2],
+        scale="tdb",
+    )
+    w = Wrapper.from_kwargs(
+        id=["a", "b", "c"],
+        times=t1,
+    )
+
+    df = w.to_dataframe()
+
+    w2 = Wrapper.from_flat_dataframe(df)
+
+    assert w == w2

--- a/adam_core/time/time.py
+++ b/adam_core/time/time.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import astropy
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
 import quivr as qv
@@ -372,6 +373,40 @@ class Timestamp(qv.Table):
             days1,
         )
         return days2, nanos2
+
+    def to_dataframe(self, flatten: bool = True) -> pd.DataFrame:
+        """Convert to a dataframe. Time scale is added as a suffix to
+        the column names.
+
+        """
+        df = super().to_dataframe(flatten=flatten)
+        return df.rename(
+            columns={col: f"{col}_{self.scale}" for col in df.columns},
+        )
+
+    @classmethod
+    def from_dataframe(cls, df: pd.DataFrame) -> "Timestamp":
+        """Convert from a pandas DataFrame. Time scale is expected to
+        be a suffix to the column names.
+
+        """
+        df_filtered = df.filter(regex=r".*(days|nanos)_[a-zA-Z]+$")
+        scale = df_filtered.columns[0].split("_")[-1]
+
+        for col in df_filtered.columns:
+            if not col.endswith(f"_{scale}"):
+                raise ValueError(f"Column {col} does not have expected suffix _{scale}")
+            if "timestamp." in col:
+                df_filtered.rename(
+                    columns={col: col.split("timetamp.")[-1]}, inplace=True
+                )
+
+        df_renamed = df_filtered.rename(
+            columns={col: col.split("_")[0] for col in df_filtered.columns}
+        )
+        return cls.from_kwargs(
+            days=df_renamed["days"], nanos=df_renamed["nanos"], scale=scale
+        )
 
 
 def _duration_arrays_within_tolerance(


### PR DESCRIPTION
This is just a copy of existing code used for coordinates.time.Time tables.

Note that this does _not_ work when the times are used as a subcolumn; see the failing test.

One way we could manage this would, perhaps, be to use DataFrame attrs: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.attrs.html We could stash the scalar attributes in that dictionary, and pull em back out. That could be a quivr feature.