### PR TITLE
Add timezone and observing night calculations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   "naif-eop-predict",
   "naif-eop-historical",
   "naif-earth-itrf93",
+  "timezonefinder",
 ]
 
 [build-system]

--- a/src/adam_core/constants.py
+++ b/src/adam_core/constants.py
@@ -14,11 +14,19 @@ S_P_DAY = 86400.0
 
 
 class _Constants:
-    def __init__(self, C=None, MU=None, R_Earth=None, Obliquity=None):
+    def __init__(
+        self,
+        C=None,
+        MU=None,
+        R_EARTH_EQUATORIAL=None,
+        R_EARTH_POLAR=None,
+        OBLIQUITY=None,
+    ):
         self.C = C
         self.MU = MU
-        self.R_EARTH = R_Earth
-        self.OBLIQUITY = Obliquity
+        self.R_EARTH_EQUATORIAL = R_EARTH_EQUATORIAL
+        self.R_EARTH_POLAR = R_EARTH_POLAR
+        self.OBLIQUITY = OBLIQUITY
 
         # Transformation matrix from Equatorial J2000 to Ecliptic J2000
         self.TRANSFORM_EQ2EC = np.array(
@@ -40,8 +48,10 @@ DE44X_CONSTANTS = {
     # Standard Gravitational Parameter -- Sun :  au**3 / d**2 (0.29591220828411956E-03 -- DE441/DE440)
     "MU": 0.29591220828411956e-03,
     # Earth Equatorial Radius: au (6378.1363 km -- DE431/DE430)
-    "R_Earth": 6378.1363 / KM_P_AU,
+    "R_EARTH_EQUATORIAL": 6378.1363 / KM_P_AU,
+    # Earth Polar Radius: au (6356.7523 km)
+    "R_EARTH_POLAR": 6356.7523 / KM_P_AU,
     # Mean Obliquity at J2000: radians (84381.448 arcseconds -- DE431/DE430)
-    "Obliquity": 84381.448 * np.pi / (180.0 * 3600.0),
+    "OBLIQUITY": 84381.448 * np.pi / (180.0 * 3600.0),
 }
 DE44X = Constants = _Constants(**DE44X_CONSTANTS)

--- a/src/adam_core/observers/__init__.py
+++ b/src/adam_core/observers/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa: F401
 from .observers import Observers
 from .state import get_observer_state
+from .utils import calculate_observing_night
 
 __all__ = ["Observers", "get_observer_state"]

--- a/src/adam_core/observers/tests/test_observers.py
+++ b/src/adam_core/observers/tests/test_observers.py
@@ -1,9 +1,10 @@
+import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 
 from ...time import Timestamp
-from ..observers import Observers
+from ..observers import OBSERVATORY_PARALLAX_COEFFICIENTS, Observers
 
 
 @pytest.fixture
@@ -59,3 +60,53 @@ def test_Observers_from_codes_raises(codes_times) -> None:
         Observers.from_codes(codes[:3], times)
     with pytest.raises(ValueError, match="codes and times must have the same length."):
         Observers.from_codes(codes, times[:3])
+
+
+def test_ObservatoryParallaxCoefficients_lon_lat() -> None:
+    # Data taken from: https://en.wikipedia.org/wiki/List_of_observatory_codes
+    # From: https://geohack.toolforge.org/geohack.php?pagename=Zwicky_Transient_Facility&params=33.35731_N_116.85981_W_
+    I41 = OBSERVATORY_PARALLAX_COEFFICIENTS.select("code", "I41")
+    lon, lat = I41.lon_lat()
+    np.testing.assert_allclose(lon[0], -116.85981, atol=1e-4, rtol=0)
+    np.testing.assert_allclose(lat[0], 33.35731, atol=1e-4, rtol=0)
+
+    # From: https://geohack.toolforge.org/geohack.php?pagename=Vera_C._Rubin_Observatory&params=30_14_40.7_S_70_44_57.9_W_region:CL-CO_type:landmark
+    X05 = OBSERVATORY_PARALLAX_COEFFICIENTS.select("code", "X05")
+    lon, lat = X05.lon_lat()
+    np.testing.assert_allclose(lon[0], -70.749417, atol=1e-4, rtol=0)
+    np.testing.assert_allclose(lat[0], -30.244639, atol=1e-4, rtol=0)
+
+    # From: https://geohack.toolforge.org/geohack.php?pagename=V%C3%ADctor_M._Blanco_Telescope&params=30.16967_S_70.80653_W_
+    W84 = OBSERVATORY_PARALLAX_COEFFICIENTS.select("code", "W84")
+    lon, lat = W84.lon_lat()
+    np.testing.assert_allclose(lon[0], -70.80653, atol=1e-3, rtol=0)
+    np.testing.assert_allclose(lat[0], -30.169679, atol=1e-3, rtol=0)
+
+    # From: https://geohack.toolforge.org/geohack.php?params=32_22_48.6_S_20_48_38.1_E
+    M22 = OBSERVATORY_PARALLAX_COEFFICIENTS.select("code", "M22")
+    lon, lat = M22.lon_lat()
+    np.testing.assert_allclose(lon[0], 20.810583, atol=1e-4, rtol=0)
+    np.testing.assert_allclose(lat[0], -32.380167, atol=1e-4, rtol=0)
+
+    # From: https://geohack.toolforge.org/geohack.php?params=20_42_26.04_N_156_15_21.28_W
+    F51 = OBSERVATORY_PARALLAX_COEFFICIENTS.select("code", "F51")
+    lon, lat = F51.lon_lat()
+    np.testing.assert_allclose(lon[0], -156.255911, atol=1e-4, rtol=0)
+    np.testing.assert_allclose(lat[0], 20.707233, atol=1e-4, rtol=0)
+
+
+def test_ObservatoryParallaxCoeffiecients_timezone() -> None:
+    I41 = OBSERVATORY_PARALLAX_COEFFICIENTS.select("code", "I41")
+    assert I41.timezone() == "America/Los_Angeles"
+
+    X05 = OBSERVATORY_PARALLAX_COEFFICIENTS.select("code", "X05")
+    assert X05.timezone() == "America/Santiago"
+
+    W84 = OBSERVATORY_PARALLAX_COEFFICIENTS.select("code", "W84")
+    assert W84.timezone() == "America/Santiago"
+
+    M22 = OBSERVATORY_PARALLAX_COEFFICIENTS.select("code", "M22")
+    assert M22.timezone() == "Africa/Johannesburg"
+
+    F51 = OBSERVATORY_PARALLAX_COEFFICIENTS.select("code", "F51")
+    assert F51.timezone() == "Pacific/Honolulu"

--- a/src/adam_core/observers/tests/test_utils.py
+++ b/src/adam_core/observers/tests/test_utils.py
@@ -1,0 +1,104 @@
+import pyarrow as pa
+import pyarrow.compute as pc
+
+from ...time import Timestamp
+from ..utils import calculate_observing_night
+
+
+def test_calculate_observing_night() -> None:
+    # Rubin Observatory is UTC-7
+    # Reasonable observating times would be +- 12 hours from local midnight
+    # or 7:00 to 17:00 UTC
+
+    # ZTF is UTC-8
+    # Reasonable observating times would be +- 12 hours from local midnight
+    # or 8:00 to 16:00 UTC
+
+    # M22 is UTC+2
+    # Reasonable observating times would be +- 12 hours from local midnight
+    # or 22:00 to 10:00 UTC
+
+    # 000 is UTC
+    # Reasonable observating times would be +- 12 hours from local midnight
+    # or 0:00 to 12:00 UTC
+
+    codes = pa.array(
+        [
+            "X05",
+            "X05",
+            "X05",
+            "X05",
+            "X05",
+            "I41",
+            "I41",
+            "I41",
+            "I41",
+            "I41",
+            "M22",
+            "M22",
+            "M22",
+            "M22",
+            "M22",
+            "000",
+            "000",
+            "000",
+            "000",
+            "000",
+        ]
+    )
+    times_utc = Timestamp.from_mjd(
+        [
+            # Rubin Observatory
+            59000 + 7 / 24 - 12 / 24,
+            59000 + 7 / 24 - 6 / 24,
+            59000 + 7 / 24,
+            59000 + 7 / 24 + 6 / 24,
+            59000 + 7 / 24 + 12 / 24,
+            # ZTF
+            59000 + 8 / 24 - 12 / 24,
+            59000 + 8 / 24 - 4 / 24,
+            59000 + 8 / 24,
+            59000 + 8 / 24 + 4 / 24,
+            59000 + 8 / 24 + 12 / 24,
+            # M22
+            59000 - 2 / 24 - 12 / 24,
+            59000 - 2 / 24 - 6 / 24,
+            59000 - 2 / 24,
+            59000 - 2 / 24 + 6 / 24,
+            59000 - 2 / 24 + 12 / 24,
+            # 000
+            59000 - 12 / 24,
+            59000 - 6 / 24,
+            59000,
+            59000 + 6 / 24,
+            59000 + 12 / 24,
+        ],
+        scale="utc",
+    )
+
+    observing_night = calculate_observing_night(codes, times_utc)
+    desired = pa.array(
+        [
+            58999,
+            58999,
+            58999,
+            58999,
+            59000,
+            58999,
+            58999,
+            58999,
+            58999,
+            59000,
+            58999,
+            58999,
+            58999,
+            58999,
+            59000,
+            58999,
+            58999,
+            58999,
+            58999,
+            59000,
+        ]
+    )
+    assert pc.all(pc.equal(observing_night, desired)).as_py()

--- a/src/adam_core/observers/utils.py
+++ b/src/adam_core/observers/utils.py
@@ -1,0 +1,57 @@
+from datetime import timedelta
+from zoneinfo import ZoneInfo
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.compute as pc
+from astropy.time import Time
+
+from ..time import Timestamp
+from .observers import OBSERVATORY_PARALLAX_COEFFICIENTS
+
+
+def calculate_observing_night(codes: pa.Array, times: Timestamp) -> pa.Array:
+    """
+    Compute the observing night for a given set of observatory codes and times. An observing night is defined as the night
+    during which the observation is made, in the local time of the observatory +- 12 hours. The observing night is defined
+    as the integer MJD of the night in the local time of the observatory.
+
+    Parameters
+    ----------
+    codes : pyarrow.Array (N)
+        An array of observatory codes.
+    times : Timestamp (N)
+        An array of times.
+
+    Returns
+    -------
+    observing_night : pyarrow.Array (N)
+        An array of observing nights.
+    """
+    half_day = timedelta(hours=12)
+    observing_night = np.empty(len(times), dtype=np.int64)
+
+    for code in pc.unique(codes):
+
+        parallax_coefficients = OBSERVATORY_PARALLAX_COEFFICIENTS.select("code", code)
+        if len(parallax_coefficients) == 0:
+            raise ValueError(f"Unknown observatory code: {code}")
+
+        tz = ZoneInfo(parallax_coefficients.timezone()[0])
+
+        mask = pc.equal(codes, code)
+        times_code = times.apply_mask(mask)
+
+        observing_night_code = Time(
+            [
+                time + time.astimezone(tz).utcoffset() - half_day
+                for time in times_code.to_astropy().datetime
+            ],
+            format="datetime",
+            scale="utc",
+        )
+        observing_night_code = observing_night_code.mjd.astype(int)
+
+        observing_night[mask.to_numpy(zero_copy_only=False)] = observing_night_code
+
+    return pa.array(observing_night)


### PR DESCRIPTION
It's often useful to get the timezone of an observatory so that you can establish the local midnight relative to the reported observation times (often reported in UTC). This PR adds code to calculate the timezone for each observatory based on the observatory's longitude and latitude. Then given a set of timestamps, a function has been added that will compute the observing night for each time (defined as +- 12 hours from the local midnight). 