### PR TITLE
Add GeodeticCoordinates

### DIFF
--- a/src/adam_core/coordinates/__init__.py
+++ b/src/adam_core/coordinates/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from .cartesian import CartesianCoordinates
 from .cometary import CometaryCoordinates
 from .covariances import CoordinateCovariances
+from .geodetics import GeodeticCoordinates
 from .keplerian import KeplerianCoordinates
 from .origin import Origin, OriginCodes
 from .residuals import Residuals

--- a/src/adam_core/coordinates/geodetics.py
+++ b/src/adam_core/coordinates/geodetics.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+import pyarrow.compute as pc
+import quivr as qv
+
+from ..constants import KM_P_AU
+from ..time import Timestamp
+from . import cartesian
+from .covariances import CoordinateCovariances, transform_covariances_jacobian
+from .origin import Origin
+
+__all__ = [
+    "GeodeticCoordinates",
+]
+
+
+@dataclass
+class GeodeticConstants:
+    """
+    Geodetic constants for the Earth.
+
+    Parameters
+    ----------
+    a : float
+        Semi-major axis of the Earth in units of distance.
+    b : float
+        Semi-minor axis of the Earth in units of distance.
+    f : float
+        Flattening of the Earth.
+    """
+
+    a: float
+    b: float
+    f: float
+
+
+WGS84 = GeodeticConstants(
+    a=6378137.0 / KM_P_AU / 1000,
+    b=6356752.31424518 / KM_P_AU / 1000,
+    f=1.0 / 298.257223563,
+)
+
+
+class GeodeticCoordinates(qv.Table):
+
+    alt = qv.Float64Column(nullable=True)
+    lon = qv.Float64Column(nullable=True)
+    lat = qv.Float64Column(nullable=True)
+    vup = qv.Float64Column(nullable=True)
+    veast = qv.Float64Column(nullable=True)
+    vnorth = qv.Float64Column(nullable=True)
+    time = Timestamp.as_column(nullable=True)
+    covariance = CoordinateCovariances.as_column(nullable=True)
+    origin = Origin.as_column()
+    frame = qv.StringAttribute(default="unspecified")
+
+    @property
+    def values(self) -> np.ndarray:
+        return np.array(
+            self.table.select(["alt", "lon", "lat", "vup", "veast", "vnorth"])
+        )
+
+    @property
+    def sigma_alt(self):
+        """
+        1-sigma uncertainty in altitude.
+        """
+        return self.covariance.sigmas[:, 0]
+
+    @property
+    def sigma_lon(self):
+        """
+        1-sigma uncertainty in longitude.
+        """
+        return self.covariance.sigmas[:, 1]
+
+    @property
+    def sigma_lat(self):
+        """
+        1-sigma uncertainty in latitude.
+        """
+        return self.covariance.sigmas[:, 2]
+
+    @property
+    def sigma_vup(self):
+        """
+        1-sigma uncertainty in up velocity.
+        """
+        return self.covariance.sigmas[:, 3]
+
+    @property
+    def sigma_veast(self):
+        """
+        1-sigma uncertainty in east velocity.
+        """
+        return self.covariance.sigmas[:, 4]
+
+    @property
+    def sigma_vnorth(self):
+        """
+        1-sigma uncertainty in north velocity.
+        """
+        return self.covariance.sigmas[:, 5]
+
+    def google_maps_url(self, zoom: int = 18) -> List[str]:
+        """
+        Generate a Google Maps URL for the coordinates.
+        """
+        urls = []
+        for lat, lon in zip(self.lat, self.lon):
+            urls.append(
+                f"https://www.google.com/maps/@{lat.as_py()},{lon.as_py() - 360},{zoom}z"
+            )
+        return urls
+
+    @classmethod
+    def from_cartesian(
+        cls, cartesian: cartesian.CartesianCoordinates
+    ) -> "GeodeticCoordinates":
+        from .transform import _cartesian_to_geodetic, cartesian_to_geodetic
+
+        assert (
+            cartesian.frame == "itrf93"
+        ), "Cartesian coordinates must be in ITRF93 frame"
+        assert pc.all(
+            pc.equal(cartesian.origin.code, "EARTH")
+        ), "Cartesian coordinates must be in Earth-centered frame"
+
+        coords_geodetic = cartesian_to_geodetic(cartesian.values, a=WGS84.a, f=WGS84.f)
+        coords_geodetic = np.array(coords_geodetic)
+
+        if not cartesian.covariance.is_all_nan():
+            cartesian_covariances = cartesian.covariance.to_matrix()
+            covariances_geodetic = transform_covariances_jacobian(
+                cartesian.values, cartesian_covariances, _cartesian_to_geodetic
+            )
+        else:
+            covariances_geodetic = np.empty(
+                (len(coords_geodetic), 6, 6), dtype=np.float64
+            )
+            covariances_geodetic.fill(np.nan)
+
+        covariances_geodetic = CoordinateCovariances.from_matrix(covariances_geodetic)
+        coords = cls.from_kwargs(
+            alt=coords_geodetic[:, 0],
+            lon=coords_geodetic[:, 1],
+            lat=coords_geodetic[:, 2],
+            vup=coords_geodetic[:, 3],
+            veast=coords_geodetic[:, 4],
+            vnorth=coords_geodetic[:, 5],
+            time=cartesian.time,
+            covariance=covariances_geodetic,
+            origin=cartesian.origin,
+            frame=cartesian.frame,
+        )
+
+        return coords

