### PR TITLE
Return Ephemeris from generate_ephemeris functions

### DIFF
--- a/adam_core/dynamics/ephemeris.py
+++ b/adam_core/dynamics/ephemeris.py
@@ -2,7 +2,6 @@ from typing import Tuple
 
 import jax.numpy as jnp
 import numpy as np
-import quivr as qv
 from jax import jit, lax, vmap
 
 from ..coordinates.cartesian import CartesianCoordinates
@@ -129,7 +128,7 @@ def generate_ephemeris_2body(
     max_iter: int = 1000,
     tol: float = 1e-15,
     stellar_aberration: bool = False,
-) -> qv.MultiKeyLinkage[Ephemeris, Observers]:
+) -> Ephemeris:
     """
     Generate on-sky ephemerides for each propagated orbit as viewed by the observers.
     This function calculates the light time delay between the propagated orbit and the observer,
@@ -174,7 +173,7 @@ def generate_ephemeris_2body(
 
     Returns
     -------
-    ephemeris : `~quivr.linkage.MultikeyLinkage` (N)
+    ephemeris : `~adam_core.orbits.ephemeris.Ephemeris` (N)
         Topocentric ephemerides for each propagated orbit as observed by the given observers.
     """
     # Transform both the orbits and observers to the barycenter if they are not already.
@@ -263,23 +262,9 @@ def generate_ephemeris_2body(
         spherical_coordinates, SphericalCoordinates, frame_out="equatorial"
     )
 
