### PR TITLE
Add Impacts Module and Update Propagators to allow for namespace packages

### DIFF
--- a/adam_core/coordinates/covariances.py
+++ b/adam_core/coordinates/covariances.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Tuple
+from typing import Callable, Optional, Tuple
 
 import numpy as np
 import pyarrow as pa
@@ -180,7 +180,10 @@ class CoordinateCovariances(qv.Table):
 
 
 def sample_covariance_random(
-    mean: np.ndarray, cov: np.ndarray, num_samples: int = 10000
+    mean: np.ndarray,
+    cov: np.ndarray,
+    num_samples: int = 10000,
+    seed: Optional[int] = None,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Sample a multivariate Gaussian distribution with given
@@ -209,7 +212,7 @@ def sample_covariance_random(
     W_cov: `~numpy.ndarray` (num_samples)
         Weights of the samples to reconstruct covariance matrix.
     """
-    normal = multivariate_normal(mean=mean, cov=cov, allow_singular=True)
+    normal = multivariate_normal(mean=mean, cov=cov, allow_singular=True, seed=seed)
     samples = normal.rvs(num_samples)
     W = np.full(num_samples, 1 / num_samples)
     W_cov = np.full(num_samples, 1 / num_samples)

--- a/adam_core/coordinates/variants.py
+++ b/adam_core/coordinates/variants.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Generic, Literal, Protocol, TypeVar
+from typing import Generic, Literal, Optional, Protocol, TypeVar
 
 import numpy as np
 import pyarrow as pa
@@ -50,6 +50,7 @@ def create_coordinate_variants(
     alpha: float = 1,
     beta: float = 0,
     kappa: float = 0,
+    seed: Optional[int] = None,
 ) -> VariantCoordinatesTable[types.CoordinateType]:
     """
     Sample and create variants for the given coordinates by sampling the covariance matrices.
@@ -97,6 +98,7 @@ def create_coordinate_variants(
         If the covariance matrices are all undefined.
         If the input coordinates are not supported.
     """
+
     if coordinates.covariance.is_all_nan():
         raise ValueError(
             "Cannot sample coordinate covariances when covariances are all undefined."
@@ -141,7 +143,7 @@ def create_coordinate_variants(
 
         elif method == "monte-carlo":
             samples, W, W_cov = sample_covariance_random(
-                mean, cov, num_samples=num_samples
+                mean, cov, num_samples=num_samples, seed=seed
             )
 
         elif method == "auto":

--- a/adam_core/dynamics/impacts.py
+++ b/adam_core/dynamics/impacts.py
@@ -1,0 +1,277 @@
+import importlib.util
+import logging
+from abc import abstractmethod
+from typing import List, Optional, Tuple
+
+import numpy as np
+import pyarrow.compute as pc
+import quivr as qv
+
+from adam_core.coordinates import CartesianCoordinates
+from adam_core.ray_cluster import initialize_use_ray
+
+from ..coordinates.residuals import Residuals
+from ..orbits import Orbits
+from ..orbits.variants import VariantOrbits
+from ..propagator import Propagator
+from ..propagator.propagator import OrbitType
+from ..propagator.utils import _iterate_chunks
+
+logger = logging.getLogger(__name__)
+
+# Test to see that at least one impact-enabled propagator is
+# installed and if not print a warning
+if importlib.util.find_spec("adam_core.propagator.adam_assist") is None:
+    logger.warning(
+        "No impact-enabled propagator installed. Impact calculations will not be possible."
+    )
+
+RAY_INSTALLED = False
+try:
+    import ray
+    from ray import ObjectRef
+
+    RAY_INSTALLED = True
+except ImportError:
+    pass
+
+
+if RAY_INSTALLED:
+
+    @ray.remote
+    def impact_worker_ray(idx_chunk, orbits, propagator_class, num_days):
+        prop = propagator_class()
+        orbits_chunk = orbits.take(idx_chunk)
+        variants, impacts = prop._detect_impacts(orbits_chunk, num_days)
+        return variants, impacts
+
+
+class EarthImpacts(qv.Table):
+    orbit_id = qv.StringColumn()
+    # Distance from earth center in km
+    distance = qv.Float64Column()
+    coordinates = CartesianCoordinates.as_column()
+    variant_id = qv.LargeStringColumn(nullable=True)
+
+
+class ImpactMixin:
+    """
+    `~adam_core.propagator.Propagator` mixin with signature for detecting Earth impacts.
+    Subclasses should implement the _detect_impacts method.
+    """
+
+    @abstractmethod
+    def _detect_impacts(self, orbits: Orbits, num_days: float) -> Orbits:
+        """
+        Detect impacts for the given orbits.
+
+        THIS FUNCTION SHOULD BE DEFINED BY THE USER.
+        """
+        pass
+
+    def detect_impacts(
+        self,
+        orbits: OrbitType,
+        num_days: int,
+        max_processes: Optional[int] = 1,
+        chunk_size: int = 100,
+    ) -> Tuple[OrbitType, EarthImpacts]:
+        """
+        Detect impacts for each orbit in orbits after num_days.
+
+        Parameters
+        ----------
+        orbits : `~adam_core.orbits.orbits.Orbits` (N)
+            Orbits for which to detect impacts.
+        num_days : int
+            Number of days after which to detect impacts.
+        max_processes : int or None, optional
+            Maximum number of processes to launch. If None then the number of
+            processes will be equal to the number of cores on the machine. If 1
+            then no multiprocessing will be used.
+
+        Returns
+        -------
+        propagated : `~adam_core.orbits.OrbitType`
+            The input orbits propagated to the end of simulation.
+        impacts : `~adam_core.orbits.earth_impacts.EarthImpacts`
+            Impacts detected for the orbits.
+        """
+        if max_processes is None or max_processes > 1:
+            impact_list: List[EarthImpacts] = []
+            propagated_list: List[OrbitType] = []
+
+            if RAY_INSTALLED is False:
+                raise ImportError(
+                    "Ray must be installed to use the ray parallel backend"
+                )
+
+            initialize_use_ray(num_cpus=max_processes)
+
+            # Add orbits to object store if
+            # they haven't already been added
+            if not isinstance(orbits, ObjectRef):
+                orbits_ref = ray.put(orbits)
+            else:
+                orbits_ref = orbits
+                # We need to dereference the orbits ObjectRef so we can
+                # check its length for chunking and determine
+                # if we need to propagate variants
+                orbits = ray.get(orbits_ref)
+
+            # Create futures
+            futures = []
+            idx = np.arange(0, len(orbits))
+            for idx_chunk in _iterate_chunks(idx, chunk_size):
+                futures.append(
+                    impact_worker_ray.remote(
+                        idx_chunk, orbits_ref, self.__class__, num_days
+                    )
+                )
+
+            # Get results as they finish (we sort later)
+            unfinished = futures
+            while unfinished:
+                finished, unfinished = ray.wait(unfinished, num_returns=1)
+                (propagated, impacts) = ray.get(finished[0])
+                propagated_list.append(propagated)
+                impact_list.append(impacts)
+
+            propagated = qv.concatenate(propagated_list)
+            impacts = qv.concatenate(impact_list)
+
+        else:
+            propagated, impacts = self._detect_impacts(orbits, num_days)
+
+        return propagated, impacts
+
+
+def calculate_impacts(
+    orbits: Orbits,
+    num_days: int,
+    propagator: Propagator,
+    num_samples: int = 1000,
+    processes: Optional[int] = None,
+    seed: Optional[int] = None,
+):
+    """
+    Calculate the impacts for each variant orbit generated from the input orbits.
+
+    Parameters
+    ----------
+    orbits : `~adam_core.orbits.orbits.Orbits`
+        Orbits for which to calculate impact probabilities.
+    num_days : int
+        Number of days to propagate the orbits.
+    propagator : `~adam_core.propagator.propagator.Propagator`
+        Propagator to use for orbit propagation.
+    num_samples : int, optional
+        Number of samples to take over the period, by default 1000.
+    processes : int, optional
+        Number of processes to use for parallelization, by default all available.
+    seed : int, optional
+        Seed for random number generation, by default None.
+
+    Returns
+    -------
+
+    """
+    assert issubclass(
+        propagator.__class__, ImpactMixin
+    ), "Propagator must support impact detection."
+    logger.info("Generating variants...")
+    variants = VariantOrbits.create(
+        orbits, method="monte-carlo", num_samples=num_samples, seed=seed
+    )
+    logger.info("Detecting impacts...")
+    results, impacts = propagator.detect_impacts(
+        variants,
+        num_days,
+        max_processes=processes,
+    )
+
+    return results, impacts
+
+
+def calculate_impact_probabilities(variants, impacts):
+    """
+    Calculate the impact probabilities for each variant orbit generated from the input orbits.
+    Parameters
+    ----------
+    variants : `~adam_core.orbits.variants.VariantOrbits`
+        Variant orbits for which to calculate impact probabilities.
+    impacts : `~adam_core.orbits.impacts.Impacts`
+        Impacts for the variant orbits.
+    Returns
+    -------
+    impact_probabilities : `~adam_core.orbits.impact_probabilities.ImpactProbabilities`
+        Impact probabilities for the variant orbits.
+    """
+
+    # Loop through the unique set of orbit_ids within variants using quivr
+    unique_orbits = pc.unique(variants.orbit_id).to_pylist()
+
+    ip_dict = {}
+
+    for orbit_id in unique_orbits:
+        mask = pc.equal(variants.orbit_id, orbit_id)
+        variant_masked = variants.table.filter(mask)
+        variant_count = len(variant_masked)
+        impacts_mask = pc.equal(impacts.orbit_id, orbit_id)
+        impacts_masked = impacts.table.filter(impacts_mask)
+        impact_count = len(impacts_masked)
+        ip = impact_count / variant_count
+        ip_dict[orbit_id] = ip
+
+    return ip_dict
+
+
+def return_impacting_variants(variants, impacts):
+    """
+    Link variants to the orbits from which they were generated.
+    Parameters
+    ----------
+    orbits : `~adam_core.orbits.orbits.Orbits`
+        Orbits from which the variants were generated.
+    Returns
+    -------
+    linkage : `~quivr.MultiKeyLinkage[Orbits, VariantOrbits]`
+        Linkage between variants and orbits.
+    """
+
+    return qv.MultiKeyLinkage(
+        impacts,
+        variants,
+        left_keys={
+            "orbit_id": impacts.orbit_id,
+            "variant_id": impacts.variant_id,
+        },
+        right_keys={
+            "orbit_id": variants.orbit_id,
+            "variant_id": variants.variant_id,
+        },
+    )
+
+
+def calculate_mahalanobis_distance(observed_orbit, predicted_orbit):
+    """
+    Calculate the Mahalanobis distance between an observed orbit and a predicted orbit.
+    Parameters
+    ----------
+    observed_orbit : `~adam_core.coordinates.CartesianCoordinates`
+        Observed orbit.
+    observed_covariance : `ndarray`
+        Covariance of the observed orbit.
+    predicted_orbit : `~adam_core.coordinates.CartesianCoordinates`
+        Predicted orbit.
+    Returns
+    -------
+    mahalanobis_distance : `ndarray` (N)
+        Mahalanobis distance between the observed and predicted orbits.
+    """
+
+    residuals = Residuals.calculate(
+        observed_orbit.coordinates, predicted_orbit.coordinates
+    )
+    mahalanobis_distance = np.sqrt(residuals.chi2.to_numpy(zero_copy_only=False))
+    return mahalanobis_distance

--- a/adam_core/dynamics/impacts.py
+++ b/adam_core/dynamics/impacts.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from typing import List, Optional, Tuple
 
 import numpy as np
+import numpy.typing as npt
 import pyarrow.compute as pc
 import quivr as qv
 
@@ -54,6 +55,7 @@ class EarthImpacts(qv.Table):
     coordinates = CartesianCoordinates.as_column()
     variant_id = qv.LargeStringColumn(nullable=True)
 
+
 class ImpactProbabilities(qv.Table):
     orbit_id = qv.LargeStringColumn()
     impacts = qv.Int64Column()
@@ -70,7 +72,9 @@ class ImpactMixin:
     """
 
     @abstractmethod
-    def _detect_impacts(self, orbits: Orbits, num_days: float) -> Tuple[OrbitType, EarthImpacts]:
+    def _detect_impacts(
+        self, orbits: Orbits, num_days: float
+    ) -> Tuple[OrbitType, EarthImpacts]:
         """
         Detect impacts for the given orbits.
 
@@ -202,7 +206,9 @@ def calculate_impacts(
     return results, impacts
 
 
-def calculate_impact_probabilities(variants: VariantOrbits, impacts: EarthImpacts) -> ImpactProbabilities:
+def calculate_impact_probabilities(
+    variants: VariantOrbits, impacts: EarthImpacts
+) -> ImpactProbabilities:
     """
     Calculate the impact probabilities for each variant orbit generated from the input orbits.
     Parameters
@@ -230,7 +236,6 @@ def calculate_impact_probabilities(variants: VariantOrbits, impacts: EarthImpact
         impacts_masked = impacts.select("orbit_id", orbit_id)
         impact_count = len(impacts_masked)
 
-
         ip = ImpactProbabilities.from_kwargs(
             orbit_id=[orbit_id],
             impacts=[impact_count],
@@ -241,7 +246,9 @@ def calculate_impact_probabilities(variants: VariantOrbits, impacts: EarthImpact
         if earth_impact_probabilities is None:
             earth_impact_probabilities = ip
         else:
-            earth_impact_probabilities = qv.concatenate([earth_impact_probabilities, ip])
+            earth_impact_probabilities = qv.concatenate(
+                [earth_impact_probabilities, ip]
+            )
 
     return earth_impact_probabilities
 
@@ -273,7 +280,9 @@ def link_impacting_variants(variants, impacts):
     )
 
 
-def calculate_mahalanobis_distance(observed_orbit: OrbitType, predicted_orbit: OrbitType) -> npt.NDArray[np.float64]:
+def calculate_mahalanobis_distance(
+    observed_orbit: OrbitType, predicted_orbit: OrbitType
+) -> npt.NDArray[np.float64]:
     """
     Calculate the Mahalanobis distance between an observed orbit and a predicted orbit.
     Parameters

--- a/adam_core/dynamics/impacts.py
+++ b/adam_core/dynamics/impacts.py
@@ -253,7 +253,7 @@ def return_impacting_variants(variants, impacts):
     )
 
 
-def calculate_mahalanobis_distance(observed_orbit, predicted_orbit):
+def calculate_mahalanobis_distance(observed_orbit: OrbitType, predicted_orbit: OrbitType) -> npt.NDArray[np.float64]:
     """
     Calculate the Mahalanobis distance between an observed orbit and a predicted orbit.
     Parameters

--- a/adam_core/dynamics/impacts.py
+++ b/adam_core/dynamics/impacts.py
@@ -153,7 +153,7 @@ def calculate_impacts(
     num_samples: int = 1000,
     processes: Optional[int] = None,
     seed: Optional[int] = None,
-):
+) -> Tuple[Orbits, EarthImpacts]:
     """
     Calculate the impacts for each variant orbit generated from the input orbits.
 

--- a/adam_core/dynamics/impacts.py
+++ b/adam_core/dynamics/impacts.py
@@ -61,7 +61,7 @@ class ImpactMixin:
     """
 
     @abstractmethod
-    def _detect_impacts(self, orbits: Orbits, num_days: float) -> Orbits:
+    def _detect_impacts(self, orbits: Orbits, num_days: float) -> Tuple[OrbitType, EarthImpacts]:
         """
         Detect impacts for the given orbits.
 

--- a/adam_core/dynamics/tests/test_impacts.py
+++ b/adam_core/dynamics/tests/test_impacts.py
@@ -8,6 +8,7 @@ from ...time import Timestamp
 from ..impacts import (
     EarthImpacts,
     ImpactMixin,
+    ImpactProbabilities,
     calculate_impact_probabilities,
     calculate_impacts,
     calculate_mahalanobis_distance,
@@ -126,9 +127,14 @@ def test_calculate_impact_probabilities():
     )
 
     ip = calculate_impact_probabilities(variants, impacts)
-    assert ip["1"] == 0.3333333333333333
-    assert ip["2"] == 0.6666666666666666
-    assert ip["3"] == 0.0
+
+    assert ip == ImpactProbabilities.from_kwargs(
+        orbit_id=["1", "2", "3"],
+        impacts=[1, 2, 0],
+        variants=[3, 3, 3],
+        cumulative_probability=[1 / 3, 2 / 3, 0.0],
+    )
+
 
 
 def test_calculate_mahalanobis_distance():

--- a/adam_core/dynamics/tests/test_impacts.py
+++ b/adam_core/dynamics/tests/test_impacts.py
@@ -26,8 +26,6 @@ class MockImpactPropagator(Propagator, ImpactMixin):
 
         # Pick random orbit to impact
         impacted = orbits[0]
-        print(impacted.coordinates.x)
-        print(impacted)
         impact = EarthImpacts.from_kwargs(
             orbit_id=impacted.orbit_id,
             variant_id=impacted.variant_id,

--- a/adam_core/dynamics/tests/test_impacts.py
+++ b/adam_core/dynamics/tests/test_impacts.py
@@ -136,7 +136,6 @@ def test_calculate_impact_probabilities():
     )
 
 
-
 def test_calculate_mahalanobis_distance():
     """ """
     observed_orbit = Orbits.from_kwargs(

--- a/adam_core/dynamics/tests/test_impacts.py
+++ b/adam_core/dynamics/tests/test_impacts.py
@@ -1,0 +1,208 @@
+import numpy as np
+import pyarrow.compute as pc
+
+from ...coordinates import CartesianCoordinates, CoordinateCovariances, Origin
+from ...orbits import Orbits, VariantOrbits
+from ...propagator import Propagator
+from ...time import Timestamp
+from ..impacts import (
+    EarthImpacts,
+    ImpactMixin,
+    calculate_impact_probabilities,
+    calculate_impacts,
+    calculate_mahalanobis_distance,
+)
+
+
+class MockImpactPropagator(Propagator, ImpactMixin):
+    def _propagate_orbits(self, orbits: Orbits, times: Timestamp) -> Orbits:
+        return orbits
+
+    def _detect_impacts(self, orbits: Orbits, num_days: float) -> Orbits:
+        # Artificially set the orbits.coordinates.times to the end time
+        # except for the orbits who impacted
+        new_times = orbits.coordinates.time.add_days(num_days)
+        orbits = orbits.set_column("coordinates.time", new_times)
+
+        # Pick random orbit to impact
+        impacted = orbits[0]
+        print(impacted.coordinates.x)
+        print(impacted)
+        impact = EarthImpacts.from_kwargs(
+            orbit_id=impacted.orbit_id,
+            variant_id=impacted.variant_id,
+            coordinates=CartesianCoordinates.from_kwargs(
+                x=impacted.coordinates.x,
+                y=impacted.coordinates.y,
+                z=impacted.coordinates.z,
+                vx=impacted.coordinates.vx,
+                vy=impacted.coordinates.vy,
+                vz=impacted.coordinates.vz,
+                time=impacted.coordinates.time,
+                origin=impacted.coordinates.origin,
+                frame=impacted.coordinates.frame,
+            ),
+            distance=[0.0],
+        )
+
+        return orbits, impact
+
+
+def test_calculate_impacts():
+    """
+    Tests the i/o of calculate_impacts
+    """
+    orbits = Orbits.from_kwargs(
+        orbit_id=["1", "2", "3"],
+        object_id=["1", "2", "3"],
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=[1.0, 2.0, 3.0],
+            y=[1.0, 2.0, 3.0],
+            z=[1.0, 2.0, 3.0],
+            vx=[1.0, 2.0, 3.0],
+            vy=[1.0, 2.0, 3.0],
+            vz=[1.0, 2.0, 3.0],
+            time=Timestamp.from_iso8601(["2020-01-01T00:00:00"] * 3),
+            origin=Origin.from_kwargs(code=["SUN"] * 3),
+            frame="ecliptic",
+            covariance=CoordinateCovariances.from_sigmas(
+                np.array(
+                    [
+                        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                    ]
+                )
+            ),
+        ),
+    )
+
+    prop = MockImpactPropagator()
+    variants, impacts = calculate_impacts(
+        orbits, 10, prop, num_samples=1000, processes=1, seed=42
+    )
+    assert pc.all(
+        pc.equal(
+            variants.coordinates.time.mjd().to_pylist(),
+            orbits[0].coordinates.time.add_days(10).mjd().to_pylist()[0],
+        )
+    )
+
+
+def test_calculate_impact_probabilities():
+    """
+    Tests the i/o of calculate_impact_probabilities
+    """
+    variants = VariantOrbits.from_kwargs(
+        orbit_id=["1", "1", "1", "2", "2", "2", "3", "3", "3"],
+        object_id=["1", "1", "1", "2", "2", "2", "3", "3", "3"],
+        variant_id=["1", "2", "3", "1", "2", "3", "1", "2", "3"],
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=[1.0, 2.0, 3.0] * 3,
+            y=[1.0, 2.0, 3.0] * 3,
+            z=[1.0, 2.0, 3.0] * 3,
+            vx=[1.0, 2.0, 3.0] * 3,
+            vy=[1.0, 2.0, 3.0] * 3,
+            vz=[1.0, 2.0, 3.0] * 3,
+            time=Timestamp.from_iso8601(["2020-01-01T00:00:00"] * 9),
+            origin=Origin.from_kwargs(code=["SUN"] * 9),
+            frame="ecliptic",
+        ),
+    )
+
+    impacts = EarthImpacts.from_kwargs(
+        orbit_id=["1", "2", "2"],
+        variant_id=["1", "1", "2"],
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=[1.0, 2.0, 3.0],
+            y=[1.0, 2.0, 3.0],
+            z=[1.0, 2.0, 3.0],
+            vx=[1.0, 2.0, 3.0],
+            vy=[1.0, 2.0, 3.0],
+            vz=[1.0, 2.0, 3.0],
+            time=Timestamp.from_iso8601(["2020-01-01T00:00:00"] * 3),
+            origin=Origin.from_kwargs(code=["SUN"] * 3),
+            frame="ecliptic",
+        ),
+        distance=[0.0, 0.0, 0.0],
+    )
+
+    ip = calculate_impact_probabilities(variants, impacts)
+    assert ip["1"] == 0.3333333333333333
+    assert ip["2"] == 0.6666666666666666
+    assert ip["3"] == 0.0
+
+
+def test_calculate_mahalanobis_distance():
+    """ """
+    observed_orbit = Orbits.from_kwargs(
+        orbit_id=["1", "1", "1"],
+        object_id=["1", "1", "1"],
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=[1.0, 2.0, 3.0],
+            y=[1.0, 2.0, 3.0],
+            z=[1.0, 2.0, 3.0],
+            vx=[1.0, 2.0, 3.0],
+            vy=[1.0, 2.0, 3.0],
+            vz=[1.0, 2.0, 3.0],
+            time=Timestamp.from_iso8601(["2020-01-01T00:00:00"] * 3),
+            origin=Origin.from_kwargs(code=["SUN"] * 3),
+            frame="ecliptic",
+            covariance=CoordinateCovariances.from_sigmas(
+                np.array(
+                    [
+                        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                    ]
+                )
+            ),
+        ),
+    )
+
+    predicted_orbit = Orbits.from_kwargs(
+        orbit_id=["1", "1", "1"],
+        object_id=["1", "1", "1"],
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=[1.0, 2.0, 3.0],
+            y=[1.0, 2.0, 3.0],
+            z=[1.0, 2.0, 3.0],
+            vx=[1.0, 2.0, 3.0],
+            vy=[1.0, 2.0, 3.0],
+            vz=[1.0, 2.0, 3.0],
+            time=Timestamp.from_iso8601(["2020-01-01T00:00:00"] * 3),
+            origin=Origin.from_kwargs(code=["SUN"] * 3),
+            frame="ecliptic",
+        ),
+    )
+
+    md = calculate_mahalanobis_distance(observed_orbit, predicted_orbit)
+    assert np.all(md == 0.0)
+
+    less_perfect_observed_orbit = Orbits.from_kwargs(
+        orbit_id=["1", "1", "1"],
+        object_id=["1", "1", "1"],
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=[1.1, 2.1, 3.1],
+            y=[1.1, 2.1, 3.1],
+            z=[1.1, 2.1, 3.1],
+            vx=[1.1, 2.1, 3.1],
+            vy=[1.1, 2.1, 3.1],
+            vz=[1.1, 2.1, 3.1],
+            time=Timestamp.from_iso8601(["2020-01-01T00:00:00"] * 3),
+            origin=Origin.from_kwargs(code=["SUN"] * 3),
+            frame="ecliptic",
+            covariance=CoordinateCovariances.from_sigmas(
+                np.array(
+                    [
+                        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                    ]
+                )
+            ),
+        ),
+    )
+
+    md = calculate_mahalanobis_distance(less_perfect_observed_orbit, predicted_orbit)
+    np.testing.assert_almost_equal(md, np.array([0.24494897, 0.24494897, 0.24494897]))

--- a/adam_core/dynamics/tisserand.py
+++ b/adam_core/dynamics/tisserand.py
@@ -13,6 +13,7 @@ for i, r in elements[["targetname", "a"]].iterrows():
    MAJOR_BODIES[body_name] = r["a"]
 
 """
+
 import numpy as np
 
 MAJOR_BODIES = {

--- a/adam_core/orbit_determination/differential_correction.py
+++ b/adam_core/orbit_determination/differential_correction.py
@@ -75,7 +75,7 @@ def fit_least_squares(
     observations: OrbitDeterminationObservations,
     propagator: Propagator,
     ignore: Optional[List[str]] = None,
-    **kwargs
+    **kwargs,
 ) -> Tuple[FittedOrbits, FittedOrbitMembers]:
     """
     Differentially correct a fitted orbit using least squares. correct a fitted orbit using least squares.

--- a/adam_core/orbits/__init__.py
+++ b/adam_core/orbits/__init__.py
@@ -1,13 +1,11 @@
 # flake8: noqa: F401
 
 # TODO: calc_orbit_class does not work currently, but would be nice as a method on Orbits
-from .classification import calc_orbit_class
 from .ephemeris import Ephemeris
 from .orbits import Orbits
 from .variants import VariantOrbits
 
 __all__ = [
-    "calc_orbit_class",
     "Ephemeris",
     "Orbits",
     "VariantOrbits",

--- a/adam_core/propagator/propagator.py
+++ b/adam_core/propagator/propagator.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 import logging
 from abc import ABC, abstractmethod
 from typing import List, Literal, Optional, Type, Union
@@ -84,227 +83,11 @@ if RAY_INSTALLED:
         return ephemeris
 
 
-class Propagator(ABC):
+class EphemerisMixin:
     """
-    Class for propagating orbits and generating ephemerides. Subclasses
-    should implement the _propagate_orbits and _generate_ephemeris methods.
-
-    Important: subclasses should be pickleable! As this class uses multiprocessing
-    to parallelize propagation and ephemeris generation. This means that
-    subclasses should not have any unpickleable attributes.
-
-
+    Mixin with signature for generating ephemerides.
+    Subclasses should implement the _generate_ephemeris method.
     """
-
-    @abstractmethod
-    def _propagate_orbits(self, orbits: OrbitType, times: TimestampType) -> OrbitType:
-        """
-        Propagate orbits to times.
-
-        THIS FUNCTION SHOULD BE DEFINED BY THE USER.
-        """
-        pass
-
-    def propagate_orbits(
-        self,
-        orbits: OrbitType,
-        times: TimestampType,
-        covariance: bool = False,
-        covariance_method: Literal[
-            "auto", "sigma-point", "monte-carlo"
-        ] = "monte-carlo",
-        num_samples: int = 1000,
-        chunk_size: int = 100,
-        max_processes: Optional[int] = 1,
-        parallel_backend: Literal["cf", "ray"] = "ray",
-    ) -> Orbits:
-        """
-        Propagate each orbit in orbits to each time in times.
-
-        Parameters
-        ----------
-        orbits : `~adam_core.orbits.orbits.Orbits` (N)
-            Orbits to propagate.
-        times : Timestamp (M)
-            Times to which to propagate orbits.
-        covariance : bool, optional
-            Propagate the covariance matrices of the orbits. This is done by sampling the
-            orbits from their covariance matrices and propagating each sample. The covariance
-            of the propagated orbits is then the covariance of the samples.
-        covariance_method : {'sigma-point', 'monte-carlo', 'auto'}, optional
-            The method to use for sampling the covariance matrix. If 'auto' is selected then the method
-            will be automatically selected based on the covariance matrix. The default is 'monte-carlo'.
-        num_samples : int, optional
-            The number of samples to draw when sampling with monte-carlo.
-        chunk_size : int, optional
-            Number of orbits to send to each job.
-        max_processes : int or None, optional
-            Maximum number of processes to launch. If None then the number of
-            processes will be equal to the number of cores on the machine. If 1
-            then no multiprocessing will be used. If "ray" is the parallel_backend and a ray instance
-            is initialized already then this argument is ignored.
-        parallel_backend : {'cf', 'ray'}, optional
-            The parallel backend to use. 'cf' uses concurrent.futures and 'ray' uses ray. The default is 'cf'.
-            To use ray, ray must be installed.
-
-        Returns
-        -------
-        propagated : `~adam_core.orbits.orbits.Orbits`
-            Propagated orbits.
-        """
-        if max_processes is None or max_processes > 1:
-            propagated_list: List[Orbits] = []
-            variants_list: List[VariantOrbits] = []
-
-            if parallel_backend == "cf":
-                with concurrent.futures.ProcessPoolExecutor(
-                    max_workers=max_processes
-                ) as executor:
-                    # Add orbits to propagate to futures
-                    futures = []
-                    for orbit_chunk in _iterate_chunks(orbits, chunk_size):
-                        futures.append(
-                            executor.submit(
-                                propagation_worker,
-                                orbit_chunk,
-                                times,
-                                self.__class__,
-                                **self.__dict__,
-                            )
-                        )
-
-                    # Add variants to propagate to futures
-                    if (
-                        covariance is True
-                        and not orbits.coordinates.covariance.is_all_nan()
-                    ):
-                        variants = VariantOrbits.create(
-                            orbits, method=covariance_method, num_samples=num_samples
-                        )
-                        for variant_chunk in _iterate_chunks(variants, chunk_size):
-                            futures.append(
-                                executor.submit(
-                                    propagation_worker,
-                                    variant_chunk,
-                                    times,
-                                    self.__class__,
-                                    **self.__dict__,
-                                )
-                            )
-
-                    for future in concurrent.futures.as_completed(futures):
-                        result = future.result()
-                        if isinstance(result, Orbits):
-                            propagated_list.append(result)
-                        elif isinstance(result, VariantOrbits):
-                            variants_list.append(result)
-                        else:
-                            raise ValueError(
-                                f"Unexpected result type from propagation worker: {type(result)}"
-                            )
-
-            elif parallel_backend == "ray":
-                if RAY_INSTALLED is False:
-                    raise ImportError(
-                        "Ray must be installed to use the ray parallel backend"
-                    )
-
-                initialize_use_ray(num_cpus=max_processes)
-
-                # Add orbits and times to object store if
-                # they haven't already been added
-                if not isinstance(times, ObjectRef):
-                    times_ref = ray.put(times)
-                else:
-                    times_ref = times
-
-                if not isinstance(orbits, ObjectRef):
-                    orbits_ref = ray.put(orbits)
-                else:
-                    orbits_ref = orbits
-                    # We need to dereference the orbits ObjectRef so we can
-                    # check its length for chunking and determine
-                    # if we need to propagate variants
-                    orbits = ray.get(orbits_ref)
-
-                # Create futures
-                futures = []
-                idx = np.arange(0, len(orbits))
-                for idx_chunk in _iterate_chunks(idx, chunk_size):
-                    futures.append(
-                        propagation_worker_ray.remote(
-                            idx_chunk,
-                            orbits_ref,
-                            times_ref,
-                            self.__class__,
-                            **self.__dict__,
-                        )
-                    )
-
-                # Add variants to propagate to futures
-                if (
-                    covariance is True
-                    and not orbits.coordinates.covariance.is_all_nan()
-                ):
-                    variants = VariantOrbits.create(
-                        orbits, method=covariance_method, num_samples=num_samples
-                    )
-                    variants_ref = ray.put(variants)
-
-                    idx = np.arange(0, len(variants))
-                    for variant_chunk in _iterate_chunks(idx, chunk_size):
-                        idx_chunk = ray.put(variant_chunk)
-                        futures.append(
-                            propagation_worker_ray.remote(
-                                idx_chunk,
-                                variants_ref,
-                                times_ref,
-                                self.__class__,
-                                **self.__dict__,
-                            )
-                        )
-
-                # Get results as they finish (we sort later)
-                unfinished = futures
-                while unfinished:
-                    finished, unfinished = ray.wait(unfinished, num_returns=1)
-                    result = ray.get(finished[0])
-                    if isinstance(result, Orbits):
-                        propagated_list.append(result)
-                    elif isinstance(result, VariantOrbits):
-                        variants_list.append(result)
-                    else:
-                        raise ValueError(
-                            f"Unexpected result type from propagation worker: {type(result)}"
-                        )
-
-            else:
-                raise ValueError(f"Unknown parallel backend: {parallel_backend}")
-
-            # Concatenate propagated orbits
-            propagated = qv.concatenate(propagated_list)
-            if len(variants_list) > 0:
-                propagated_variants = qv.concatenate(variants_list)
-            else:
-                propagated_variants = None
-
-        else:
-            propagated = self._propagate_orbits(orbits, times)
-
-            if covariance is True and not orbits.coordinates.covariance.is_all_nan():
-                variants = VariantOrbits.create(
-                    orbits, method=covariance_method, num_samples=num_samples
-                )
-                propagated_variants = self._propagate_orbits(variants, times)
-            else:
-                propagated_variants = None
-
-        if propagated_variants is not None:
-            propagated = propagated_variants.collapse(propagated)
-
-        return propagated.sort_by(
-            ["orbit_id", "coordinates.time.days", "coordinates.time.nanos"]
-        )
 
     @abstractmethod
     def _generate_ephemeris(
@@ -329,7 +112,6 @@ class Propagator(ABC):
         num_samples: int = 1000,
         chunk_size: int = 100,
         max_processes: Optional[int] = 1,
-        parallel_backend: Literal["cf", "ray"] = "cf",
     ) -> Ephemeris:
         """
         Generate ephemerides for each orbit in orbits as observed by each observer
@@ -376,131 +158,78 @@ class Propagator(ABC):
             ephemeris_list: List[Ephemeris] = []
             variants_list: List[VariantEphemeris] = []
 
-            if parallel_backend == "cf":
-                with concurrent.futures.ProcessPoolExecutor(
-                    max_workers=max_processes
-                ) as executor:
-                    # Add orbits to propagate to futures
-                    futures = []
-                    for orbit_chunk in _iterate_chunks(orbits, chunk_size):
-                        futures.append(
-                            executor.submit(
-                                ephemeris_worker,
-                                orbit_chunk,
-                                observers,
-                                self.__class__,
-                                **self.__dict__,
-                            )
-                        )
+            if RAY_INSTALLED is False:
+                raise ImportError(
+                    "Ray must be installed to use the ray parallel backend"
+                )
 
-                    # Add variants to propagate to futures
-                    if (
-                        covariance is True
-                        and not orbits.coordinates.covariance.is_all_nan()
-                    ):
-                        variants = VariantOrbits.create(
-                            orbits, method=covariance_method, num_samples=num_samples
-                        )
-                        for variant_chunk in _iterate_chunks(variants, chunk_size):
-                            futures.append(
-                                executor.submit(
-                                    ephemeris_worker,
-                                    variant_chunk,
-                                    observers,
-                                    self.__class__,
-                                    **self.__dict__,
-                                )
-                            )
+            initialize_use_ray(num_cpus=max_processes)
 
-                    for future in concurrent.futures.as_completed(futures):
-                        result = future.result()
-                        if isinstance(result, Ephemeris):
-                            ephemeris_list.append(result)
-                        elif isinstance(result, VariantEphemeris):
-                            variants_list.append(result)
-                        else:
-                            raise ValueError(
-                                f"Unexpected result type from ephemeris worker: {type(result)}"
-                            )
-            elif parallel_backend == "ray":
-                if RAY_INSTALLED is False:
-                    raise ImportError(
-                        "Ray must be installed to use the ray parallel backend"
+            # Add orbits and observers to object store if
+            # they haven't already been added
+            if not isinstance(observers, ObjectRef):
+                observers_ref = ray.put(observers)
+            else:
+                observers_ref = observers
+
+            if not isinstance(orbits, ObjectRef):
+                orbits_ref = ray.put(orbits)
+            else:
+                orbits_ref = orbits
+                # We need to dereference the orbits ObjectRef so we can
+                # check its length for chunking and determine
+                # if we need to propagate variants
+                orbits = ray.get(orbits_ref)
+
+            # Create futures
+            futures = []
+            idx = np.arange(0, len(orbits))
+            for idx_chunk in _iterate_chunks(idx, chunk_size):
+                futures.append(
+                    ephemeris_worker_ray.remote(
+                        idx_chunk,
+                        orbits_ref,
+                        observers_ref,
+                        self.__class__,
+                        **self.__dict__,
                     )
+                )
 
-                initialize_use_ray(num_cpus=max_processes)
+            # Add variants to futures (if we have any)
+            if covariance is True and not orbits.coordinates.covariance.is_all_nan():
+                variants = VariantOrbits.create(
+                    orbits, method=covariance_method, num_samples=num_samples
+                )
 
-                # Add orbits and observers to object store if
-                # they haven't already been added
-                if not isinstance(observers, ObjectRef):
-                    observers_ref = ray.put(observers)
-                else:
-                    observers_ref = observers
+                # Add variants to object store
+                variants_ref = ray.put(variants)
 
-                if not isinstance(orbits, ObjectRef):
-                    orbits_ref = ray.put(orbits)
-                else:
-                    orbits_ref = orbits
-                    # We need to dereference the orbits ObjectRef so we can
-                    # check its length for chunking and determine
-                    # if we need to propagate variants
-                    orbits = ray.get(orbits_ref)
-
-                # Create futures
-                futures = []
-                idx = np.arange(0, len(orbits))
-                for idx_chunk in _iterate_chunks(idx, chunk_size):
+                idx = np.arange(0, len(variants))
+                for variant_chunk in _iterate_chunks(idx, chunk_size):
+                    idx_chunk = ray.put(variant_chunk)
                     futures.append(
                         ephemeris_worker_ray.remote(
                             idx_chunk,
-                            orbits_ref,
+                            variants_ref,
                             observers_ref,
                             self.__class__,
                             **self.__dict__,
                         )
                     )
 
-                # Add variants to futures (if we have any)
-                if (
-                    covariance is True
-                    and not orbits.coordinates.covariance.is_all_nan()
-                ):
-                    variants = VariantOrbits.create(
-                        orbits, method=covariance_method, num_samples=num_samples
+            # Get results as they finish (we sort later)
+            unfinished = futures
+            while unfinished:
+                finished, unfinished = ray.wait(unfinished, num_returns=1)
+                result = ray.get(finished[0])
+                if isinstance(result, Ephemeris):
+                    ephemeris_list.append(result)
+                elif isinstance(result, VariantEphemeris):
+                    variants_list.append(result)
+                else:
+                    raise ValueError(
+                        f"Unexpected result type from ephemeris worker: {type(result)}"
                     )
-
-                    # Add variants to object store
-                    variants_ref = ray.put(variants)
-
-                    idx = np.arange(0, len(variants))
-                    for variant_chunk in _iterate_chunks(idx, chunk_size):
-                        idx_chunk = ray.put(variant_chunk)
-                        futures.append(
-                            ephemeris_worker_ray.remote(
-                                idx_chunk,
-                                variants_ref,
-                                observers_ref,
-                                self.__class__,
-                                **self.__dict__,
-                            )
-                        )
-
-                # Get results as they finish (we sort later)
-                unfinished = futures
-                while unfinished:
-                    finished, unfinished = ray.wait(unfinished, num_returns=1)
-                    result = ray.get(finished[0])
-                    if isinstance(result, Ephemeris):
-                        ephemeris_list.append(result)
-                    elif isinstance(result, VariantEphemeris):
-                        variants_list.append(result)
-                    else:
-                        raise ValueError(
-                            f"Unexpected result type from ephemeris worker: {type(result)}"
-                        )
-
-            else:
-                raise ValueError(f"Unknown parallel backend: {parallel_backend}")
 
             ephemeris = qv.concatenate(ephemeris_list)
             if len(variants_list) > 0:
@@ -529,4 +258,172 @@ class Propagator(ABC):
                 "coordinates.time.nanos",
                 "coordinates.origin.code",
             ]
+        )
+
+
+class Propagator(ABC):
+    """
+    Abstract class for propagating orbits and related functions.
+
+    Subclasses should implement the _propagate_orbits.
+    For additional functions, subclasses can add abstract mixins.
+
+    Important: subclasses should be pickleable! As this class uses multiprocessing
+    to parallelize propagation and ephemeris generation. This means that
+    subclasses should not have any unpickleable attributes.
+    """
+
+    @abstractmethod
+    def _propagate_orbits(self, orbits: OrbitType, times: TimestampType) -> OrbitType:
+        """
+        Propagate orbits to times.
+
+        THIS FUNCTION SHOULD BE DEFINED BY THE USER.
+        """
+        pass
+
+    def propagate_orbits(
+        self,
+        orbits: OrbitType,
+        times: TimestampType,
+        covariance: bool = False,
+        covariance_method: Literal[
+            "auto", "sigma-point", "monte-carlo"
+        ] = "monte-carlo",
+        num_samples: int = 1000,
+        chunk_size: int = 100,
+        max_processes: Optional[int] = 1,
+    ) -> Orbits:
+        """
+        Propagate each orbit in orbits to each time in times.
+
+        This method handles parallelization of the propagation of the orbits.
+        Subclasses may override this method to modify parallelization behavior.
+
+        Parameters
+        ----------
+        orbits : `~adam_core.orbits.orbits.Orbits` (N)
+            Orbits to propagate.
+        times : Timestamp (M)
+            Times to which to propagate orbits.
+        covariance : bool, optional
+            Propagate the covariance matrices of the orbits. This is done by sampling the
+            orbits from their covariance matrices and propagating each sample. The covariance
+            of the propagated orbits is then the covariance of the samples.
+        covariance_method : {'sigma-point', 'monte-carlo', 'auto'}, optional
+            The method to use for sampling the covariance matrix. If 'auto' is selected then the method
+            will be automatically selected based on the covariance matrix. The default is 'monte-carlo'.
+        num_samples : int, optional
+            The number of samples to draw when sampling with monte-carlo.
+        chunk_size : int, optional
+            Number of orbits to send to each job.
+        max_processes : int or None, optional
+            Maximum number of processes to launch. If None then the number of
+            processes will be equal to the number of cores on the machine. If 1
+            then no multiprocessing will be used. If "ray" is the parallel_backend and a ray instance
+            is initialized already then this argument is ignored.
+
+        Returns
+        -------
+        propagated : `~adam_core.orbits.orbits.Orbits`
+            Propagated orbits.
+        """
+        if max_processes is None or max_processes > 1:
+            propagated_list: List[Orbits] = []
+            variants_list: List[VariantOrbits] = []
+
+            if RAY_INSTALLED is False:
+                raise ImportError(
+                    "Ray must be installed to use the ray parallel backend"
+                )
+
+            initialize_use_ray(num_cpus=max_processes)
+
+            # Add orbits and times to object store if
+            # they haven't already been added
+            if not isinstance(times, ObjectRef):
+                times_ref = ray.put(times)
+            else:
+                times_ref = times
+
+            if not isinstance(orbits, ObjectRef):
+                orbits_ref = ray.put(orbits)
+            else:
+                orbits_ref = orbits
+                # We need to dereference the orbits ObjectRef so we can
+                # check its length for chunking and determine
+                # if we need to propagate variants
+                orbits = ray.get(orbits_ref)
+
+            # Create futures
+            futures = []
+            idx = np.arange(0, len(orbits))
+            for idx_chunk in _iterate_chunks(idx, chunk_size):
+                futures.append(
+                    propagation_worker_ray.remote(
+                        idx_chunk,
+                        orbits_ref,
+                        times_ref,
+                        self.__class__,
+                        **self.__dict__,
+                    )
+                )
+
+            # Add variants to propagate to futures
+            if covariance is True and not orbits.coordinates.covariance.is_all_nan():
+                variants = VariantOrbits.create(
+                    orbits, method=covariance_method, num_samples=num_samples
+                )
+                variants_ref = ray.put(variants)
+
+                idx = np.arange(0, len(variants))
+                for variant_chunk in _iterate_chunks(idx, chunk_size):
+                    idx_chunk = ray.put(variant_chunk)
+                    futures.append(
+                        propagation_worker_ray.remote(
+                            idx_chunk,
+                            variants_ref,
+                            times_ref,
+                            self.__class__,
+                            **self.__dict__,
+                        )
+                    )
+
+            # Get results as they finish (we sort later)
+            unfinished = futures
+            while unfinished:
+                finished, unfinished = ray.wait(unfinished, num_returns=1)
+                result = ray.get(finished[0])
+                if isinstance(result, Orbits):
+                    propagated_list.append(result)
+                elif isinstance(result, VariantOrbits):
+                    variants_list.append(result)
+                else:
+                    raise ValueError(
+                        f"Unexpected result type from propagation worker: {type(result)}"
+                    )
+
+            # Concatenate propagated orbits
+            propagated = qv.concatenate(propagated_list)
+            if len(variants_list) > 0:
+                propagated_variants = qv.concatenate(variants_list)
+            else:
+                propagated_variants = None
+
+        else:
+            propagated = self._propagate_orbits(orbits, times)
+
+            if covariance is True and not orbits.coordinates.covariance.is_all_nan():
+                variants = VariantOrbits.create(
+                    orbits, method=covariance_method, num_samples=num_samples
+                )
+                propagated_variants = self._propagate_orbits(variants, times)
+            else:
+                propagated_variants = None
+
+        if propagated_variants is not None:
+            propagated = propagated_variants.collapse(propagated)
+
+        return propagated.sort_by(
+            ["orbit_id", "coordinates.time.days", "coordinates.time.nanos"]
         )

--- a/adam_core/propagator/pyoorb.py
+++ b/adam_core/propagator/pyoorb.py
@@ -19,7 +19,7 @@ from ..orbits.ephemeris import Ephemeris
 from ..orbits.orbits import Orbits
 from ..orbits.variants import VariantEphemeris, VariantOrbits
 from ..time import Timestamp
-from .propagator import EphemerisType, OrbitType, Propagator
+from .propagator import EphemerisMixin, EphemerisType, OrbitType, Propagator
 from .utils import _assert_times_almost_equal
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ def process_safe_oorb_init(ephfile):
         raise RuntimeError(f"PYOORB returned error code: {err}")
 
 
-class PYOORB(Propagator):
+class PYOORB(Propagator, EphemerisMixin):
     def __init__(
         self, *, dynamical_model: str = "N", ephemeris_file: str = "de430.dat"
     ):

--- a/adam_core/time/tests/test_time.py
+++ b/adam_core/time/tests/test_time.py
@@ -459,7 +459,7 @@ class TestTimeMath:
             {"in_days": 2, "in_nanos": 200, "out_days": 1, "out_nanos": 100},
         ]
 
-        for (i, c) in enumerate(cases):
+        for i, c in enumerate(cases):
             t1 = Timestamp.from_kwargs(
                 days=[c["in_days"]],
                 nanos=[c["in_nanos"]],

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,11 +6,12 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'adam_core'
-copyright = '2023, B612 Asteroid Institute'
-author = 'B612 Asteroid Institute'
+project = "adam_core"
+copyright = "2023, B612 Asteroid Institute"
+author = "B612 Asteroid Institute"
 
 import adam_core
+
 version = adam_core.__version__
 release = adam_core.__version__
 
@@ -33,16 +34,17 @@ extensions = [
 # From sphinx_toolbox.more_autodoc.typehints
 hide_none_rtype = True
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
 
 autodoc_type_aliases = {
     "Coordinates": "adam_core.coordinates.types.Coordinates",
 }
 
-autodoc_member_order = 'bysource'
+autodoc_member_order = "bysource"
 
 import quivr
+
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
@@ -68,4 +70,3 @@ intersphinx_mapping = {
 
 #     ("py:mod", "pyarrow.compute"),
 # }
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
 check = ["lint", "typecheck", "test"]
 fix = ["ruff ./adam_core --fix"]
 lint = [
-  "ruff ./adam_core",
+  "ruff check ./adam_core",
   "black --check ./adam_core",
   "isort --check-only ./adam_core",
 ]
@@ -99,7 +99,7 @@ profile = "black"
 [tool.ruff]
 line-length = 110
 target-version = "py311"
-ignore = []
+lint.ignore = []
 exclude = ["build"]
 
 [tool.hatch.envs.docs]


### PR DESCRIPTION
This PR adds an `impacts` module which contains types, propagator mixins, and high level functions for calculating NEO impact probabilities. Using the mixin requires use of one or more ImpactMixin enabled propagators (such as adam-assist).

