### PR TITLE
Add covariance propagation / mapping via sampling

### DIFF
--- a/adam_core/orbits/ephemeris.py
+++ b/adam_core/orbits/ephemeris.py
@@ -20,6 +20,7 @@ class Ephemeris(qv.Table):
     # will be different from its actual geometric coordinates at the time of observation.
     # Aberrated coordinates are coordinates that account for the light travel time
     # from the time of emission/reflection to the time of observation
+    alpha = qv.Float64Column(nullable=True)
     light_time = qv.Float64Column(nullable=True)
     aberrated_coordinates = CartesianCoordinates.as_column(nullable=True)
 

--- a/adam_core/propagator/propagator.py
+++ b/adam_core/propagator/propagator.py
@@ -8,13 +8,14 @@ import quivr as qv
 from ..observers.observers import Observers
 from ..orbits.ephemeris import Ephemeris
 from ..orbits.orbits import Orbits
-from ..orbits.variants import VariantOrbits
+from ..orbits.variants import VariantEphemeris, VariantOrbits
 from ..time import Timestamp
 from .utils import _iterate_chunks
 
 logger = logging.getLogger(__name__)
 
 OrbitType = Union[Orbits, VariantOrbits]
+EphemerisType = Union[Ephemeris, VariantOrbits]
 
 
 def propagation_worker(
@@ -150,7 +151,7 @@ class Propagator(ABC):
     @abstractmethod
     def _generate_ephemeris(
         self, orbits: Orbits, observers: Observers
-    ) -> qv.MultiKeyLinkage[Ephemeris, Observers]:
+    ) -> EphemerisType:
         """
         Generate ephemerides for the given orbits as observed by
         the observers.
@@ -163,6 +164,7 @@ class Propagator(ABC):
         self,
         orbits: Orbits,
         observers: Observers,
+        covariance: bool = False,
         chunk_size: int = 100,
         max_processes: Optional[int] = 1,
     ) -> Ephemeris:
@@ -177,6 +179,11 @@ class Propagator(ABC):
         observers : `~adam_core.observers.observers.Observers` (M)
             Observers for which to generate the ephemerides of each
             orbit.
+        covariance: bool, optional
+            Propagate the covariance matrices of the orbits. This is done by sampling the
+            orbits from their covariance matrices and propagating each sample and for each
+            sample also generating ephemerides. The covariance
+            of the ephemerides is then the covariance of the samples.
         chunk_size : int, optional
             Number of orbits to send to each job.
         max_processes : int or None, optional
@@ -190,24 +197,63 @@ class Propagator(ABC):
             Predicted ephemerides for each orbit observed by each
             observer.
         """
+        # Check if we need to propagate orbit variants so we can propagate covariance
+        # matrices
+        if not orbits.coordinates.covariance.is_all_nan() and covariance is True:
+            variants = VariantOrbits.create(orbits)
+        else:
+            variants = None
+
         if max_processes is None or max_processes > 1:
             with concurrent.futures.ProcessPoolExecutor(
                 max_workers=max_processes
             ) as executor:
+
+                # Add orbits to propagate to futures
                 futures = []
                 for orbit_chunk in _iterate_chunks(orbits, chunk_size):
                     futures.append(
                         executor.submit(ephemeris_worker, orbit_chunk, observers, self)
                     )
 
-                ephemeris_list = []
+                # Add variants to propagate to futures
+                if variants is not None:
+                    for variant_chunk in _iterate_chunks(variants, chunk_size):
+                        futures.append(
+                            executor.submit(
+                                ephemeris_worker, variant_chunk, observers, self
+                            )
+                        )
+
+                ephemeris_list: List[Ephemeris] = []
+                variants_list: List[VariantEphemeris] = []
                 for future in concurrent.futures.as_completed(futures):
-                    ephemeris_list.append(future.result())
+                    result = future.result()
+                    if isinstance(result, Ephemeris):
+                        ephemeris_list.append(result)
+                    elif isinstance(result, VariantEphemeris):
+                        variants_list.append(result)
+                    else:
+                        raise ValueError(
+                            f"Unexpected result type from ephemeris worker: {type(result)}"
+                        )
 
             ephemeris = qv.concatenate(ephemeris_list)
+            if len(variants_list) > 0:
+                ephemeris_variants = qv.concatenate(variants_list)
+            else:
+                ephemeris_variants = None
 
         else:
             ephemeris = self._generate_ephemeris(orbits, observers)
+
+            if variants is not None:
+                ephemeris_variants = self._generate_ephemeris(variants, observers)
+            else:
+                ephemeris_variants = None
+
+        if ephemeris_variants is not None:
+            ephemeris = ephemeris_variants.collapse(ephemeris)
 
         return ephemeris.sort_by(
             [

--- a/adam_core/propagator/propagator.py
+++ b/adam_core/propagator/propagator.py
@@ -10,7 +10,7 @@ from ..orbits.ephemeris import Ephemeris
 from ..orbits.orbits import Orbits
 from ..orbits.variants import VariantOrbits
 from ..time import Timestamp
-from .utils import _iterate_chunks, sort_propagated_orbits
+from .utils import _iterate_chunks
 
 logger = logging.getLogger(__name__)
 
@@ -140,12 +140,12 @@ class Propagator(ABC):
             else:
                 propagated_variants = None
 
-        propagated = sort_propagated_orbits(propagated)
-
         if propagated_variants is not None:
             propagated = propagated_variants.collapse(propagated)
 
-        return propagated
+        return propagated.sort_by(
+            ["orbit_id", "coordinates.time.days", "coordinates.time.nanos"]
+        )
 
     @abstractmethod
     def _generate_ephemeris(


### PR DESCRIPTION
This is based on #81. Similar to propagating orbital covariances, this PR allows orbital covariances to be mapped to ephemerides via sampling. 

For the time-being I have set the default method to monte-carlo, the sigma point code needs to be investigated for optimal parameter selection. There was an array shape bug that was fixed in https://github.com/B612-Asteroid-Institute/adam_core/commit/d9dab91e36bc67ce565403a9e0e17a3c921627e7, that I think impacts the way the random draws were working. 