### PR TITLE
Fix orbital period property

### DIFF
--- a/adam_core/coordinates/cometary.py
+++ b/adam_core/coordinates/cometary.py
@@ -168,7 +168,7 @@ class CometaryCoordinates(qv.Table):
         )
         raise ValueError(err)
 
-    @p.deleter
+    @P.deleter
     def P(self):
         err = (
             "Cannot delete period (P) as it is"

--- a/adam_core/coordinates/cometary.py
+++ b/adam_core/coordinates/cometary.py
@@ -81,7 +81,9 @@ class CometaryCoordinates(qv.Table):
         """
         Semi-major axis.
         """
-        return self.q.to_numpy() / (1 - self.e.to_numpy())
+        from ..dynamics.kepler import calc_semi_major_axis
+
+        return np.array(calc_semi_major_axis(self.q.to_numpy(), self.e.to_numpy()))
 
     @a.setter
     def a(self, value):
@@ -104,7 +106,9 @@ class CometaryCoordinates(qv.Table):
         """
         Apoapsis distance.
         """
-        return self.a.to_numpy() * (1 + self.e.to_numpy())
+        from ..dynamics.kepler import calc_apoapsis_distance
+
+        return np.array(calc_apoapsis_distance(self.a, self.e.to_numpy()))
 
     @Q.setter
     def Q(self, value):
@@ -127,7 +131,9 @@ class CometaryCoordinates(qv.Table):
         """
         Semi-latus rectum.
         """
-        return self.a.to_numpy() / (1 - self.e.to_numpy() ** 2)
+        from ..dynamics.kepler import calc_semi_latus_rectum
+
+        return np.array(calc_semi_latus_rectum(self.a, self.e.to_numpy()))
 
     @p.setter
     def p(self, value):
@@ -150,7 +156,9 @@ class CometaryCoordinates(qv.Table):
         """
         Period.
         """
-        return np.sqrt(4 * np.pi**2 * self.a.to_numpy() ** 3 / self.origin.mu)
+        from ..dynamics.kepler import calc_period
+
+        return np.array(calc_period(self.a, self.origin.mu()))
 
     @P.setter
     def P(self, value):
@@ -165,6 +173,31 @@ class CometaryCoordinates(qv.Table):
         err = (
             "Cannot delete period (P) as it is"
             " derived from the semi-major axis (a) and gravitational parameter (mu)."
+        )
+        raise ValueError(err)
+
+    @property
+    def n(self):
+        """
+        Mean motion in degrees.
+        """
+        from ..dynamics.kepler import calc_mean_motion
+
+        return np.degrees(np.array(calc_mean_motion(self.a, self.origin.mu())))
+
+    @n.setter
+    def n(self, value):
+        err = (
+            "Cannot set mean motion (n) as it is"
+            " derived from semi-major axis (a) and gravitational parameter (mu)."
+        )
+        raise ValueError(err)
+
+    @n.deleter
+    def n(self):
+        err = (
+            "Cannot delete mean motion (n) as it is"
+            " derived from semi-major axis (a) and gravitational parameter (mu)."
         )
         raise ValueError(err)
 

--- a/adam_core/coordinates/keplerian.py
+++ b/adam_core/coordinates/keplerian.py
@@ -77,7 +77,9 @@ class KeplerianCoordinates(qv.Table):
         """
         Periapsis distance.
         """
-        return self.a.to_numpy() * (1 - self.e.to_numpy())
+        from ..dynamics.kepler import calc_periapsis_distance
+
+        return np.array(calc_periapsis_distance(self.a.to_numpy(), self.e.to_numpy()))
 
     @q.setter
     def q(self, value):
@@ -100,7 +102,9 @@ class KeplerianCoordinates(qv.Table):
         """
         Apoapsis distance.
         """
-        return self.a.to_numpy() * (1 + self.e.to_numpy())
+        from ..dynamics.kepler import calc_apoapsis_distance
+
+        return np.array(calc_apoapsis_distance(self.a.to_numpy(), self.e.to_numpy()))
 
     @Q.setter
     def Q(self, value):
@@ -123,7 +127,9 @@ class KeplerianCoordinates(qv.Table):
         """
         Semi-latus rectum.
         """
-        return self.a.to_numpy() / (1 - self.e.to_numpy() ** 2)
+        from ..dynamics.kepler import calc_semi_latus_rectum
+
+        return np.array(calc_semi_latus_rectum(self.a.to_numpy(), self.e.to_numpy()))
 
     @p.setter
     def p(self, value):
@@ -146,7 +152,9 @@ class KeplerianCoordinates(qv.Table):
         """
         Period.
         """
-        return np.sqrt(4 * np.pi**2 * self.a.to_numpy() ** 3 / self.origin.mu)
+        from ..dynamics.kepler import calc_period
+
+        return np.array(calc_period(self.a.to_numpy(), self.origin.mu()))
 
     @P.setter
     def P(self, value):
@@ -160,6 +168,33 @@ class KeplerianCoordinates(qv.Table):
     def P(self):
         err = (
             "Cannot delete period (P) as it is"
+            " derived from semi-major axis (a) and gravitational parameter (mu)."
+        )
+        raise ValueError(err)
+
+    @property
+    def n(self):
+        """
+        Mean motion in degrees.
+        """
+        from ..dynamics.kepler import calc_mean_motion
+
+        return np.degrees(
+            np.array(calc_mean_motion(self.a.to_numpy(), self.origin.mu()))
+        )
+
+    @n.setter
+    def n(self, value):
+        err = (
+            "Cannot set mean motion (n) as it is"
+            " derived from semi-major axis (a) and gravitational parameter (mu)."
+        )
+        raise ValueError(err)
+
+    @n.deleter
+    def n(self):
+        err = (
+            "Cannot delete mean motion (n) as it is"
             " derived from semi-major axis (a) and gravitational parameter (mu)."
         )
         raise ValueError(err)

--- a/adam_core/coordinates/keplerian.py
+++ b/adam_core/coordinates/keplerian.py
@@ -164,7 +164,7 @@ class KeplerianCoordinates(qv.Table):
         )
         raise ValueError(err)
 
