### PR TITLE
Use __getstate__ and __setstate__ for propagator serialization

### DIFF
--- a/src/adam_core/dynamics/tests/test_impacts.py
+++ b/src/adam_core/dynamics/tests/test_impacts.py
@@ -16,6 +16,13 @@ from ..impacts import (
 
 
 class MockImpactPropagator(Propagator, ImpactMixin):
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     def _propagate_orbits(self, orbits: Orbits, times: Timestamp) -> Orbits:
         return orbits
 


### PR DESCRIPTION
Rather than instantiate propagators in the workers implicitly by using self.__dict__ and self.__class__, the proper way to do this is to take advantage of dunder methods __getstate__ and __setstate__. Now we can pass in propagator instances directly without fear of nasty stateful bits or non-initialization keyword arguments getting passed around.

Here we implement them as required in the ABC. Tests will fail until pointing to updated adam-assist in the development requirements.