--- a/src/adam_core/coordinates/types.py
+++ b/src/adam_core/coordinates/types.py
@@ -4,6 +4,7 @@ import typing
 
 from .cartesian import CartesianCoordinates
 from .cometary import CometaryCoordinates
+from .geodetics import GeodeticCoordinates
 from .keplerian import KeplerianCoordinates
 from .spherical import SphericalCoordinates
 
@@ -13,6 +14,7 @@ Coordinates = typing.Union[
     KeplerianCoordinates,
     SphericalCoordinates,
     CometaryCoordinates,
+    GeodeticCoordinates,
 ]
 
 #: Type variable which represents any of the coordinate classes.
@@ -23,5 +25,6 @@ CoordinateType = typing.TypeVar(
         KeplerianCoordinates,
         CometaryCoordinates,
         SphericalCoordinates,
+        GeodeticCoordinates,
     ],
 )

--- a/src/adam_core/dynamics/plots.py
+++ b/src/adam_core/dynamics/plots.py
@@ -10,6 +10,7 @@ from ..constants import KM_P_AU
 from ..constants import Constants as c
 from ..coordinates import (
     CartesianCoordinates,
+    GeodeticCoordinates,
     Origin,
     OriginCodes,
     SphericalCoordinates,
@@ -902,22 +903,19 @@ def plot_risk_corridor(
             "No Earth impacts found. Other collision objects are not supported yet."
         )
 
-    # Transform impact coordinates to ITRF
-    impacts = impacts.set_column(
-        "collision_coordinates",
-        transform_coordinates(
-            impacts.collision_coordinates,
-            representation_out=SphericalCoordinates,
-            frame_out="itrf93",
-            origin_out=OriginCodes.EARTH,
-        ),
+    # Transform impact coordinates to ITRF93 Geodetic Coordinates
+    geodetic_impacts = transform_coordinates(
+        impacts.collision_coordinates,
+        representation_out=GeodeticCoordinates,
+        frame_out="itrf93",
+        origin_out=OriginCodes.EARTH,
     )
 
     # Sort all data by time
-    times = impacts.collision_coordinates.time.to_astropy()
+    times = geodetic_impacts.time.to_astropy()
     time_order = np.argsort(times.mjd)
-    lon = impacts.collision_coordinates.lon.to_numpy(zero_copy_only=False)[time_order]
-    lat = impacts.collision_coordinates.lat.to_numpy(zero_copy_only=False)[time_order]
+    lon = geodetic_impacts.lon.to_numpy(zero_copy_only=False)[time_order]
+    lat = geodetic_impacts.lat.to_numpy(zero_copy_only=False)[time_order]
     times = times[time_order]
 
     # Convert times to minutes since first impact


### PR DESCRIPTION
Stumbled on this while debugging some other stuff. ITRF93 Cartesian coordinates are the most accurate coordinates to use for impact calculations. However, when plotting impact points on maps, external tools often require geodetic coordinates (such as those tied to the WGS84 ellipsoid). 

This PR adds a one-way conversion from Cartesian coordinates in an Earth-centered, Earth-fixed frame (ECEF) to geodetic coordinates supported by tools like Google Maps. We can implement the return trip at a later date if needed.

In the example below, we calculate the heliocentric state vector for "X05" (using our Observers class, which utilizes the SPICE kernels underneath) and then transform that state vector into geodetic coordinates. We then generate a Google Maps URL with the calculated geodetic longitude and latitude. 
```python
from adam_core.time import Timestamp
from adam_core.observers import Observers
from adam_core.coordinates import transform_coordinates
from adam_core.coordinates import GeodeticCoordinates
from adam_core.coordinates import OriginCodes


observers = Observers.from_codes(
    ["X05", "I41", "F51"], 
    Timestamp.from_mjd([60900.0, 60900.0, 60900.0], scale="tdb")
)

geodetic = transform_coordinates(
    observers.coordinates, 
    frame_out="itrf93", 
    representation_out=GeodeticCoordinates, 
    origin_out=OriginCodes.EARTH
)
for i in range(len(geodetic)):
    print(f"Observer: {observers.code[i].as_py()}")
    print(f"Lat: {geodetic.lat[i].as_py()}, Lon: {geodetic.lon[i].as_py() - 360}")
    print(geodetic.google_maps_url()[i])
```
Observer: X05
Lat: -30.24460035258423, Lon: -70.74941999997259
https://www.google.com/maps/@-30.24460035258423,-70.74941999997259,18z
Observer: I41
Lat: 33.35733638788152, Lon: -116.85978000002132
https://www.google.com/maps/@33.35733638788152,-116.85978000002132,18z
Observer: F51
Lat: 20.707233518725637, Lon: -156.25591000006395
https://www.google.com/maps/@20.707233518725637,-156.25591000006395,18z