-    @p.deleter
+    @P.deleter
     def P(self):
         err = (
             "Cannot delete period (P) as it is"

--- a/adam_core/coordinates/tests/test_cometary.py
+++ b/adam_core/coordinates/tests/test_cometary.py
@@ -1,0 +1,130 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from ...time import Timestamp
+from ..cometary import CometaryCoordinates
+from ..origin import Origin
+
+
+@pytest.fixture
+def cometary_elements(orbital_elements):
+    return CometaryCoordinates.from_kwargs(
+        q=orbital_elements["q"],
+        e=orbital_elements["e"],
+        i=orbital_elements["incl"],
+        raan=orbital_elements["Omega"],
+        ap=orbital_elements["w"],
+        tp=orbital_elements["tp_mjd"],
+        time=Timestamp.from_mjd(orbital_elements["mjd_tdb"].values, scale="tdb"),
+        origin=Origin.from_kwargs(code=["SUN"] * len(orbital_elements)),
+        frame="ecliptic",
+    )
+
+
+def test_CometaryCoordinates_period(cometary_elements, orbital_elements):
+    # Test that the period calculated from Cometary elements matches the
+    # period in the test data.
+    P_desired = orbital_elements["P"]
+    # For parabolic/hyperbolic orbits, orbital period is infinite
+    # Our test data from JPL Horizons uses a value of 1e99 for infinite
+    P_desired = np.where(P_desired > 1e99, np.inf, P_desired)
+    P_actual = cometary_elements.P
+    npt.assert_allclose(P_actual, P_desired, rtol=0.0, atol=1e-10)
+
+
+def test_CometaryCoordinates_period_setter(cometary_elements):
+    # Assert that we cannot set the period
+    with pytest.raises(ValueError, match="Cannot set period (P)*"):
+        cometary_elements.P = np.full(len(cometary_elements), np.nan)
+
+
+def test_CometaryCoordinates_period_deleter(cometary_elements):
+    # Assert that we cannot delete the period
+    with pytest.raises(ValueError, match="Cannot delete period (P)*"):
+        del cometary_elements.P
+
+
+def test_CometaryCoordinates_apoapsis_distance(cometary_elements, orbital_elements):
+    # Test that the apoapsis distance calculated from Cometary elements
+    # matches the apoapsis distance in the test data.
+    Q_desired = orbital_elements["Q"]
+    # For parabolic/hyperbolic orbits, apoapsis distance is infinite
+    # Our test data from JPL Horizons uses a value of 1e99 for infinite
+    Q_desired = np.where(Q_desired > 1e99, np.inf, Q_desired)
+    Q_actual = cometary_elements.Q
+    npt.assert_allclose(Q_actual, Q_desired, rtol=0.0, atol=1e-12)
+
+
+def test_CometaryCoordinates_apoapsis_distance_setter(cometary_elements):
+    # Assert that we cannot set the apoapsis distance
+    with pytest.raises(ValueError, match="Cannot set apoapsis distance (Q)*"):
+        cometary_elements.Q = np.full(len(cometary_elements), np.nan)
+
+
+def test_CometaryCoordinates_apoapsis_distance_deleter(cometary_elements):
+    # Assert that we cannot delete the apoapsis distance
+    with pytest.raises(ValueError, match="Cannot delete apoapsis distance (Q)*"):
+        del cometary_elements.Q
+
+
+def test_CometaryCoordinates_semi_major_axis(cometary_elements, orbital_elements):
+    # Test that the semi-major axis calculated from Cometary elements
+    # matches the semi-major axis in the test data.
+    a_desired = orbital_elements["a"]
+    a_actual = cometary_elements.a
+    npt.assert_allclose(a_actual, a_desired, rtol=0.0, atol=1e-12)
+
+
+def test_CometaryCoordinates_semi_major_axis_setter(cometary_elements):
+    # Assert that we cannot set the semi-major axis
+    with pytest.raises(ValueError, match="Cannot set semi-major axis (a)*"):
+        cometary_elements.a = np.full(len(cometary_elements), np.nan)
+
+
+def test_CometaryCoordinates_semi_major_axis_deleter(cometary_elements):
+    # Assert that we cannot delete the semi-major axis
+    with pytest.raises(ValueError, match="Cannot delete semi-major axis (a)*"):
+        del cometary_elements.a
+
+
+def test_CometaryCoordinates_semi_latus_rectum(cometary_elements, orbital_elements):
+    # Test that the semi-latus rectum calculated from Cometary elements
+    # matches the semi-latus rectum in the test data.
+    a = orbital_elements["a"].values
+    e = orbital_elements["e"].values
+    p_desired = (1 - e**2) * a
+    p_actual = cometary_elements.p
+    npt.assert_allclose(p_actual, p_desired, rtol=0.0, atol=1e-12)
+
+
+def test_CometaryCoordinates_semi_latus_rectum_setter(cometary_elements):
+    # Assert that we cannot set the semi-latus rectum
+    with pytest.raises(ValueError, match="Cannot set semi-latus rectum (p)*"):
+        cometary_elements.p = np.full(len(cometary_elements), np.nan)
+
+
+def test_CometaryCoordinates_semi_latus_rectum_deleter(cometary_elements):
+    # Assert that we cannot delete the semi-latus rectum
+    with pytest.raises(ValueError, match="Cannot delete semi-latus rectum (p)*"):
+        del cometary_elements.p
+
+
+def test_CometaryCoordinates_mean_motion(cometary_elements, orbital_elements):
+    # Test that the mean motion calculated from Cometary elements
+    # matches the mean motion in the test data.
+    n_desired = orbital_elements["n"]
+    n_actual = cometary_elements.n
+    npt.assert_allclose(n_actual, n_desired, rtol=0.0, atol=1e-12)
+
+
+def test_CometaryCoordinates_mean_motion_setter(cometary_elements):
+    # Assert that we cannot set the mean motion
+    with pytest.raises(ValueError, match="Cannot set mean motion (n)*"):
+        cometary_elements.n = np.full(len(cometary_elements), np.nan)
+
+
+def test_CometaryCoordinates_mean_motion_deleter(cometary_elements):
+    # Assert that we cannot delete the mean motion
+    with pytest.raises(ValueError, match="Cannot delete mean motion (n)*"):
+        del cometary_elements.n

--- a/adam_core/coordinates/tests/test_keplerian.py
+++ b/adam_core/coordinates/tests/test_keplerian.py
@@ -1,0 +1,130 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from ...time import Timestamp
+from ..keplerian import KeplerianCoordinates
+from ..origin import Origin
+
+
+@pytest.fixture
+def keplerian_elements(orbital_elements):
+    return KeplerianCoordinates.from_kwargs(
+        a=orbital_elements["a"],
+        e=orbital_elements["e"],
+        i=orbital_elements["incl"],
+        raan=orbital_elements["Omega"],
+        ap=orbital_elements["w"],
+        M=orbital_elements["M"],
+        time=Timestamp.from_mjd(orbital_elements["mjd_tdb"].values, scale="tdb"),
+        origin=Origin.from_kwargs(code=["SUN"] * len(orbital_elements)),
+        frame="ecliptic",
+    )
+
+
+def test_KeplerianCoordinates_period(keplerian_elements, orbital_elements):
+    # Test that the period calculated from Keplerian elements matches the
+    # period in the test data.
+    P_desired = orbital_elements["P"]
+    # For parabolic/hyperbolic orbits, orbital period is infinite
+    # Our test data from JPL Horizons uses a value of 1e99 for infinite
+    P_desired = np.where(P_desired > 1e99, np.inf, P_desired)
+    P_actual = keplerian_elements.P
+    npt.assert_allclose(P_actual, P_desired, rtol=0.0, atol=1e-10)
+
+
+def test_KeplerianCoordinates_period_setter(keplerian_elements):
+    # Assert that we cannot set the period
+    with pytest.raises(ValueError, match="Cannot set period (P)*"):
+        keplerian_elements.P = np.full(len(keplerian_elements), np.nan)
+
+
+def test_KeplerianCoordinates_period_deleter(keplerian_elements):
+    # Assert that we cannot delete the period
+    with pytest.raises(ValueError, match="Cannot delete period (P)*"):
+        del keplerian_elements.P
+
+
+def test_KeplerianCoordinates_perapsis_distance(keplerian_elements, orbital_elements):
+    # Test that the periapsis distance calculated from Keplerian elements
+    # matches the periapsis distance in the test data.
+    q_desired = orbital_elements["q"]
+    q_actual = keplerian_elements.q
+    npt.assert_allclose(q_actual, q_desired, rtol=0.0, atol=1e-12)
+
+
+def test_KeplerianCoordinates_perapsis_distance_setter(keplerian_elements):
+    # Assert that we cannot set the periapsis distance
+    with pytest.raises(ValueError, match="Cannot set periapsis distance (q)*"):
+        keplerian_elements.q = np.full(len(keplerian_elements), np.nan)
+
+
+def test_KeplerianCoordinates_perapsis_distance_deleter(keplerian_elements):
+    # Assert that we cannot delete the periapsis distance
+    with pytest.raises(ValueError, match="Cannot delete periapsis distance (q)*"):
+        del keplerian_elements.q
+
+
+def test_KeplerianCoordinates_apoapsis_distance(keplerian_elements, orbital_elements):
+    # Test that the apoapsis distance calculated from Keplerian elements
+    # matches the apoapsis distance in the test data.
+    Q_desired = orbital_elements["Q"]
+    # For parabolic/hyperbolic orbits, apoapsis distance is infinite
+    # Our test data from JPL Horizons uses a value of 1e99 for infinite
+    Q_desired = np.where(Q_desired > 1e99, np.inf, Q_desired)
+    Q_actual = keplerian_elements.Q
+    npt.assert_allclose(Q_actual, Q_desired, rtol=0.0, atol=1e-12)
+
+
+def test_KeplerianCoordinates_apoapsis_distance_setter(keplerian_elements):
+    # Assert that we cannot set the apoapsis distance
+    with pytest.raises(ValueError, match="Cannot set apoapsis distance (Q)*"):
+        keplerian_elements.Q = np.full(len(keplerian_elements), np.nan)
+
+
+def test_KeplerianCoordinates_apoapsis_distance_deleter(keplerian_elements):
+    # Assert that we cannot delete the apoapsis distance
+    with pytest.raises(ValueError, match="Cannot delete apoapsis distance (Q)*"):
+        del keplerian_elements.Q
+
+
+def test_KeplerianCoordinates_semi_latus_rectum(keplerian_elements, orbital_elements):
+    # Test that the semi-latus rectum calculated from Keplerian elements
+    # matches the semi-latus rectum in the test data.
+    a = orbital_elements["a"].values
+    e = orbital_elements["e"].values
+    p_desired = (1 - e**2) * a
+    p_actual = keplerian_elements.p
+    npt.assert_allclose(p_actual, p_desired, rtol=0.0, atol=1e-12)
+
+
+def test_KeplerianCoordinates_semi_latus_rectum_setter(keplerian_elements):
+    # Assert that we cannot set the semi-latus rectum
+    with pytest.raises(ValueError, match="Cannot set semi-latus rectum (p)*"):
+        keplerian_elements.p = np.full(len(keplerian_elements), np.nan)
+
+
+def test_KeplerianCoordinates_semi_latus_rectum_deleter(keplerian_elements):
+    # Assert that we cannot delete the semi-latus rectum
+    with pytest.raises(ValueError, match="Cannot delete semi-latus rectum (p)*"):
+        del keplerian_elements.p
+
+
+def test_KeplerianCoordinates_mean_motion(keplerian_elements, orbital_elements):
+    # Test that the mean motion calculated from Keplerian elements
+    # matches the mean motion in the test data.
+    n_desired = orbital_elements["n"]
+    n_actual = keplerian_elements.n
+    npt.assert_allclose(n_actual, n_desired, rtol=0.0, atol=1e-12)
+
+
+def test_KeplerianCoordinates_mean_motion_setter(keplerian_elements):
+    # Assert that we cannot set the mean motion
+    with pytest.raises(ValueError, match="Cannot set mean motion (n)*"):
+        keplerian_elements.n = np.full(len(keplerian_elements), np.nan)
+
+
+def test_KeplerianCoordinates_mean_motion_deleter(keplerian_elements):
+    # Assert that we cannot delete the mean motion
+    with pytest.raises(ValueError, match="Cannot delete mean motion (n)*"):
+        del keplerian_elements.n

--- a/adam_core/coordinates/transform.py
+++ b/adam_core/coordinates/transform.py
@@ -336,7 +336,11 @@ def _cartesian_to_keplerian(
     [1] Bate, R. R; Mueller, D. D; White, J. E. (1971). Fundamentals of Astrodynamics. 1st ed.,
         Dover Publications, Inc. ISBN-13: 978-0486600611
     """
-    from ..dynamics.kepler import calc_mean_anomaly
+    from ..dynamics.kepler import (
+        calc_mean_anomaly,
+        calc_mean_motion,
+        calc_periapsis_distance,
+    )
 
     coords_keplerian = jnp.zeros(13, dtype=jnp.float64)
     r = coords_cartesian[0:3]
@@ -410,7 +414,7 @@ def _cartesian_to_keplerian(
     q = jnp.where(
         (e > (1.0 - FLOAT_TOLERANCE)) & (e < (1.0 + FLOAT_TOLERANCE)),
         p / 2,
-        a * (1 - e),
+        calc_periapsis_distance(a, e),
     )
 
     # Calculate the apoapsis distance (infinite for
@@ -424,7 +428,7 @@ def _cartesian_to_keplerian(
     n = lax.cond(
         (e > (1.0 - FLOAT_TOLERANCE)) & (e < (1.0 + FLOAT_TOLERANCE)),
         lambda a, q: jnp.sqrt(mu / (2 * q**3)),
-        lambda a, q: jnp.sqrt(mu / jnp.abs(a) ** 3),
+        lambda a, q: calc_mean_motion(a, mu),
         a,
         q,
     )

--- a/adam_core/dynamics/kepler.py
+++ b/adam_core/dynamics/kepler.py
@@ -1,12 +1,139 @@
 from typing import Tuple
 
 import jax.numpy as jnp
+import jax.typing as jnpt
 from jax import config, jit, lax
 
 from .barker import solve_barker
 
 config.update("jax_enable_x64", True)
 config.update("jax_platform_name", "cpu")
+
+
+@jit
+def calc_period(a: jnpt.ArrayLike, mu: jnpt.ArrayLike) -> jnpt.ArrayLike:
+    """
+    Calculate the period of an orbit given the semi-major axis and
+    gravitational parameter.
+
+    Parameters
+    ----------
+    a
+        Semi-major axis.
+    mu
+        Gravitational parameter.
+
+    Returns
+    -------
+    P
+        Period.
+    """
+    return jnp.where(a < 0.0, jnp.inf, 2 * jnp.pi * jnp.sqrt(a**3 / mu))
+
+
+@jit
+def calc_periapsis_distance(a: jnpt.ArrayLike, e: jnpt.ArrayLike) -> jnpt.ArrayLike:
+    """
+    Calculate the periapsis distance of an orbit given the semi-major axis and
+    eccentricity.
+
+    Parameters
+    ----------
+    a
+        Semi-major axis.
+    e
+        Eccentricity.
+
+    Returns
+    -------
+    q
+        Periapsis distance.
+    """
+    return a * (1 - e)
+
+
+@jit
+def calc_apoapsis_distance(a: jnpt.ArrayLike, e: jnpt.ArrayLike) -> jnpt.ArrayLike:
+    """
+    Calculate the apoapsis distance of an orbit given the semi-major axis and
+    eccentricity.
+
+    Parameters
+    ----------
+    a
+        Semi-major axis.
+    e
+        Eccentricity.
+
+    Returns
+    -------
+    Q
+        Apoapsis distance.
+    """
+    return jnp.where(e >= 1.0, jnp.inf, a * (1 + e))
+
+
+@jit
+def calc_semi_major_axis(q: jnpt.ArrayLike, e: jnpt.ArrayLike) -> jnpt.ArrayLike:
+    """
+    Calculate the semi-major axis of an orbit given the periapsis distance and
+    eccentricity.
+
+    Parameters
+    ----------
+    q
+        Periapsis distance.
+    e
+        Eccentricity.
+
+    Returns
+    -------
+    a
+        Semi-major axis.
+    """
+    return q / (1 - e)
+
+
+@jit
+def calc_semi_latus_rectum(a: jnpt.ArrayLike, e: jnpt.ArrayLike) -> jnpt.ArrayLike:
+    """
+    Calculate the semi-latus rectum of an orbit given the semi-major axis and
+    eccentricity.
+
+    Parameters
+    ----------
+    a
+        Semi-major axis.
+    e
+        Eccentricity.
+
+    Returns
+    -------
+    p
+        Semi-latus rectum.
+    """
+    return a * (1 - e**2)
+
+
+@jit
+def calc_mean_motion(a: jnpt.ArrayLike, mu: jnpt.ArrayLike) -> jnpt.ArrayLike:
+    """
+    Calculate the mean motion of an orbit given the semi-major axis and
+    gravitational parameter.
+
+    Parameters
+    ----------
+    a
+        Semi-major axis.
+    mu
+        Gravitational parameter.
+
+    Returns
+    -------
+    n
+        Mean motion in radians per unit time.
+    """
+    return jnp.sqrt(mu / jnp.abs(a) ** 3)
 
 
 @jit

--- a/adam_core/dynamics/tests/test_kepler.py
+++ b/adam_core/dynamics/tests/test_kepler.py
@@ -1,18 +1,25 @@
 import numpy as np
 import numpy.testing as npt
 
+from ...coordinates.origin import Origin
 from ..kepler import (
     _calc_elliptical_anomalies,
     _calc_hyperbolic_anomalies,
     _calc_parabolic_anomalies,
+    calc_apoapsis_distance,
     calc_mean_anomaly,
+    calc_mean_motion,
+    calc_periapsis_distance,
+    calc_period,
+    calc_semi_latus_rectum,
+    calc_semi_major_axis,
     solve_kepler,
 )
 
 RELATIVE_TOLERANCE = 0.0
 ABSOLUTE_TOLERANCE = 1e-15
 
-# --- Tests last updated: 2023-06-14
+# --- Tests last updated: 2023-12-18
 
 
 def test_calc_mean_anomaly_elliptical():
@@ -218,3 +225,71 @@ def test_solve_kepler_hyperbolic_orbits(orbital_elements):
     for e_i, M_i, nu_desired_i in zip(e, M, nu_desired):
         nu_actual = np.degrees(solve_kepler(e_i, np.radians(M_i)))
         npt.assert_allclose(nu_actual, nu_desired_i, rtol=0.0, atol=1e-12)
+
+
+def test_calc_period(orbital_elements):
+    # Test period calculations for elliptical orbits
+    P_desired = orbital_elements["P"]
+    # For parabolic/hyperbolic orbits, orbital period is infinite
+    # Our test data from JPL Horizons uses a value of 1e99 for infinite
+    P_desired = np.where(P_desired > 1e99, np.inf, P_desired)
+    a = orbital_elements["a"].values
+    origin = Origin.from_kwargs(code=np.full(len(orbital_elements), "SUN"))
+    mu = origin.mu()
+
+    P_actual = calc_period(a, mu)
+    npt.assert_allclose(P_actual, P_desired, rtol=0.0, atol=1e-10)
+
+
+def test_calc_periapsis_distance(orbital_elements):
+    # Test periapse distance calculations
+    q_desired = orbital_elements["q"]
+    a = orbital_elements["a"].values
+    e = orbital_elements["e"].values
+
+    q_actual = calc_periapsis_distance(a, e)
+    npt.assert_allclose(q_actual, q_desired, rtol=0.0, atol=1e-12)
+
+
+def test_calc_apoapsis_distance(orbital_elements):
+    # Test apoapsis distance calculations
+    Q_desired = orbital_elements["Q"]
+    # For parabolic/hyperbolic orbits, apoapsis distance is infinite
+    # Our test data from JPL Horizons uses a value of 1e99 for infinite
+    Q_desired = np.where(Q_desired > 1e99, np.inf, Q_desired)
+    a = orbital_elements["a"].values
+    e = orbital_elements["e"].values
+
+    Q_actual = calc_apoapsis_distance(a, e)
+    npt.assert_allclose(Q_actual, Q_desired, rtol=0.0, atol=1e-12)
+
+
+def test_calc_semi_major_axis(orbital_elements):
+    # Test semi-major axis calculations
+    a_desired = orbital_elements["a"]
+    q = orbital_elements["q"].values
+    e = orbital_elements["e"].values
+
+    a_actual = calc_semi_major_axis(q, e)
+    npt.assert_allclose(a_actual, a_desired, rtol=0.0, atol=1e-12)
+
+
+def test_calc_semi_latus_rectum(orbital_elements):
+    # Test semi-latus rectum calculations
+    a = orbital_elements["a"].values
+    e = orbital_elements["e"].values
+    p_desired = (1 - e**2) * a
+
+    p_actual = calc_semi_latus_rectum(a, e)
+    npt.assert_allclose(p_actual, p_desired, rtol=0.0, atol=1e-12)
+
+
+def test_calc_mean_motion(orbital_elements):
+    # Test mean motion calculations
+    n_desired = orbital_elements["n"]
+    a = orbital_elements["a"].values
+    origin = Origin.from_kwargs(code=np.full(len(orbital_elements), "SUN"))
+    mu = origin.mu()
+
+    n_actual = np.degrees(calc_mean_motion(a, mu))
+    npt.assert_allclose(n_actual, n_desired, rtol=0.0, atol=1e-12)

--- a/adam_core/tests/test_ray_cluster.py
+++ b/adam_core/tests/test_ray_cluster.py
@@ -15,7 +15,9 @@ def test_initialize_ray_no_cluster(mocker):
     ]
 
     initialize_use_ray(num_cpus=4, object_store_bytes=1000)
-    mock_ray.init.assert_called_with(dashboard_host="0.0.0.0", num_cpus=4, object_store_memory=1000)
+    mock_ray.init.assert_called_with(
+        dashboard_host="0.0.0.0", num_cpus=4, object_store_memory=1000
+    )
     mock_ray.init.call_count == 1
 
 

--- a/adam_core/tests/test_ray_cluster.py
+++ b/adam_core/tests/test_ray_cluster.py
@@ -15,7 +15,7 @@ def test_initialize_ray_no_cluster(mocker):
     ]
 
     initialize_use_ray(num_cpus=4, object_store_bytes=1000)
-    mock_ray.init.assert_called_with(num_cpus=4, object_store_memory=1000)
+    mock_ray.init.assert_called_with(dashboard_host="0.0.0.0", num_cpus=4, object_store_memory=1000)
     mock_ray.init.call_count == 1
 
 


### PR DESCRIPTION
I noticed a bug in the orbital period property but couldn't figure out what was going on. I've added a bunch of JAX-jitted functions for repeated calculations with unit tests and then implemented those in the Keplerian and Cometary coordinate properties. Turns out the deleter for the orbital period was incorrectly defined. 