### PR TITLE
Import astropy.time in time.py

### DIFF
--- a/adam_core/time/time.py
+++ b/adam_core/time/time.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import astropy
+import astropy.time
 import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc


### PR DESCRIPTION
This circumvents an issue with astropy's import of the time subpackage. At import time, astropy.time will check for cached files and download files such as the leapseconds definitions. This only occurs if you explicitly import astropy.time and not astropy.