### PR TITLE
Apply latitude correction and bound SphericalCoordinate residuals

### DIFF
--- a/adam_core/coordinates/tests/test_residuals.py
+++ b/adam_core/coordinates/tests/test_residuals.py
@@ -7,6 +7,7 @@ from ..origin import Origin
 from ..residuals import (
     Residuals,
     _batch_coords_and_covariances,
+    apply_cosine_latitude_correction,
     bound_longitude_residuals,
     calculate_chi2,
 )
@@ -332,6 +333,214 @@ def test_Residuals_calculate_raises_origins():
 
     with pytest.raises(ValueError, match=r"coordinates must have the same origin."):
         Residuals.calculate(observed, predicted)
+
+
+def test_apply_cosine_latitude_correction():
+    # Test that apply_cosine_latitude_correction correctly applies the cosine latitude correction
+    # to the residuals and covariances as a function of the latitude.
+    residual_array = np.array(
+        [
+            [0, 10, 0, 0, 1, 0],
+            [0, 10, 0, 0, 1, 0],
+            [0, 10, 0, 0, 1, 0],
+            [0, 10, 0, 0, 1, 0],
+        ],
+        dtype=np.float64,
+    )
+
+    # Create covariances that are all 1
+    covariance_array = np.ones((4, 6, 6), dtype=np.float64)
+
+    # Cosine of 0 degrees is 1
+    # Cosine of 45 degrees is 1/sqrt(2)
+    # Cosien of 60 degrees is 1/2
+    # Cosine of 90 degrees is 0
+    # The latter represents an unphysical case
+    latitude_array = np.array([0, 45, 60, 90])
+    cos_latitude = np.cos(np.radians(latitude_array))
+    expected_residual_array = np.array(
+        [
+            [0, 10, 0, 0, 1, 0],
+            [0, 10 / np.sqrt(2), 0, 0, 1 / np.sqrt(2), 0],
+            [0, 5, 0, 0, 1 / 2, 0],
+            [0, 0, 0, 0, 0, 0],
+        ],
+        dtype=np.float64,
+    )
+
+    # Covariance matrix elements
+    # rho_rho  (:,0,0), rho_lon  (: 0,1), rho_lat  (:,0,2), rho_vrho  (:,0,3), rho_vlon  (:,0,4), rho_vlat  (:,0,5)
+    # lon_rho  (:,1,0), lon_lon  (:,1,1), lon_lat  (:,1,2), lon_vrho  (:,1,3), lon_vlon  (:,1,4), lon_vlat  (:,1,5)
+    # lat_rho  (:,2,0), lat_lon  (:,2,1), lat_lat  (:,2,2), lat_vrho  (:,2,3), lat_vlon  (:,2,4), lat_vlat  (:,2,5)
+    # vrho_rho (:,3,0), vrho_lon (:,3,1), vrho_lat (:,3,2), vrho_vrho (:,3,3), vrho_vlon (:,3,4), vrho_vlat (:,3,5)
+    # vlon_rho (:,4,0), vlon_lon (:,4,1), vlon_lat (:,4,2), vlon_vrho (:,4,3), vlon_vlon (:,4,4), vlon_vlat (:,4,5)
+    # vlat_rho (:,5,0), vlat_lon (:,5,1), vlat_lat (:,5,2), vlat_vrho (:,5,3), vlat_vlon (:,5,4), vlat_vlat (:,5,5)
+    # The only elements that should change are those rows and columns containing longitude and longitudinal velocity
+    # Not that for cov_lon_lon and cov_vlon_vlon the correction is applied twice as expected (we touch both quantities as
+    # rows and columns)
+    expected_covariance = np.ones_like(covariance_array)
+    expected_covariance[:, :, 1] *= cos_latitude[:, np.newaxis]
+    expected_covariance[:, :, 4] *= cos_latitude[:, np.newaxis]
+    expected_covariance[:, 1, :] *= cos_latitude[:, np.newaxis]
+    expected_covariance[:, 4, :] *= cos_latitude[:, np.newaxis]
+
+    corrected_residuals, corrected_covariances = apply_cosine_latitude_correction(
+        latitude_array, residual_array, covariance_array
+    )
+
+    # Test that the residuals are corrected correctly
+    np.testing.assert_almost_equal(
+        corrected_residuals, expected_residual_array, decimal=15
+    )
+
+    # Test that the covariances are corrected correctly
+    np.testing.assert_almost_equal(
+        corrected_covariances, expected_covariance, decimal=15
+    )
+
+    # Add additional assertions for clarity
+    # The above are sufficient to test the code but obfuscate the linear algebra
+
+    # We expect that the first covariance matrix is completely unchanged
+    np.testing.assert_equal(corrected_covariances[:, 0, 0], covariance_array[:, 0, 0])
+
+    # Define the expected diagonal and off-diagonal elements that would have changed
+    expected_covariates = np.array([1, 1 / np.sqrt(2), 1 / 2, 0])
+    expected_variates = expected_covariates**2
+
+    # Test_cov_lon_rho and rho_lon (1, 2)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 1, 0], expected_covariates, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 0, 1], expected_covariates, decimal=15
+    )
+    # Test cov_lon_lon (3)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 1, 1], expected_variates, decimal=15
+    )
+    # Test cov_lon_lat and lat_lon (4, 5)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 1, 2], expected_covariates, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 2, 1], expected_covariates, decimal=15
+    )
+    # Test cov_lon_vrho and vrho_lon (6, 7)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 1, 3], expected_covariates, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 3, 1], expected_covariates, decimal=15
+    )
+    # Test cov_lon_vlon and vlon_lon (8, 9) - note that this is applied twice
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 1, 4], expected_variates, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 4, 1], expected_variates, decimal=15
+    )
+    # Test cov_lon_vlat and vlat_lon (10, 11)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 1, 5], expected_covariates, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 5, 1], expected_covariates, decimal=15
+    )
+
+    # Test cov_vlon_rho and rho_vlon (12, 13)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 4, 0], expected_covariates, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 0, 4], expected_covariates, decimal=15
+    )
+    # Test cov_vlon_lat and lat_vlon (14, 15)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 4, 2], expected_covariates, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 2, 4], expected_covariates, decimal=15
+    )
+    # Test cov_vlon_vlon (16)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 4, 4], expected_variates, decimal=15
+    )
+    # Test cov vlon_vrho and vrho_vlon (17, 18)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 4, 3], expected_covariates, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 3, 4], expected_covariates, decimal=15
+    )
+    # Test cov_vlon_vlat and vlat_vlon (19, 20)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 4, 5], expected_covariates, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 5, 4], expected_covariates, decimal=15
+    )
+
+    # Define the expected diagonal and off-diagonal elements that would not have changed
+    expected_covariates_unchanged = expected_variates_unchanged = np.ones(4)
+    # Test cov_rho_rho (21)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 0, 0], expected_variates_unchanged, decimal=15
+    )
+    # Test cov_rho_lat and lat_rho (22, 23)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 0, 2], expected_covariates_unchanged, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 2, 0], expected_covariates_unchanged, decimal=15
+    )
+    # Test cov_rho_vrho and vrho_rho (24, 25)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 0, 3], expected_covariates_unchanged, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 3, 0], expected_covariates_unchanged, decimal=15
+    )
+    # Test cov_rho_vlat and vlat_rho (26, 27)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 0, 5], expected_covariates_unchanged, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 5, 0], expected_covariates_unchanged, decimal=15
+    )
+    # Test cov_lat_lat (28)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 2, 2], expected_variates_unchanged, decimal=15
+    )
+    # Test cov_lat_vrho and vrho_lat (29, 30)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 2, 3], expected_covariates_unchanged, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 3, 2], expected_covariates_unchanged, decimal=15
+    )
+    # Test cov_lat_vlat and vlat_lat (31, 32)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 2, 5], expected_covariates_unchanged, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 5, 2], expected_covariates_unchanged, decimal=15
+    )
+    # Test cov_vrho_vrho (33)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 3, 3], expected_variates_unchanged, decimal=15
+    )
+    # Test cov_vrho_vlat and vlat_vrho (34, 35)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 3, 5], expected_covariates_unchanged, decimal=15
+    )
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 5, 3], expected_covariates_unchanged, decimal=15
+    )
+    # Test cov_vlat_vlat (36)
+    np.testing.assert_almost_equal(
+        corrected_covariances[:, 5, 5], expected_variates_unchanged, decimal=15
+    )
 
 
 def test_bound_longitude_residuals():


### PR DESCRIPTION
Residuals in SphericalCoordinates require a bit of special care. This PR adds a few main changes:
- Residuals in spherical coordinates are bounded to [-180, 180] degrees in longitude (the sign is also corrected for residuals across the 0/360 boundary). 
- A cosine latitude correction factor is applied to longitude and longitudinal velocity residuals
- The same cosine latitude correction factor is applied to the covariance matrices