### PR TITLE
ensure orbits_abberated is an Orbits (

### DIFF
--- a/src/adam_core/propagator/propagator.py
+++ b/src/adam_core/propagator/propagator.py
@@ -104,7 +104,7 @@ class EphemerisMixin:
         lt_tol: float = 1e-12,
         max_iter: int = 10,
     ):
-        orbits_aberrated = orbits.empty()
+        orbits_aberrated = Orbits.empty()
         lts = np.zeros(len(orbits))
         for i, (orbit, observer) in enumerate(zip(orbits, observers)):
             # Set the running variables


### PR DESCRIPTION
`orbits` is sometimes passed in as a `VariantOrbits` - need to ensure this is an Orbits table