### PR TITLE
Vectorize Origin.mu and use throughout adam_core

### DIFF
--- a/adam_core/coordinates/cometary.py
+++ b/adam_core/coordinates/cometary.py
@@ -199,7 +199,7 @@ class CometaryCoordinates(qv.Table):
             raise ValueError(err)
 
         # Extract gravitational parameter from origin
-        mu = self.origin.mu
+        mu = self.origin.mu()
 
         coords_cartesian = cometary_to_cartesian(
             self.values,
@@ -216,7 +216,7 @@ class CometaryCoordinates(qv.Table):
                 self.values,
                 cometary_covariances,
                 _cometary_to_cartesian,
-                in_axes=(0, 0, None, None, None),
+                in_axes=(0, 0, 0, None, None),
                 out_axes=0,
                 t0=self.time.to_numpy(),
                 mu=mu,
@@ -258,7 +258,7 @@ class CometaryCoordinates(qv.Table):
             raise ValueError(err)
 
         # Extract gravitational parameter from origin
-        mu = cartesian.origin.mu
+        mu = cartesian.origin.mu()
 
         coords_cometary = cartesian_to_cometary(
             cartesian.values,
@@ -273,7 +273,7 @@ class CometaryCoordinates(qv.Table):
                 cartesian.values,
                 cartesian_covariances,
                 _cartesian_to_cometary,
-                in_axes=(0, 0, None),
+                in_axes=(0, 0, 0),
                 out_axes=0,
                 t0=cartesian.time.to_numpy(),
                 mu=mu,

--- a/adam_core/coordinates/keplerian.py
+++ b/adam_core/coordinates/keplerian.py
@@ -187,7 +187,7 @@ class KeplerianCoordinates(qv.Table):
         from .transform import _keplerian_to_cartesian_a, keplerian_to_cartesian
 
         # Extract gravitational parameter from origin
-        mu = self.origin.mu
+        mu = self.origin.mu()
 
         coords_cartesian = keplerian_to_cartesian(
             self.values,
@@ -203,7 +203,7 @@ class KeplerianCoordinates(qv.Table):
                 self.values,
                 covariances_keplerian,
                 _keplerian_to_cartesian_a,
-                in_axes=(0, None, None, None),
+                in_axes=(0, 0, None, None),
                 out_axes=0,
                 mu=mu,
                 max_iter=1000,
@@ -236,7 +236,7 @@ class KeplerianCoordinates(qv.Table):
         from .transform import _cartesian_to_keplerian6, cartesian_to_keplerian
 
         # Extract gravitational parameter from origin
-        mu = cartesian.origin.mu
+        mu = cartesian.origin.mu()
 
         coords_keplerian = cartesian_to_keplerian(
             cartesian.values,
@@ -251,7 +251,7 @@ class KeplerianCoordinates(qv.Table):
                 cartesian.values,
                 cartesian_covariances,
                 _cartesian_to_keplerian6,
-                in_axes=(0, 0, None),
+                in_axes=(0, 0, 0),
                 out_axes=0,
                 t0=cartesian.time.to_numpy(),
                 mu=mu,

--- a/adam_core/coordinates/tests/test_benchmarks.py
+++ b/adam_core/coordinates/tests/test_benchmarks.py
@@ -31,6 +31,11 @@ def test_benchmark_transform_cartesian_coordinates(
     if origin == OriginCodes.SOLAR_SYSTEM_BARYCENTER:
         pytest.skip("barycenter transform not yet implemented")
 
+    if frame == "ecliptic":
+        frame_in = "equatorial"
+    else:
+        frame_in = "ecliptic"
+
     from_coords = CartesianCoordinates.from_kwargs(
         x=np.array([1]),
         y=np.array([1]),
@@ -40,7 +45,7 @@ def test_benchmark_transform_cartesian_coordinates(
         vz=np.array([1]),
         time=Timestamp.from_mjd([50000]),
         origin=Origin.from_kwargs(code=["SUN"]),
-        frame="ecliptic",
+        frame=frame_in,
     )
     benchmark(
         transform_coordinates,

--- a/adam_core/coordinates/tests/test_origin.py
+++ b/adam_core/coordinates/tests/test_origin.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from ..origin import Origin, OriginCodes
+from ..origin import Origin, OriginCodes, OriginGravitationalParameters
 
 
 def test_origin_eq__():
@@ -53,8 +53,32 @@ def test_origin_eq__():
     np.testing.assert_equal(origin != OriginCodes.EARTH, np.array([True, False, True]))
 
 
-def test_origin_eq__raises():
+def test_origin__eq__raises():
     # Test that an error is raised when an unsupported type is passed
     origin = Origin.from_kwargs(code=["SUN", "EARTH", "MARS"])
     with pytest.raises(TypeError):
         origin == 1
+
+
+def test_origin_mu():
+    # Test that the mu function returns the correct values
+    origin = Origin.from_kwargs(
+        code=["SUN", "MARS_BARYCENTER", "JUPITER_BARYCENTER", "SUN"]
+    )
+
+    expected = np.array(
+        [
+            OriginGravitationalParameters.SUN,
+            OriginGravitationalParameters.MARS_BARYCENTER,
+            OriginGravitationalParameters.JUPITER_BARYCENTER,
+            OriginGravitationalParameters.SUN,
+        ]
+    )
+    np.testing.assert_equal(origin.mu(), expected)
+
+
+def test_origin_mu_raises():
+    # Test that the mu function raises a ValueError when an unsupported code is passed
+    origin = Origin.from_kwargs(code=["VESTA"])
+    with pytest.raises(ValueError):
+        origin.mu()

--- a/adam_core/coordinates/tests/test_transforms_cometary.py
+++ b/adam_core/coordinates/tests/test_transforms_cometary.py
@@ -1,6 +1,7 @@
 import numpy as np
 from astropy import units as u
 
+from ..origin import Origin
 from ..transform import cartesian_to_cometary, cometary_to_cartesian
 
 
@@ -18,8 +19,11 @@ def test_cometary_to_cartesian_elliptical(orbital_elements):
         ["x", "y", "z", "vx", "vy", "vz"]
     ].values
     t0_mjd = orbital_elements["mjd_tdb"].values
+    origin = Origin.from_kwargs(code=["SUN"] * len(orbital_elements))
 
-    cartesian_elements_actual = cometary_to_cartesian(cometary_elements, t0_mjd)
+    cartesian_elements_actual = cometary_to_cartesian(
+        cometary_elements, t0_mjd, origin.mu()
+    )
     diff = cartesian_elements_actual - cartesian_elements_expected
 
     # Calculate offset in position in mm
@@ -49,8 +53,11 @@ def test_cometary_to_cartesian_hyperbolic(orbital_elements):
         ["x", "y", "z", "vx", "vy", "vz"]
     ].values
     t0_mjd = orbital_elements["mjd_tdb"].values
+    origin = Origin.from_kwargs(code=["SUN"] * len(orbital_elements))
 
-    cartesian_elements_actual = cometary_to_cartesian(cometary_elements, t0_mjd)
+    cartesian_elements_actual = cometary_to_cartesian(
+        cometary_elements, t0_mjd, origin.mu()
+    )
     diff = cartesian_elements_actual - cartesian_elements_expected
 
     # Calculate offset in position in mm
@@ -78,10 +85,13 @@ def test_cartesian_to_cometary_elliptical(orbital_elements):
     ].values
     epochs = orbital_elements["mjd_tdb"].values
     cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
+    origin = Origin.from_kwargs(code=["SUN"] * len(orbital_elements))
 
     # Cartesian to cometary returns an N, 13 array containing the cometary elements and cometary
     # elements, with some additional columns.
-    cometary_elements_actual = cartesian_to_cometary(cartesian_elements, epochs)
+    cometary_elements_actual = cartesian_to_cometary(
+        cartesian_elements, epochs, origin.mu()
+    )
 
     # Calculate the difference
     diff = cometary_elements_actual - cometary_elements_expected
@@ -132,10 +142,13 @@ def test_cartesian_to_cometary_hyperbolic(orbital_elements):
     ].values
     epochs = orbital_elements["mjd_tdb"].values
     cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
+    origin = Origin.from_kwargs(code=["SUN"] * len(orbital_elements))
 
     # Cartesian to cometary returns an N, 13 array containing the cometary elements and cometary
     # elements, with some additional columns.
-    cometary_elements_actual = cartesian_to_cometary(cartesian_elements, epochs)
+    cometary_elements_actual = cartesian_to_cometary(
+        cartesian_elements, epochs, origin.mu()
+    )
 
     # Calculate the difference
     diff = cometary_elements_actual - cometary_elements_expected

--- a/adam_core/coordinates/tests/test_transforms_keplerian.py
+++ b/adam_core/coordinates/tests/test_transforms_keplerian.py
@@ -1,6 +1,7 @@
 import numpy as np
 from astropy import units as u
 
+from ..origin import Origin
 from ..transform import cartesian_to_keplerian, keplerian_to_cartesian
 
 
@@ -15,8 +16,9 @@ def test_keplerian_to_cartesian_elliptical(orbital_elements):
     cartesian_elements_expected = orbital_elements[
         ["x", "y", "z", "vx", "vy", "vz"]
     ].values
+    origin = Origin.from_kwargs(code=["SUN"] * len(orbital_elements))
 
-    cartesian_elements_actual = keplerian_to_cartesian(keplerian_elements)
+    cartesian_elements_actual = keplerian_to_cartesian(keplerian_elements, origin.mu())
     diff = cartesian_elements_actual - cartesian_elements_expected
 
     # Calculate offset in position in mm
@@ -41,8 +43,9 @@ def test_keplerian_to_cartesian_hyperbolic(orbital_elements):
     cartesian_elements_expected = orbital_elements[
         ["x", "y", "z", "vx", "vy", "vz"]
     ].values
+    origin = Origin.from_kwargs(code=["SUN"] * len(orbital_elements))
 
-    cartesian_elements_actual = keplerian_to_cartesian(keplerian_elements)
+    cartesian_elements_actual = keplerian_to_cartesian(keplerian_elements, origin.mu())
     diff = cartesian_elements_actual - cartesian_elements_expected
 
     # Calculate offset in position in mm
@@ -68,10 +71,13 @@ def test_cartesian_to_keplerian_elliptical(orbital_elements):
     ].values
     epochs = orbital_elements["mjd_tdb"].values
     cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
+    origin = Origin.from_kwargs(code=["SUN"] * len(orbital_elements))
 
     # Cartesian to keplerian returns an N, 13 array containing the keplerian elements and cometary
     # elements, with some additional columns.
-    keplerian_elements_actual = cartesian_to_keplerian(cartesian_elements, epochs)
+    keplerian_elements_actual = cartesian_to_keplerian(
+        cartesian_elements, epochs, origin.mu()
+    )
 
     # Remove semi-latus rectum
     keplerian_elements_actual = keplerian_elements_actual[
@@ -157,10 +163,13 @@ def test_cartesian_to_keplerian_hyperbolic(orbital_elements):
     ].values
     epochs = orbital_elements["mjd_tdb"].values
     cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
+    origin = Origin.from_kwargs(code=["SUN"] * len(orbital_elements))
 
     # Cartesian to keplerian returns an N, 13 array containing the keplerian elements and cometary
     # elements, with some additional columns.
-    keplerian_elements_actual = cartesian_to_keplerian(cartesian_elements, epochs)
+    keplerian_elements_actual = cartesian_to_keplerian(
+        cartesian_elements, epochs, origin.mu()
+    )
 
     # Remove semi-latus rectum
     keplerian_elements_actual = keplerian_elements_actual[

--- a/adam_core/coordinates/transform.py
+++ b/adam_core/coordinates/transform.py
@@ -41,7 +41,6 @@ CoordinatesClasses = (
 )
 
 
-MU = c.MU
 Z_AXIS = jnp.array([0.0, 0.0, 1.0])
 FLOAT_TOLERANCE = 1e-15
 
@@ -291,7 +290,7 @@ def spherical_to_cartesian(
 def _cartesian_to_keplerian(
     coords_cartesian: Union[np.ndarray, jnp.ndarray],
     t0: float,
-    mu: float = MU,
+    mu: float,
 ) -> jnp.ndarray:
     """
     Convert a single Cartesian coordinate to a Keplerian coordinate.
@@ -316,7 +315,7 @@ def _cartesian_to_keplerian(
         vz : z-velocity in units of au per day.
     t0 : float (1)
         Epoch at which cometary elements are defined in MJD TDB.
-    mu : float, optional
+    mu : float (1)
         Gravitational parameter (GM) of the attracting body in units of
         au**3 / d**2.
 
@@ -475,7 +474,7 @@ def _cartesian_to_keplerian(
 _cartesian_to_keplerian_vmap = jit(
     vmap(
         _cartesian_to_keplerian,
-        in_axes=(0, 0, None),
+        in_axes=(0, 0, 0),
     )
 )
 
@@ -484,7 +483,7 @@ _cartesian_to_keplerian_vmap = jit(
 def _cartesian_to_keplerian6(
     coords_cartesian: Union[np.ndarray, jnp.ndarray],
     t0: float,
-    mu: float = MU,
+    mu: float,
 ) -> jnp.ndarray:
     """
     Limit conversion of Cartesian coordinates to Keplerian 6 fundamental coordinates.
@@ -501,7 +500,7 @@ def _cartesian_to_keplerian6(
         vz : z-velocity in units of au per day.
     t0 : float (1)
         Epoch at which cometary elements are defined in MJD TDB.
-    mu : float, optional
+    mu : float (1)
         Gravitational parameter (GM) of the attracting body in units of
         au**3 / d**2.
 
@@ -523,7 +522,7 @@ def _cartesian_to_keplerian6(
 def cartesian_to_keplerian(
     coords_cartesian: Union[np.ndarray, jnp.ndarray],
     t0: Union[np.ndarray, jnp.ndarray],
-    mu: float = MU,
+    mu: Union[np.ndarray, jnp.ndarray],
 ) -> jnp.ndarray:
     """
     Convert Cartesian coordinates to Keplerian coordinates.
@@ -540,7 +539,7 @@ def cartesian_to_keplerian(
         vz : z-velocity in units of au per day.
     t0 : {`~numpy.ndarray`, `~jax.numpy.ndarray`} (N)
         Epoch at which cometary elements are defined in MJD TDB.
-    mu : float, optional
+    mu : {`~numpy.ndarray`, `~jax.numpy.ndarray`} (N, 6)
         Gravitational parameter (GM) of the attracting body in units of
         au**3 / d**2.
 
@@ -569,7 +568,7 @@ def cartesian_to_keplerian(
 @jit
 def _keplerian_to_cartesian_p(
     coords_keplerian: Union[np.ndarray, jnp.ndarray],
-    mu: float = MU,
+    mu: float,
     max_iter: int = 1000,
     tol: float = 1e-15,
 ) -> jnp.ndarray:
@@ -591,7 +590,7 @@ def _keplerian_to_cartesian_p(
         raan : Right ascension (longitude) of the ascending node in degrees.
         ap : argument of periapsis in degrees.
         M : mean anomaly in degrees.
-    mu : float, optional
+    mu : float
         Gravitational parameter (GM) of the attracting body in units of
         au**3 / d**2.
     max_iter : int, optional
@@ -697,7 +696,7 @@ def _keplerian_to_cartesian_p(
 _keplerian_to_cartesian_p_vmap = jit(
     vmap(
         _keplerian_to_cartesian_p,
-        in_axes=(0, None, None, None),
+        in_axes=(0, 0, None, None),
     )
 )
 
@@ -705,7 +704,7 @@ _keplerian_to_cartesian_p_vmap = jit(
 @jit
 def _keplerian_to_cartesian_a(
     coords_keplerian: Union[np.ndarray, jnp.ndarray],
-    mu: float = MU,
+    mu: float,
     max_iter: int = 1000,
     tol: float = 1e-15,
 ) -> jnp.ndarray:
@@ -727,7 +726,7 @@ def _keplerian_to_cartesian_a(
         raan : Right ascension (longitude) of the ascending node in degrees.
         ap : argument of periapsis in degrees.
         M : mean anomaly in degrees.
-    mu : float, optional
+    mu : float (1)
         Gravitational parameter (GM) of the attracting body in units of
         au**3 / d**2.
     max_iter : int, optional
@@ -780,7 +779,7 @@ def _keplerian_to_cartesian_a(
 _keplerian_to_cartesian_a_vmap = jit(
     vmap(
         _keplerian_to_cartesian_a,
-        in_axes=(0, None, None, None),
+        in_axes=(0, 0, None, None),
     )
 )
 
@@ -788,7 +787,7 @@ _keplerian_to_cartesian_a_vmap = jit(
 @jit
 def _keplerian_to_cartesian_q(
     coords_keplerian: Union[np.ndarray, jnp.ndarray],
-    mu: float = MU,
+    mu: float,
     max_iter: int = 1000,
     tol: float = 1e-15,
 ) -> jnp.ndarray:
@@ -810,7 +809,7 @@ def _keplerian_to_cartesian_q(
         raan : Right ascension (longitude) of the ascending node in degrees.
         ap : argument of periapsis in degrees.
         M : mean anomaly in degrees.
-    mu : float, optional
+    mu : float (1)
         Gravitational parameter (GM) of the attracting body in units of
         au**3 / d**2.
     max_iter : int, optional
@@ -863,14 +862,14 @@ def _keplerian_to_cartesian_q(
 _keplerian_to_cartesian_q_vmap = jit(
     vmap(
         _keplerian_to_cartesian_q,
-        in_axes=(0, None, None, None),
+        in_axes=(0, 0, None, None),
     )
 )
 
 
 def keplerian_to_cartesian(
     coords_keplerian: Union[np.ndarray, jnp.ndarray],
-    mu: float = MU,
+    mu: Union[np.ndarray, jnp.ndarray],
     max_iter: int = 100,
     tol: float = 1e-15,
 ) -> jnp.ndarray:
@@ -892,7 +891,7 @@ def keplerian_to_cartesian(
         raan : Right ascension (longitude) of the ascending node in degrees.
         ap : argument of periapsis in degrees.
         M : mean anomaly in degrees.
-    mu : float, optional
+    mu : {`~numpy.ndarray`, `~jax.numpy.ndarray`} (N)
         Gravitational parameter (GM) of the attracting body in units of
         au**3 / d**2.
     max_iter : int, optional
@@ -958,7 +957,7 @@ def keplerian_to_cartesian(
 def _cartesian_to_cometary(
     coords_cartesian: Union[np.ndarray, jnp.ndarray],
     t0: float,
-    mu: float = MU,
+    mu: float,
 ) -> jnp.ndarray:
     """
     Convert Cartesian coordinates to Cometary coordinates.
@@ -975,7 +974,7 @@ def _cartesian_to_cometary(
         vz : z-velocity in units of au per day.
     t0 : float (1)
         Epoch at which cometary elements are defined in MJD TDB.
-    mu : float, optional
+    mu : float (1)
         Gravitational parameter (GM) of the attracting body in units of
         au**3 / d**2.
 
@@ -998,7 +997,7 @@ def _cartesian_to_cometary(
 _cartesian_to_cometary_vmap = jit(
     vmap(
         _cartesian_to_cometary,
-        in_axes=(0, 0, None),
+        in_axes=(0, 0, 0),
     )
 )
 
@@ -1006,7 +1005,7 @@ _cartesian_to_cometary_vmap = jit(
 def cartesian_to_cometary(
     coords_cartesian: Union[np.ndarray, jnp.ndarray],
     t0: Union[np.ndarray, jnp.ndarray],
-    mu: float = MU,
+    mu: Union[np.ndarray, jnp.ndarray],
 ) -> jnp.ndarray:
     """
     Convert Cartesian coordinates to Keplerian coordinates.
@@ -1023,7 +1022,7 @@ def cartesian_to_cometary(
         vz : z-velocity in units of au per day.
     t0 : {`~numpy.ndarray`, `~jax.numpy.ndarray`} (N)
         Epoch at which cometary elements are defined in MJD TDB.
-    mu : float, optional
+    mu : {`~numpy.ndarray`, `~jax.numpy.ndarray`} (N)
         Gravitational parameter (GM) of the attracting body in units of
         au**3 / d**2.
 
@@ -1046,7 +1045,7 @@ def cartesian_to_cometary(
 def _cometary_to_cartesian(
     coords_cometary: Union[np.ndarray, jnp.ndarray],
     t0: float,
-    mu: float = MU,
+    mu: float,
     max_iter: int = 100,
     tol: float = 1e-15,
 ) -> jnp.ndarray:
@@ -1065,7 +1064,7 @@ def _cometary_to_cartesian(
         tp : time of periapse passage in days.
     t0 : float (1)
         Epoch at which cometary elements are defined in MJD TDB.
-    mu : float, optional
+    mu : float
         Gravitational parameter (GM) of the attracting body in units of
         au**3 / d**2.
     max_iter : int, optional
@@ -1143,7 +1142,7 @@ def _cometary_to_cartesian(
 _cometary_to_cartesian_vmap = jit(
     vmap(
         _cometary_to_cartesian,
-        in_axes=(0, 0, None, None, None),
+        in_axes=(0, 0, 0, None, None),
     )
 )
 
@@ -1151,7 +1150,7 @@ _cometary_to_cartesian_vmap = jit(
 def cometary_to_cartesian(
     coords_cometary: Union[np.ndarray, jnp.ndarray],
     t0: Union[np.ndarray, jnp.ndarray],
-    mu: float = MU,
+    mu: Union[np.ndarray, jnp.ndarray],
     max_iter: int = 100,
     tol: float = 1e-15,
 ) -> jnp.ndarray:
@@ -1170,7 +1169,7 @@ def cometary_to_cartesian(
         tp : time of periapse passage in days.
     t0 : {`~numpy.ndarray`, `~jax.numpy.ndarray`} (N)
         Epoch at which cometary elements are defined in MJD TDB.
-    mu : float, optional
+    mu : {`~numpy.ndarray`, `~jax.numpy.ndarray`} (N)
         Gravitational parameter (GM) of the attracting body in units of
         au**3 / d**2.
     max_iter : int, optional

--- a/adam_core/dynamics/tests/conftest.py
+++ b/adam_core/dynamics/tests/conftest.py
@@ -18,6 +18,17 @@ def orbital_elements():
 
 
 @pytest.fixture
+def orbital_elements_barycentric():
+    orbital_elements_file = files("adam_core.utils.helpers.data").joinpath(
+        "elements_ssb_ec.csv"
+    )
+    df = pd.read_csv(
+        orbital_elements_file, index_col=False, float_precision="round_trip"
+    )
+    return df
+
+
+@pytest.fixture
 def propagated_orbits():
     return Orbits.from_parquet(
         files("adam_core.utils.helpers.data").joinpath("propagated_orbits.parquet")

--- a/adam_core/dynamics/tests/test_propagation.py
+++ b/adam_core/dynamics/tests/test_propagation.py
@@ -230,8 +230,10 @@ def test_benchmark__propagate_2body(benchmark, orbital_elements):
     orbital_elements = orbital_elements[orbital_elements["e"] < 1.0]
     cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
     t0 = orbital_elements["mjd_tdb"].values
+    origin = Origin.from_kwargs(code=["SUN" for i in range(len(orbital_elements))])
+    mu = origin.mu()
 
-    benchmark(_propagate_2body, cartesian_elements[0], t0[0], t0[0] + 1)
+    benchmark(_propagate_2body, cartesian_elements[0], t0[0], t0[0] + 1, mu[0])
 
 
 def test_benchmark__propagate_2body_vmap(benchmark, orbital_elements):
@@ -248,7 +250,7 @@ def test_benchmark__propagate_2body_vmap(benchmark, orbital_elements):
         cartesian_elements[:1],
         t0[:1],
         t0[:1] + 1,
-        mu,
+        mu[:1],
         1000,
         1e-14,
     )

--- a/adam_core/dynamics/tests/test_propagation.py
+++ b/adam_core/dynamics/tests/test_propagation.py
@@ -157,11 +157,161 @@ def test_propagate_2body_against_spice_elliptical(orbital_elements):
 
 def test_propagate_2body_against_spice_hyperbolic(orbital_elements):
     # Test propagation against SPICE for hyperbolic orbits.
-
     orbital_elements = orbital_elements[orbital_elements["e"] > 1.0]
     cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
     t0 = orbital_elements["mjd_tdb"].values
     origin = Origin.from_kwargs(code=["SUN" for i in range(len(cartesian_elements))])
+    mu = origin.mu()
+
+    # Create orbits object
+    orbits = Orbits.from_kwargs(
+        orbit_id=orbital_elements["targetname"].values,
+        object_id=orbital_elements["targetname"].values,
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=cartesian_elements[:, 0],
+            y=cartesian_elements[:, 1],
+            z=cartesian_elements[:, 2],
+            vx=cartesian_elements[:, 3],
+            vy=cartesian_elements[:, 4],
+            vz=cartesian_elements[:, 5],
+            time=Timestamp.from_mjd(
+                t0,
+                scale="tdb",
+            ),
+            origin=origin,
+            frame="ecliptic",
+        ),
+    )
+
+    # Set propagation times (same for all orbits)
+    times = Timestamp.from_mjd(
+        t0.min() + np.arange(0, 10000, 10),
+        scale="tdb",
+    )
+
+    # Propagate orbits with SPICE and accumulate results
+    spice_propagated = []
+    times_mjd = times.mjd()
+    for i, cartesian_i in enumerate(cartesian_elements):
+
+        # Calculate dts from t0 for this orbit (each orbit's t0 is different)
+        # but the final times we are propagating to are the same for all orbits
+        dts = times_mjd - t0[i]
+        spice_propagated_i = np.empty((len(dts), 6))
+        for j, dt_i in enumerate(dts):
+            spice_propagated_i[j] = sp.prop2b(
+                mu[i], np.ascontiguousarray(cartesian_i), dt_i
+            )
+
+        spice_propagated.append(spice_propagated_i)
+
+    spice_propagated = np.vstack(spice_propagated)
+
+    # Propagate orbits with adam_core
+    orbits_propagated = propagate_2body(orbits, times)
+
+    # Calculate difference between SPICE and adam_core
+    diff = orbits_propagated.coordinates.values - spice_propagated
+
+    # Calculate offset in position in cm
+    r_diff = np.linalg.norm(diff[:, :3], axis=1) * u.au.to(u.cm)
+    # Calculate offset in velocity in mm/s
+    v_diff = np.linalg.norm(diff[:, 3:], axis=1) * (u.au / u.d).to(u.mm / u.s)
+
+    # Assert positions are to within 10 cm
+    np.testing.assert_array_less(r_diff, 10)
+    # Assert velocities are to within 1 mm/s
+    np.testing.assert_array_less(v_diff, 1)
+
+
+def test_propagate_2body_against_spice_elliptical_barycentric(
+    orbital_elements_barycentric,
+):
+    # Test propagation against SPICE for elliptical orbits.
+    orbital_elements = orbital_elements_barycentric[
+        orbital_elements_barycentric["e"] < 1.0
+    ]
+    cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
+    t0 = orbital_elements["mjd_tdb"].values
+    origin = Origin.from_kwargs(
+        code=["SOLAR_SYSTEM_BARYCENTER" for i in range(len(cartesian_elements))]
+    )
+    mu = origin.mu()
+
+    # Create orbits object
+    orbits = Orbits.from_kwargs(
+        orbit_id=orbital_elements["targetname"].values,
+        object_id=orbital_elements["targetname"].values,
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=cartesian_elements[:, 0],
+            y=cartesian_elements[:, 1],
+            z=cartesian_elements[:, 2],
+            vx=cartesian_elements[:, 3],
+            vy=cartesian_elements[:, 4],
+            vz=cartesian_elements[:, 5],
+            time=Timestamp.from_mjd(
+                t0,
+                scale="tdb",
+            ),
+            origin=origin,
+            frame="ecliptic",
+        ),
+    )
+
+    # Set propagation times (same for all orbits)
+    times = Timestamp.from_mjd(
+        t0.min() + np.arange(0, 10000, 10),
+        scale="tdb",
+    )
+
+    # Propagate orbits with SPICE and accumulate results
+    spice_propagated = []
+    times_mjd = times.mjd()
+    for i, cartesian_i in enumerate(cartesian_elements):
+
+        # Calculate dts from t0 for this orbit (each orbit's t0 is different)
+        # but the final times we are propagating to are the same for all orbits
+        dts = times_mjd - t0[i]
+        spice_propagated_i = np.empty((len(dts), 6))
+        for j, dt_i in enumerate(dts):
+            spice_propagated_i[j] = sp.prop2b(
+                mu[i], np.ascontiguousarray(cartesian_i), dt_i
+            )
+
+        spice_propagated.append(spice_propagated_i)
+
+    spice_propagated = np.vstack(spice_propagated)
+
+    # Propagate orbits with adam_core
+    orbits_propagated = propagate_2body(orbits, times)
+
+    # Calculate difference between SPICE and adam_core
+    diff = orbits_propagated.coordinates.values - spice_propagated
+
+    # Calculate offset in position in cm
+    r_diff = np.linalg.norm(diff[:, :3], axis=1) * u.au.to(u.cm)
+    # Calculate offset in velocity in mm/s
+    v_diff = np.linalg.norm(diff[:, 3:], axis=1) * (u.au / u.d).to(u.mm / u.s)
+
+    # Assert positions are to within 10 cm
+    np.testing.assert_array_less(r_diff, 10)
+    # Assert velocities are to within 1 mm/s
+    np.testing.assert_array_less(v_diff, 1)
+
+
+def test_propagate_2body_against_spice_hyperbolic_barycentric(
+    orbital_elements_barycentric,
+):
+    # Test propagation against SPICE for hyperbolic orbits.
+
+    orbital_elements = orbital_elements_barycentric[
+        orbital_elements_barycentric["e"] > 1.0
+    ]
+    cartesian_elements = orbital_elements[["x", "y", "z", "vx", "vy", "vz"]].values
+    t0 = orbital_elements["mjd_tdb"].values
+    origin = Origin.from_kwargs(
+        code=["SOLAR_SYSTEM_BARYCENTER" for i in range(len(cartesian_elements))]
+    )
     mu = origin.mu()
 
     # Create orbits object


### PR DESCRIPTION
This PR cleans up how the gravitational parameter as calculated from an origin code is used. We had inconsistent behavior in adam_core where some functions would use the constants module's solar GM despite the origin conceivably being something else. Instead, the keplerian and cometary conversion functions now require mu to be explicitly passed, and the `propagate_2body` and `generate_ephemeris_2body` now will calculate mu directly from the input orbits. 