-    ephems = Ephemeris.from_kwargs(
+    return Ephemeris.from_kwargs(
         orbit_id=propagated_orbits_barycentric.orbit_id,
         object_id=propagated_orbits_barycentric.object_id,
         coordinates=spherical_coordinates,
         light_time=light_time,
     )
-
-    linkages = qv.MultiKeyLinkage(
-        left_table=ephems,
-        right_table=observers,
-        left_keys={
-            "code": ephems.coordinates.origin.code,
-            "mjd": ephems.coordinates.time.mjd(),
-        },
-        right_keys={
-            "code": observers.code,
-            "mjd": observers.coordinates.time.mjd(),
-        },
-    )
-    return linkages

--- a/adam_core/dynamics/tests/test_ephemeris.py
+++ b/adam_core/dynamics/tests/test_ephemeris.py
@@ -93,9 +93,6 @@ def test_generate_ephemeris_2body(object_id, propagated_orbits, ephemeris):
 
     ephemeris_orbit_2body = generate_ephemeris_2body(propagated_orbit, observers)
 
-    # Extract only the ephemeris table
-    ephemeris_orbit_2body = ephemeris_orbit_2body.left_table
-
     # Get the tolerances for this orbit
     if object_id in TOLERANCES:
         range_tolerance, angular_tolerance, light_time_tolerance = TOLERANCES[object_id]

--- a/adam_core/orbits/ephemeris.py
+++ b/adam_core/orbits/ephemeris.py
@@ -1,7 +1,11 @@
+import warnings
+
+import pyarrow as pa
 import quivr as qv
 
 from ..coordinates.cartesian import CartesianCoordinates
 from ..coordinates.spherical import SphericalCoordinates
+from ..observers.observers import Observers
 
 
 class Ephemeris(qv.Table):
@@ -18,3 +22,79 @@ class Ephemeris(qv.Table):
     # from the time of emission/reflection to the time of observation
     light_time = qv.Float64Column(nullable=True)
     aberrated_coordinates = CartesianCoordinates.as_column(nullable=True)
+
+    def link_to_observers(
+        self, observers: Observers, precision="ns"
+    ) -> qv.MultiKeyLinkage["Ephemeris", Observers]:
+        """
+        Link these ephemerides back to the observers that generated them. This is useful if
+        you want or need to use the observer's position as part of any computation for
+        any given set of ephemerides.
+
+        Not all propagators will return ephemerides exactly at the time of the input observers.
+        As an example, PYOORB stores times as a single MJD, when converting from two integers to
+        this singular float there will be a loss of precision. To mitigate this, the user may
+        optionally define the precision to which would like to link back to observers. Times
+        for both the ephemerides and observers will be rounded to this precision before linking.
+
+        Parameters
+        ----------
+        observers : `~adam_core.observers.observers.Observers` (N)
+            Observers that generated the ephemerides.
+        precision : str, optional
+            Precision to which to link back to observers, by default "ns".
+
+        Returns
+        -------
+        `~qv.MultiKeyLinkage[
+                `~adam_core.orbits.ephemeris.Ephemeris`,
+                `~adam_core.observers.observersObservers
+        ]`
+            Linkage between ephemerides and observers.
+        """
+        if self.coordinates.time.scale != observers.coordinates.time.scale:
+            observers = observers.set_column(
+                "coordinates.time",
+                observers.coordinates.time.rescale(self.coordinates.time.scale),
+            )
+
+        rounded = self.coordinates.time.rounded(precision)
+        observers_rounded = observers.coordinates.time.rounded(precision)
+
+        left_keys = {
+            "days": rounded.days,
+            "nanos": rounded.nanos,
+            "observatory_code": self.coordinates.origin.code,
+        }
+        right_keys = {
+            "days": observers_rounded.days,
+            "nanos": observers_rounded.nanos,
+            "observatory_code": observers.code,
+        }
+        linkage = qv.MultiKeyLinkage(self, observers, left_keys, right_keys)
+
+        # Check to make sure we have the correct number of linkages by calculating the number
+        # of unique observers in the table and checking to see if that matches the number of
+        # unique keys in the linkage
+        observers_table = pa.table(
+            [
+                observers.code,
+                observers.coordinates.time.days,
+                observers.coordinates.time.nanos,
+            ],
+            names=["observatory_code", "days", "nanos"],
+        )
+        unique_observers = observers_table.group_by(
+            ["observatory_code", "days", "nanos"]
+        ).aggregate([])
+
+        expected_length = len(unique_observers)
+        actual_length = len(linkage.all_unique_values)
+        if expected_length != actual_length:
+            warnings.warn(
+                "The number of unique keys in the linkage does not match the number"
+                " of unique observers. Linkage precision may be too low."
+                f"Expected {expected_length} unique keys, got {actual_length}.",
+                UserWarning,
+            )
+        return linkage

--- a/adam_core/orbits/tests/test_ephemeris.py
+++ b/adam_core/orbits/tests/test_ephemeris.py
@@ -1,0 +1,90 @@
+import pyarrow as pa
+import pytest
+import quivr as qv
+
+from ...coordinates.origin import Origin
+from ...coordinates.spherical import SphericalCoordinates
+from ...observers.observers import Observers
+from ...time import Timestamp
+from ..ephemeris import Ephemeris
+
+
+def test_Ephemeris_link_to_observers():
+    # Test that we can link ephemerides to observers with different
+    # precisions
+    observer_01 = Observers.from_code(
+        "X05",
+        Timestamp.from_kwargs(
+            days=[59000, 59000, 59000],
+            nanos=[9, 999, 999_999],
+            scale="utc",
+        ),
+    )
+    observer_02 = Observers.from_code(
+        "500",
+        Timestamp.from_kwargs(
+            days=[59000, 59000, 59000],
+            nanos=[9, 999, 999_999],
+            scale="utc",
+        ),
+    )
+    observers = qv.concatenate([observer_01, observer_02])
+
+    ephemeris = Ephemeris.from_kwargs(
+        orbit_id=pa.array(["00000" for i in range(6)]),
+        object_id=pa.array(["00000" for i in range(6)]),
+        coordinates=SphericalCoordinates.from_kwargs(
+            time=Timestamp.from_kwargs(
+                days=[59000, 59000, 59000, 59000, 59000, 59000],
+                nanos=[9, 999, 999_999, 9, 999, 999_999],
+                scale="utc",
+            ),
+            lon=[0, 0, 0, 0, 0, 0],
+            lat=[0, 0, 0, 0, 0, 0],
+            frame="equatorial",
+            origin=Origin.from_kwargs(
+                code=pa.array(["X05", "X05", "X05", "500", "500", "500"])
+            ),
+        ),
+    )
+
+    linkage = ephemeris.link_to_observers(observers, precision="ns")
+    assert len(linkage.all_unique_values) == 6
+    e1, o1 = linkage.select((59000, 9, "X05"))
+    assert len(e1) == len(o1) == 1
+    e2, o2 = linkage.select((59000, 999, "X05"))
+    assert len(e2) == len(o2) == 1
+    e3, o3 = linkage.select((59000, 999_999, "X05"))
+    assert len(e3) == len(o3) == 1
+    e4, o4 = linkage.select((59000, 9, "500"))
+    assert len(e4) == len(o4) == 1
+    e5, o5 = linkage.select((59000, 999, "500"))
+    assert len(e5) == len(o5) == 1
+    e6, o6 = linkage.select((59000, 999_999, "500"))
+    assert len(e6) == len(o6) == 1
+
+    # Reduce precision to microseconds
+    with pytest.warns(UserWarning):
+        linkage = ephemeris.link_to_observers(observers, precision="us")
+
+    # First two times should be grouped together
+    # Last 2 times should be round-down to the previous microsecond
+    assert len(linkage.all_unique_values) == 4
+    e1, o1 = linkage.select((59000, 0, "X05"))
+    assert len(e1) == len(o1) == 2
+    e2, o2 = linkage.select((59000, 0, "500"))
+    assert len(e2) == len(o2) == 2
+    e3, o3 = linkage.select((59000, 999_000, "X05"))
+    assert len(e3) == len(o3) == 1
+    e4, o4 = linkage.select((59000, 999_000, "500"))
+    assert len(e4) == len(o4) == 1
+
+    # Reduce precision to milliseconds
+    with pytest.warns(UserWarning):
+        linkage = ephemeris.link_to_observers(observers, precision="ms")
+
+    assert len(linkage.all_unique_values) == 2
+    e1, o1 = linkage.select((59000, 0, "X05"))
+    assert len(e1) == len(o1) == 3
+    e2, o2 = linkage.select((59000, 0, "500"))
+    assert len(e2) == len(o2) == 3


### PR DESCRIPTION
This PR changes the generate ephemeris function to return the Ephemeris table. A function `Ephemeris.link_to_observers` was added to support linking back to the input observers. 