### PR TITLE
Add fit_orbit entrypoint and backend wrappers for orbit determination

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,18 @@ plots = [
 oem = [
     "oem>=0.4.5",
 ]
+# Orbit-determination backends (all optional)
+find_orb = [
+    "adam-fo",
+]
+orbfit = [
+    # TODO(od-module): pin a version once the orbfit package is published.
+    "orbfit",
+]
+layup = [
+    # TODO(od-module): pin a version once the layup OD API is stable.
+    "layup",
+]
 
 [build-system]
 requires = ["pdm-backend"]

--- a/src/adam_core/orbit_determination/__init__.py
+++ b/src/adam_core/orbit_determination/__init__.py
@@ -1,6 +1,18 @@
 # flake8: noqa: F401
+from .backends import (
+    FIND_ORB_AVAILABLE,
+    LAYUP_AVAILABLE,
+    ORBFIT_AVAILABLE,
+    AdamBackend,
+    BackendWrapper,
+    FindOrbBackend,
+    LayupBackend,
+    OrbFitBackend,
+)
+from .config import BackendConfig, WeightingPolicy
 from .differential_correction import fit_least_squares
 from .evaluate import OrbitDeterminationObservations, evaluate_orbits
+from .fit_orbit import fit_orbit
 from .fitted_orbits import FittedOrbitMembers, FittedOrbits, drop_duplicate_orbits
 from .gauss import gaussIOD
 from .gibbs import calcGibbs

--- a/src/adam_core/orbit_determination/backends/__init__.py
+++ b/src/adam_core/orbit_determination/backends/__init__.py
@@ -1,0 +1,70 @@
+"""
+Backend wrappers for :func:`~adam_core.orbit_determination.fit_orbit.fit_orbit`.
+
+Each backend is imported lazily so that missing optional dependencies do not
+prevent the rest of adam_core from loading.  After this module has been
+imported, the ``*_AVAILABLE`` booleans can be queried to determine which
+backends are usable in the current environment.
+
+Availability flags
+------------------
+FIND_ORB_AVAILABLE : bool
+    ``True`` if the ``adam_fo`` package is importable.
+ORBFIT_AVAILABLE : bool
+    ``True`` if the ``orbfit`` package is importable.
+LAYUP_AVAILABLE : bool
+    ``True`` if the ``layup`` package is importable.
+
+Examples
+--------
+>>> from adam_core.orbit_determination.backends import FIND_ORB_AVAILABLE
+>>> if FIND_ORB_AVAILABLE:
+...     from adam_core.orbit_determination.backends import FindOrbBackend
+"""
+
+# flake8: noqa: F401
+
+# --- FindOrb ----------------------------------------------------------------
+try:
+    import adam_fo  # noqa: F401
+
+    FIND_ORB_AVAILABLE = True
+except ImportError:
+    FIND_ORB_AVAILABLE = False
+
+# --- OrbFit -----------------------------------------------------------------
+try:
+    import orbfit  # noqa: F401
+
+    ORBFIT_AVAILABLE = True
+except ImportError:
+    ORBFIT_AVAILABLE = False
+
+# --- Layup ------------------------------------------------------------------
+try:
+    import layup  # noqa: F401
+
+    LAYUP_AVAILABLE = True
+except ImportError:
+    LAYUP_AVAILABLE = False
+
+# Always-available backends
+from .adam import AdamBackend
+from .base import BackendWrapper
+
+# Conditionally-available backends (always importable; raise at runtime if
+# the underlying package is absent)
+from .find_orb import FindOrbBackend
+from .layup import LayupBackend
+from .orbfit import OrbFitBackend
+
+__all__ = [
+    "FIND_ORB_AVAILABLE",
+    "ORBFIT_AVAILABLE",
+    "LAYUP_AVAILABLE",
+    "BackendWrapper",
+    "AdamBackend",
+    "FindOrbBackend",
+    "OrbFitBackend",
+    "LayupBackend",
+]

--- a/src/adam_core/orbit_determination/backends/adam.py
+++ b/src/adam_core/orbit_determination/backends/adam.py
@@ -1,0 +1,228 @@
+"""
+Native adam_core orbit-determination backend for
+:func:`~adam_core.orbit_determination.fit_orbit.fit_orbit`.
+
+This backend chains the existing adam_core IOD pipeline with differential
+correction:
+
+1. :func:`~adam_core.orbit_determination.iod.iod` — runs Gauss IOD on
+   observation triplets selected from the input set and evaluates candidate
+   orbits against all observations.
+2. :func:`~adam_core.orbit_determination.od.differential_correction` — refines
+   the IOD candidates.
+
+A :class:`~adam_core.propagator.Propagator` class **must** be supplied via
+``BackendConfig.backend_kwargs["propagator"]``.  The canonical choice is
+``ASSISTPropagator`` from the ``adam-assist`` package.
+
+Notes
+-----
+The adam backend is *always* available (no optional dependency).  It uses only
+packages that are already required by adam_core itself.
+
+Because :func:`~adam_core.orbit_determination.iod.iod` may return multiple
+candidate orbits (one per Gauss triplet that converges), this backend returns
+*all* candidates after differential correction.  Callers that want a single
+best orbit should select the row with the lowest ``reduced_chi2``.
+
+The :attr:`~adam_core.orbit_determination.config.WeightingPolicy` setting has
+no effect on this backend because residuals are always computed by
+:func:`~adam_core.orbit_determination.evaluate.evaluate_orbits`.
+"""
+
+import logging
+import os
+from typing import Literal, Optional, Tuple, Type
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import quivr as qv
+
+from ..config import BackendConfig
+from ..evaluate import OrbitDeterminationObservations
+from ..fitted_orbits import FittedOrbitMembers, FittedOrbits
+from ..iod import iod
+from ..od import differential_correction
+from .base import BackendWrapper
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.environ.get("ADAM_LOG_LEVEL", "INFO"))
+
+_BACKEND_VERSION = "adam_core"  # versioned at package level; see importlib.metadata
+
+
+class AdamBackend(BackendWrapper):
+    """Native adam_core IOD + differential-correction backend.
+
+    This backend is always available and requires no external binaries.
+
+    Parameters
+    ----------
+    None
+
+    Examples
+    --------
+    >>> from adam_core.orbit_determination.backends import AdamBackend
+    >>> from adam_core.orbit_determination.config import BackendConfig
+    >>> from adam_assist import ASSISTPropagator
+    >>> backend = AdamBackend()
+    >>> config = BackendConfig(backend_kwargs={"propagator": ASSISTPropagator})
+    >>> fitted, members = backend.fit(observations, config)
+    """
+
+    AVAILABLE: bool = True
+    BACKEND_NAME: str = "adam"
+
+    def fit(
+        self,
+        observations: OrbitDeterminationObservations,
+        config: BackendConfig,
+    ) -> Tuple[FittedOrbits, FittedOrbitMembers]:
+        """Fit an orbit using adam_core's IOD + differential-correction pipeline.
+
+        Parameters
+        ----------
+        observations : OrbitDeterminationObservations
+            Observations for a single object.
+        config : BackendConfig
+            Runtime configuration.  Relevant ``backend_kwargs`` keys:
+
+            * ``"propagator"`` *(Type[Propagator], required)* — propagator
+              class used for ephemeris generation.
+            * ``"min_obs"`` *(int, default 6)* — minimum number of
+              observations required for a valid solution.
+            * ``"min_arc_length"`` *(float, default 1.0)* — minimum arc
+              length in days.
+            * ``"contamination_percentage"`` *(float, default 20.0)* —
+              maximum fraction of observations that can be flagged as
+              outliers.
+            * ``"rchi2_threshold"`` *(float, default 200)* — maximum reduced
+              chi2 for an IOD candidate to be accepted.
+            * ``"observation_selection_method"``
+              *({'combinations', 'first+middle+last', 'thirds'}, default
+              'combinations')* — how to pick triplets for Gauss IOD.
+            * ``"max_processes"`` *(int or None, default 1)* — number of
+              parallel processes to use.
+
+        Returns
+        -------
+        fitted_orbits : FittedOrbits
+            Differentially-corrected orbit(s).  Multiple rows indicate
+            multiple IOD candidates that all converged.
+        fitted_orbit_members : FittedOrbitMembers
+            Per-observation residuals and outlier flags.
+
+        Raises
+        ------
+        ValueError
+            If ``propagator`` is not provided in ``backend_kwargs``, or if
+            no valid IOD candidate is found and differential correction
+            fails for all of them.
+        RuntimeError
+            If differential correction produces no orbits (all candidates
+            rejected after outlier removal).
+        """
+        self._check_available()
+
+        # --- Extract configuration ------------------------------------------
+        propagator_cls = config.backend_kwargs.get("propagator")
+        if propagator_cls is None:
+            raise ValueError(
+                "The adam backend requires a 'propagator' key in "
+                "BackendConfig.backend_kwargs.  "
+                "Example:\n"
+                "  from adam_assist import ASSISTPropagator\n"
+                "  config = BackendConfig(\n"
+                "      backend_kwargs={'propagator': ASSISTPropagator}\n"
+                "  )"
+            )
+
+        kwargs = config.backend_kwargs
+        min_obs: int = kwargs.get("min_obs", 6)
+        min_arc_length: float = kwargs.get("min_arc_length", 1.0)
+        contamination_percentage: float = kwargs.get("contamination_percentage", 20.0)
+        rchi2_threshold: float = kwargs.get("rchi2_threshold", 200.0)
+        observation_selection_method: Literal[
+            "combinations", "first+middle+last", "thirds"
+        ] = kwargs.get("observation_selection_method", "combinations")
+        max_processes: Optional[int] = kwargs.get("max_processes", 1)
+        propagator_kwargs: dict = kwargs.get("propagator_kwargs", {})
+
+        logger.info(
+            "AdamBackend: running IOD on %d observations (min_obs=%d, "
+            "rchi2_threshold=%.1f).",
+            len(observations),
+            min_obs,
+            rchi2_threshold,
+        )
+
+        # --- Step 1: Initial orbit determination (Gauss IOD) -----------------
+        iod_orbits, iod_members = iod(
+            observations=observations,
+            propagator=propagator_cls,
+            min_obs=min_obs,
+            min_arc_length=min_arc_length,
+            contamination_percentage=contamination_percentage,
+            rchi2_threshold=rchi2_threshold,
+            observation_selection_method=observation_selection_method,
+            propagator_kwargs=propagator_kwargs,
+        )
+
+        if len(iod_orbits) == 0:
+            raise ValueError(
+                f"adam backend: IOD found no valid orbit candidates for "
+                f"{len(observations)} observations.  "
+                f"Try lowering 'rchi2_threshold' (currently {rchi2_threshold}) "
+                f"or 'min_obs' (currently {min_obs}), or check that observer "
+                f"states are populated and covariances are set."
+            )
+
+        logger.info(
+            "AdamBackend: IOD produced %d candidate(s); running differential correction.",
+            len(iod_orbits),
+        )
+
+        # --- Step 2: Differential correction ---------------------------------
+        dc_orbits, dc_members = differential_correction(
+            orbits=iod_orbits,
+            orbit_members=iod_members,
+            observations=observations,
+            propagator=propagator_cls,
+            min_obs=min_obs,
+            min_arc_length=min_arc_length,
+            contamination_percentage=contamination_percentage,
+            rchi2_threshold=rchi2_threshold,
+            max_processes=max_processes,
+            propagator_kwargs=propagator_kwargs,
+        )
+
+        if len(dc_orbits) == 0:
+            raise RuntimeError(
+                "adam backend: differential correction produced no orbits.  "
+                "All IOD candidates were rejected (reduced chi2 too high or "
+                "arc length too short after outlier removal).  "
+                f"Started with {len(iod_orbits)} IOD candidate(s), "
+                f"{len(observations)} observations."
+            )
+
+        logger.info(
+            "AdamBackend: differential correction converged on %d orbit(s).",
+            len(dc_orbits),
+        )
+
+        # --- Stamp provenance ------------------------------------------------
+        try:
+            from importlib.metadata import version as _version
+
+            pkg_version = _version("adam-core")
+        except Exception:
+            pkg_version = _BACKEND_VERSION
+
+        dc_orbits = dc_orbits.set_column(
+            "backend", pa.repeat(self.BACKEND_NAME, len(dc_orbits))
+        )
+        dc_orbits = dc_orbits.set_column(
+            "backend_version", pa.repeat(pkg_version, len(dc_orbits))
+        )
+
+        return dc_orbits, dc_members

--- a/src/adam_core/orbit_determination/backends/base.py
+++ b/src/adam_core/orbit_determination/backends/base.py
@@ -1,0 +1,108 @@
+"""
+Abstract base class for orbit-determination backend wrappers.
+
+Every backend must:
+
+* Set the class-level ``AVAILABLE`` flag at import time by attempting to
+  import its optional dependency.
+* Implement :meth:`fit` to accept
+  :class:`~adam_core.orbit_determination.evaluate.OrbitDeterminationObservations`
+  and :class:`~adam_core.orbit_determination.config.BackendConfig` and return
+  ``(FittedOrbits, FittedOrbitMembers)``.
+* Implement :meth:`__getstate__` / :meth:`__setstate__` from the parent
+  :class:`~adam_core.orbit_determination.orbit_fitter.OrbitFitter` ABC so the
+  backend can be serialised for Ray-based parallelism.
+
+Notes
+-----
+``BackendWrapper`` intentionally does *not* subclass ``OrbitFitter`` because
+``OrbitFitter.initial_fit`` expects a pre-linked ``object_id`` and is oriented
+toward THOR's cluster-and-link pipeline.  ``BackendWrapper.fit`` is a
+higher-level entrypoint that accepts a full observation set for a *single*
+tracklet and produces a complete fitted orbit including residuals.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import ClassVar, Tuple
+
+from ..config import BackendConfig
+from ..evaluate import OrbitDeterminationObservations
+from ..fitted_orbits import FittedOrbitMembers, FittedOrbits
+
+logger = logging.getLogger(__name__)
+
+
+class BackendWrapper(ABC):
+    """Abstract wrapper around an external (or internal) orbit-determination backend.
+
+    Attributes
+    ----------
+    AVAILABLE : bool
+        Set to ``True`` at class definition time if the backend's required
+        package / binary is detectable.  Checked by
+        :func:`~adam_core.orbit_determination.fit_orbit.fit_orbit` before
+        dispatching.
+    BACKEND_NAME : str
+        Short human-readable label used in provenance and error messages.
+    """
+
+    AVAILABLE: ClassVar[bool] = False
+    BACKEND_NAME: ClassVar[str] = "unknown"
+
+    # ------------------------------------------------------------------
+    # Pickling support required by Ray / multiprocessing
+    # ------------------------------------------------------------------
+
+    def __getstate__(self) -> dict:
+        return self.__dict__.copy()
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+
+    # ------------------------------------------------------------------
+    # Core interface
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def fit(
+        self,
+        observations: OrbitDeterminationObservations,
+        config: BackendConfig,
+    ) -> Tuple[FittedOrbits, FittedOrbitMembers]:
+        """Fit an orbit to *observations* using this backend.
+
+        Parameters
+        ----------
+        observations : OrbitDeterminationObservations
+            All observations for a single object.  The caller is responsible
+            for ensuring all observations belong to one object.
+        config : BackendConfig
+            Runtime configuration including weighting policy and any
+            backend-specific kwargs.
+
+        Returns
+        -------
+        fitted_orbits : FittedOrbits
+            Best-fit orbit(s) with provenance columns populated.
+        fitted_orbit_members : FittedOrbitMembers
+            Per-observation residuals and outlier flags.
+
+        Raises
+        ------
+        RuntimeError
+            If the backend binary returns a non-zero exit code or produces
+            unreadable output.
+        ValueError
+            If the backend output cannot be parsed.
+        """
+        ...
+
+    def _check_available(self) -> None:
+        """Raise :exc:`ImportError` with install instructions if not available."""
+        if not self.AVAILABLE:
+            raise ImportError(
+                f"The '{self.BACKEND_NAME}' backend is not available.  "
+                f"See the installation instructions for this backend in the "
+                f"adam_core orbit determination documentation."
+            )

--- a/src/adam_core/orbit_determination/backends/find_orb.py
+++ b/src/adam_core/orbit_determination/backends/find_orb.py
@@ -1,0 +1,360 @@
+"""
+FindOrb backend wrapper for
+:func:`~adam_core.orbit_determination.fit_orbit.fit_orbit`.
+
+This module wraps the ``adam_fo`` package, which provides a Python interface
+to Bill Gray's Find_Orb orbit-determination program.
+
+Installation
+------------
+Install the optional dependency with::
+
+    pip install adam-fo
+
+or, via the adam_core extras::
+
+    pip install adam_core[find_orb]
+
+Notes on the DELEGATE vs ADAM weighting policy
+-----------------------------------------------
+Find_Orb does not expose per-observation residuals through the ``adam_fo``
+Python API.  When :attr:`WeightingPolicy.DELEGATE` (the default) is selected
+the returned :class:`~adam_core.orbit_determination.fitted_orbits.FittedOrbitMembers`
+will have ``residuals=None`` for every observation; ``chi2`` and
+``reduced_chi2`` on
+:class:`~adam_core.orbit_determination.fitted_orbits.FittedOrbits` will be
+``NaN``.
+
+When :attr:`WeightingPolicy.ADAM` is selected, a propagator class must be
+supplied via ``BackendConfig.backend_kwargs["propagator"]``.  After Find_Orb
+returns the orbit, :func:`~adam_core.orbit_determination.evaluate.evaluate_orbits`
+is called to compute adam-managed residuals and chi2 values.
+
+ADES conversion
+---------------
+:class:`OrbitDeterminationObservations` is converted to the ADES format that
+Find_Orb expects.  The ``trkSub`` field (8-character limit in ADES) is
+populated from the first observation's ``id``, truncated to 8 characters.
+RA/Dec covariance sigma values are converted from degrees to arcseconds.
+"""
+
+import logging
+import os
+from importlib.metadata import PackageNotFoundError, version
+from typing import Optional, Tuple
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.compute as pc
+
+from ..config import BackendConfig, WeightingPolicy
+from ..evaluate import OrbitDeterminationObservations, evaluate_orbits
+from ..fitted_orbits import FittedOrbitMembers, FittedOrbits
+from .base import BackendWrapper
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.environ.get("ADAM_LOG_LEVEL", "INFO"))
+
+# ---------------------------------------------------------------------------
+# Availability check — performed once at import time
+# ---------------------------------------------------------------------------
+try:
+    from adam_fo import fo as _fo
+    from adam_core.observations.ades import (
+        ADES_to_string,
+        ADESObservations,
+        ObsContext,
+        ObservatoryObsContext,
+        SubmitterObsContext,
+        TelescopeObsContext,
+    )
+
+    _FIND_ORB_AVAILABLE = True
+except ImportError:
+    _FIND_ORB_AVAILABLE = False
+
+
+def _get_adam_fo_version() -> Optional[str]:
+    """Return the installed ``adam_fo`` version string, or ``None``."""
+    try:
+        return version("adam-fo")
+    except PackageNotFoundError:
+        return None
+
+
+def _observations_to_ades(
+    observations: OrbitDeterminationObservations,
+) -> Tuple[str, "ADESObservations"]:
+    """Convert :class:`OrbitDeterminationObservations` to an ADES format string.
+
+    Parameters
+    ----------
+    observations : OrbitDeterminationObservations
+        Observations for a single object.  The ``id`` of the *first*
+        observation is used as ``trkSub`` (truncated to 8 characters).
+
+    Returns
+    -------
+    ades_string : str
+        ADES-formatted text ready to be passed to ``adam_fo.fo``.
+    ades_observations : ADESObservations
+        Structured ADES table (returned for downstream use / logging).
+
+    Raises
+    ------
+    ValueError
+        If ``observations`` is empty.
+    """
+    if len(observations) == 0:
+        raise ValueError("Cannot convert empty observations to ADES format.")
+
+    # Use the first observation's id as trkSub (ADES 8-char limit)
+    trk_sub = pc.utf8_slice_codeunits(observations.id, 0, 8)
+
+    # Convert RA/Dec covariance sigmas from degrees to arcseconds.
+    # The RA sigma must additionally be scaled by cos(Dec) to give the
+    # on-sky (projected) uncertainty.
+    dec_rad = np.radians(
+        observations.coordinates.lat.to_numpy(zero_copy_only=False)
+    )
+    sigmas = observations.coordinates.covariance.sigmas  # shape (N, 6)
+    # sigmas[:, 1] = RA sigma (degrees), sigmas[:, 2] = Dec sigma (degrees)
+    sigma_ra_cos_dec = np.cos(dec_rad) * sigmas[:, 1]
+    sigma_ra_arcsec = pa.array(sigma_ra_cos_dec * 3600.0, type=pa.float64())
+    sigma_dec_arcsec = pa.array(
+        sigmas[:, 2].to_numpy(zero_copy_only=False) * 3600.0, type=pa.float64()
+    )
+
+    # Replace NaN with null so ADES serialisation omits the field
+    sigma_ra_arcsec = pc.if_else(pc.is_nan(sigma_ra_arcsec), None, sigma_ra_arcsec)
+    sigma_dec_arcsec = pc.if_else(
+        pc.is_nan(sigma_dec_arcsec), None, sigma_dec_arcsec
+    )
+
+    # Determine observatory code from coordinates.origin.code
+    stn_codes = observations.coordinates.origin.code
+
+    # Build photometry fields — may be null if photometry is absent
+    phot = observations.photometry
+    mag = phot.mag if phot is not None else pa.repeat(None, len(observations))
+    rms_mag = (
+        phot.rmsmag if phot is not None else pa.repeat(None, len(observations))
+    )
+    band = phot.band if phot is not None else pa.repeat(None, len(observations))
+
+    ades_obs = ADESObservations.from_kwargs(
+        trkSub=trk_sub,
+        obsTime=observations.coordinates.time,
+        ra=observations.coordinates.lon,
+        dec=observations.coordinates.lat,
+        rmsRACosDec=sigma_ra_arcsec,
+        rmsDec=sigma_dec_arcsec,
+        mag=mag,
+        rmsMag=rms_mag,
+        band=band,
+        stn=stn_codes,
+        mode=pa.repeat("NA", len(observations)),
+        astCat=pa.repeat("NA", len(observations)),
+    )
+
+    # Build a minimal ObsContext for each unique observatory code
+    unique_codes = pc.unique(stn_codes).to_pylist()
+    obs_contexts = {
+        code: ObsContext(
+            observatory=ObservatoryObsContext(mpcCode=code),
+            submitter=SubmitterObsContext(
+                name="adam_core",
+                institution="adam_core automated OD",
+            ),
+            observers=["adam_core"],
+            measurers=["adam_core"],
+            telescope=TelescopeObsContext(
+                design="Unknown",
+                aperture=1.0,
+                detector="Unknown",
+            ),
+        )
+        for code in unique_codes
+    }
+
+    ades_string = ADES_to_string(ades_obs, obs_contexts)
+    return ades_string, ades_obs
+
+
+class FindOrbBackend(BackendWrapper):
+    """Orbit-determination backend that delegates to Find_Orb via ``adam_fo``.
+
+    Parameters
+    ----------
+    out_dir : str, optional
+        If provided, Find_Orb output files are copied to this directory after
+        the run.  Useful for debugging.
+
+    Examples
+    --------
+    >>> from adam_core.orbit_determination.backends import FindOrbBackend
+    >>> backend = FindOrbBackend()
+    >>> fitted, members = backend.fit(observations, config)
+    """
+
+    AVAILABLE: bool = _FIND_ORB_AVAILABLE
+    BACKEND_NAME: str = "find_orb"
+
+    def fit(
+        self,
+        observations: OrbitDeterminationObservations,
+        config: BackendConfig,
+    ) -> Tuple[FittedOrbits, FittedOrbitMembers]:
+        """Fit an orbit using Find_Orb.
+
+        Parameters
+        ----------
+        observations : OrbitDeterminationObservations
+            Observations for a single object.
+        config : BackendConfig
+            Runtime configuration.  Relevant ``backend_kwargs`` keys:
+
+            * ``"out_dir"`` *(str)* – directory where Find_Orb writes its
+              output files (forwarded to ``adam_fo.fo``).
+            * ``"propagator"`` *(Type[Propagator])* – required when
+              ``weighting_policy`` is :attr:`WeightingPolicy.ADAM`.
+
+        Returns
+        -------
+        fitted_orbits : FittedOrbits
+            Orbit returned by Find_Orb.  ``chi2`` and ``reduced_chi2`` are
+            ``NaN`` in :attr:`WeightingPolicy.DELEGATE` mode.
+        fitted_orbit_members : FittedOrbitMembers
+            Per-observation membership table.  ``residuals`` is ``None`` in
+            :attr:`WeightingPolicy.DELEGATE` mode.
+
+        Raises
+        ------
+        ImportError
+            If ``adam_fo`` is not installed.
+        RuntimeError
+            If Find_Orb returns an error or produces no orbit.
+        ValueError
+            If the output cannot be parsed.
+        """
+        self._check_available()
+
+        out_dir: Optional[str] = config.backend_kwargs.get("out_dir", None)
+
+        logger.info(
+            "FindOrbBackend: fitting orbit for %d observations.", len(observations)
+        )
+
+        # --- Convert to ADES --------------------------------------------------
+        ades_string, ades_obs = _observations_to_ades(observations)
+
+        # --- Invoke Find_Orb --------------------------------------------------
+        orbit_raw, rejected_raw, error = _fo(
+            ades_string,
+            out_dir=out_dir,
+            clean_up=(out_dir is None),
+        )
+
+        if error is not None or len(orbit_raw) == 0:
+            raise RuntimeError(
+                f"Find_Orb failed to produce an orbit. "
+                f"Error message: {error!r}. "
+                f"Ensure the find_orb binary is installed correctly "
+                f"('build-fo' command from adam-fo) and that the observations "
+                f"have valid covariances and observer states."
+            )
+
+        logger.info("FindOrbBackend: Find_Orb returned %d orbit(s).", len(orbit_raw))
+
+        # --- Determine which obs were rejected --------------------------------
+        # rejected_raw is an ADESObservations table; match by time+code.
+        rejected_times = set()
+        if len(rejected_raw) > 0:
+            for i in range(len(rejected_raw)):
+                mjd = rejected_raw.obsTime.mjd()[i].as_py()
+                code = rejected_raw.stn[i].as_py()
+                rejected_times.add((round(mjd, 8), code))
+
+        obs_mjds = observations.coordinates.time.mjd().to_pylist()
+        obs_codes = observations.coordinates.origin.code.to_pylist()
+        outlier_flags = pa.array(
+            [
+                (round(m, 8), c) in rejected_times
+                for m, c in zip(obs_mjds, obs_codes)
+            ],
+            type=pa.bool_(),
+        )
+
+        # --- Build provenance -------------------------------------------------
+        backend_version = _get_adam_fo_version()
+
+        # --- Apply weighting policy -------------------------------------------
+        if config.weighting_policy is WeightingPolicy.ADAM:
+            propagator_cls = config.backend_kwargs.get("propagator")
+            if propagator_cls is None:
+                raise ValueError(
+                    "WeightingPolicy.ADAM requires a 'propagator' key in "
+                    "BackendConfig.backend_kwargs.  "
+                    "Example: BackendConfig(weighting_policy=WeightingPolicy.ADAM, "
+                    "backend_kwargs={'propagator': ASSISTPropagator})"
+                )
+            logger.info(
+                "FindOrbBackend: computing adam-managed residuals with %s.",
+                propagator_cls.__name__,
+            )
+            fitted_orbits, fitted_members = evaluate_orbits(
+                orbit_raw,
+                observations,
+                propagator_cls(),
+            )
+            # Stamp provenance
+            fitted_orbits = fitted_orbits.set_column(
+                "backend",
+                pa.repeat(self.BACKEND_NAME, len(fitted_orbits)),
+            )
+            fitted_orbits = fitted_orbits.set_column(
+                "backend_version",
+                pa.repeat(backend_version, len(fitted_orbits)),
+            )
+            # Preserve the outlier flags from Find_Orb
+            fitted_members = FittedOrbitMembers.from_kwargs(
+                orbit_id=fitted_members.orbit_id,
+                obs_id=fitted_members.obs_id,
+                residuals=fitted_members.residuals,
+                solution=pc.invert(outlier_flags),
+                outlier=outlier_flags,
+            )
+            return fitted_orbits, fitted_members
+
+        # DELEGATE mode: build minimal FittedOrbits without chi2/residuals
+        orbit_id = orbit_raw.orbit_id[0].as_py()
+        num_inliers = int(pc.sum(pc.invert(outlier_flags)).as_py())
+        arc_days = (
+            observations.coordinates.time.max().mjd()[0].as_py()
+            - observations.coordinates.time.min().mjd()[0].as_py()
+        )
+
+        fitted_orbits = FittedOrbits.from_kwargs(
+            orbit_id=[orbit_id],
+            object_id=orbit_raw.object_id,
+            coordinates=orbit_raw.coordinates,
+            arc_length=[arc_days],
+            num_obs=[num_inliers],
+            chi2=[float("nan")],
+            reduced_chi2=[float("nan")],
+            iterations=pa.repeat(None, 1),
+            success=[True],
+            status_code=[0],
+            backend=pa.repeat(self.BACKEND_NAME, 1),
+            backend_version=pa.repeat(backend_version, 1),
+        )
+
+        fitted_members = FittedOrbitMembers.from_kwargs(
+            orbit_id=pa.repeat(orbit_id, len(observations)),
+            obs_id=observations.id,
+            residuals=None,
+            solution=pc.invert(outlier_flags),
+            outlier=outlier_flags,
+        )
+
+        return fitted_orbits, fitted_members

--- a/src/adam_core/orbit_determination/backends/layup.py
+++ b/src/adam_core/orbit_determination/backends/layup.py
@@ -1,0 +1,106 @@
+"""
+Layup backend wrapper for
+:func:`~adam_core.orbit_determination.fit_orbit.fit_orbit`.
+
+.. note::
+
+    This backend is a **stub**.  Once the ``layup`` package exposes a stable
+    Python OD API this module should:
+
+    1. Convert :class:`~adam_core.orbit_determination.evaluate.OrbitDeterminationObservations`
+       to the format expected by ``layup``.
+    2. Invoke the Layup orbit-determination routine.
+    3. Parse the result into
+       :class:`~adam_core.orbit_determination.fitted_orbits.FittedOrbits` and
+       :class:`~adam_core.orbit_determination.fitted_orbits.FittedOrbitMembers`.
+
+Installation (once available)
+------------------------------
+::
+
+    pip install layup
+    # or
+    pip install adam_core[layup]
+
+TODO(od-module): Implement Layup backend once layup OD API is stable.
+"""
+
+import logging
+import os
+from importlib.metadata import PackageNotFoundError, version
+from typing import Optional, Tuple
+
+import pyarrow as pa
+
+from ..config import BackendConfig
+from ..evaluate import OrbitDeterminationObservations
+from ..fitted_orbits import FittedOrbitMembers, FittedOrbits
+from .base import BackendWrapper
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.environ.get("ADAM_LOG_LEVEL", "INFO"))
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+try:
+    import layup as _layup  # noqa: F401
+
+    _LAYUP_AVAILABLE = True
+except ImportError:
+    _LAYUP_AVAILABLE = False
+
+
+def _get_layup_version() -> Optional[str]:
+    try:
+        return version("layup")
+    except PackageNotFoundError:
+        return None
+
+
+class LayupBackend(BackendWrapper):
+    """Orbit-determination backend wrapping the Layup solver.
+
+    .. warning::
+        This backend is not yet implemented.  Calling :meth:`fit` will
+        raise :exc:`NotImplementedError`.
+
+    Raises
+    ------
+    ImportError
+        If the ``layup`` package is not installed.
+    NotImplementedError
+        Always, until this stub is completed.
+    """
+
+    AVAILABLE: bool = _LAYUP_AVAILABLE
+    BACKEND_NAME: str = "layup"
+
+    def fit(
+        self,
+        observations: OrbitDeterminationObservations,
+        config: BackendConfig,
+    ) -> Tuple[FittedOrbits, FittedOrbitMembers]:
+        """Not yet implemented.
+
+        Parameters
+        ----------
+        observations : OrbitDeterminationObservations
+            Observations for a single object.
+        config : BackendConfig
+            Runtime configuration (currently unused).
+
+        Raises
+        ------
+        ImportError
+            If ``layup`` is not installed.
+        NotImplementedError
+            Always — this backend is a stub.
+        """
+        self._check_available()
+        # TODO(od-module): Implement Layup input/output translation and invocation.
+        raise NotImplementedError(
+            "The Layup backend is not yet implemented.  "
+            "Contributions are welcome — see the adam_core orbit determination "
+            "documentation for the expected input/output contract."
+        )

--- a/src/adam_core/orbit_determination/backends/orbfit.py
+++ b/src/adam_core/orbit_determination/backends/orbfit.py
@@ -1,0 +1,110 @@
+"""
+OrbFit backend wrapper for
+:func:`~adam_core.orbit_determination.fit_orbit.fit_orbit`.
+
+.. note::
+
+    This backend is a **stub**.  The ``orbfit`` Python package API has not
+    yet been finalised.  Once a stable API is available this module should:
+
+    1. Convert :class:`~adam_core.orbit_determination.evaluate.OrbitDeterminationObservations`
+       to the input format expected by ``orbfit``.
+    2. Invoke the OrbFit solver.
+    3. Parse the solver's output into
+       :class:`~adam_core.orbit_determination.fitted_orbits.FittedOrbits` and
+       :class:`~adam_core.orbit_determination.fitted_orbits.FittedOrbitMembers`.
+
+Installation (once available)
+------------------------------
+::
+
+    pip install orbfit
+    # or
+    pip install adam_core[orbfit]
+
+TODO(od-module): Implement OrbFit backend once orbfit Python API is stable.
+"""
+
+import logging
+import os
+from importlib.metadata import PackageNotFoundError, version
+from typing import Optional, Tuple
+
+import pyarrow as pa
+
+from ..config import BackendConfig
+from ..evaluate import OrbitDeterminationObservations
+from ..fitted_orbits import FittedOrbitMembers, FittedOrbits
+from .base import BackendWrapper
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.environ.get("ADAM_LOG_LEVEL", "INFO"))
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+try:
+    import orbfit as _orbfit  # noqa: F401
+
+    _ORBFIT_AVAILABLE = True
+except ImportError:
+    _ORBFIT_AVAILABLE = False
+
+
+def _get_orbfit_version() -> Optional[str]:
+    try:
+        return version("orbfit")
+    except PackageNotFoundError:
+        return None
+
+
+class OrbFitBackend(BackendWrapper):
+    """Orbit-determination backend wrapping the OrbFit solver.
+
+    .. warning::
+        This backend is not yet implemented.  Calling :meth:`fit` will
+        raise :exc:`NotImplementedError`.
+
+    Parameters
+    ----------
+    None
+
+    Raises
+    ------
+    ImportError
+        If the ``orbfit`` package is not installed.
+    NotImplementedError
+        Always, until this stub is completed.
+    """
+
+    AVAILABLE: bool = _ORBFIT_AVAILABLE
+    BACKEND_NAME: str = "orbfit"
+
+    def fit(
+        self,
+        observations: OrbitDeterminationObservations,
+        config: BackendConfig,
+    ) -> Tuple[FittedOrbits, FittedOrbitMembers]:
+        """Not yet implemented.
+
+        Parameters
+        ----------
+        observations : OrbitDeterminationObservations
+            Observations for a single object.
+        config : BackendConfig
+            Runtime configuration (currently unused).
+
+        Raises
+        ------
+        ImportError
+            If ``orbfit`` is not installed.
+        NotImplementedError
+            Always — this backend is a stub.
+        """
+        self._check_available()
+        # TODO(od-module): Implement OrbFit input/output translation and invocation.
+        raise NotImplementedError(
+            "The OrbFit backend is not yet implemented.  "
+            "Contributions are welcome — see the adam_core orbit determination "
+            "documentation for the expected input/output contract."
+        )

--- a/src/adam_core/orbit_determination/config.py
+++ b/src/adam_core/orbit_determination/config.py
@@ -1,0 +1,68 @@
+"""
+Configuration dataclasses and enumerations for the orbit determination module.
+"""
+
+import enum
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class WeightingPolicy(enum.Enum):
+    """Controls how residual weighting is handled during orbit fitting.
+
+    Parameters
+    ----------
+    DELEGATE :
+        Delegate residual weighting entirely to the backend.  The backend
+        is responsible for computing and applying its own weights.  This is
+        the default and is appropriate when you want to use the backend
+        author's recommended settings without post-processing.
+    ADAM :
+        After the backend returns an orbit, override the per-observation
+        residuals by calling :func:`~adam_core.orbit_determination.evaluate.evaluate_orbits`
+        with an adam-managed propagator.  This requires a ``propagator``
+        key to be present in :attr:`BackendConfig.backend_kwargs`.
+
+    Notes
+    -----
+    Per-observatory uncertainty overrides are a planned future extension;
+    see TODO(od-module): per-observatory uncertainty overrides.
+    """
+
+    DELEGATE = "delegate"
+    ADAM = "adam"
+
+
+@dataclass
+class BackendConfig:
+    """Runtime configuration passed to a :func:`~adam_core.orbit_determination.fit_orbit.fit_orbit`
+    backend.
+
+    Parameters
+    ----------
+    weighting_policy : WeightingPolicy, optional
+        How to handle residual weighting.  Defaults to
+        :attr:`WeightingPolicy.DELEGATE`.
+    backend_kwargs : dict, optional
+        Arbitrary keyword arguments forwarded transparently to the selected
+        backend.  Common keys:
+
+        * ``"propagator"`` – a :class:`~adam_core.propagator.Propagator`
+          *class* (not instance) required by the
+          :attr:`WeightingPolicy.ADAM` policy and the adam backend.
+        * ``"min_obs"`` – minimum number of observations for the adam backend.
+        * ``"rchi2_threshold"`` – reduced-chi2 convergence threshold.
+        * ``"contamination_percentage"`` – maximum fraction of outliers.
+        * ``"out_dir"`` – output directory forwarded to the find_orb backend.
+
+    Examples
+    --------
+    >>> from adam_core.orbit_determination.config import BackendConfig, WeightingPolicy
+    >>> cfg = BackendConfig(
+    ...     weighting_policy=WeightingPolicy.ADAM,
+    ...     backend_kwargs={"propagator": MyPropagator},
+    ... )
+    """
+
+    weighting_policy: WeightingPolicy = WeightingPolicy.DELEGATE
+    backend_kwargs: dict[str, Any] = field(default_factory=dict)

--- a/src/adam_core/orbit_determination/fit_orbit.py
+++ b/src/adam_core/orbit_determination/fit_orbit.py
@@ -1,0 +1,303 @@
+"""
+Public entrypoint for orbit determination.
+
+The single public symbol exported from this module is :func:`fit_orbit`.  All
+backend-specific implementation details live under
+:mod:`adam_core.orbit_determination.backends`.
+
+Usage
+-----
+::
+
+    from adam_core.orbit_determination import fit_orbit
+    from adam_core.orbit_determination.config import BackendConfig
+    from adam_assist import ASSISTPropagator
+
+    fitted_orbits, fitted_members = fit_orbit(
+        observations,
+        backend="adam",
+        config=BackendConfig(backend_kwargs={"propagator": ASSISTPropagator}),
+    )
+
+Backend availability
+--------------------
+The :func:`fit_orbit` function checks whether the requested backend is
+installed before dispatching.  If the backend package is absent it raises an
+:exc:`ImportError` with an install command in the message.
+"""
+
+import logging
+import os
+from typing import Literal, Optional, Tuple
+
+import pyarrow.compute as pc
+
+from .backends import (
+    FIND_ORB_AVAILABLE,
+    LAYUP_AVAILABLE,
+    ORBFIT_AVAILABLE,
+    AdamBackend,
+    FindOrbBackend,
+    LayupBackend,
+    OrbFitBackend,
+)
+from .config import BackendConfig
+from .evaluate import OrbitDeterminationObservations
+from .fitted_orbits import FittedOrbitMembers, FittedOrbits
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.environ.get("ADAM_LOG_LEVEL", "INFO"))
+
+# ---------------------------------------------------------------------------
+# Backend registry
+# ---------------------------------------------------------------------------
+
+_BACKEND_CLASSES = {
+    "adam": AdamBackend,
+    "find_orb": FindOrbBackend,
+    "orbfit": OrbFitBackend,
+    "layup": LayupBackend,
+}
+
+_BACKEND_INSTALL_COMMANDS: dict[str, str] = {
+    "find_orb": "pip install adam-fo  # then run: build-fo",
+    "orbfit": "pip install orbfit",
+    "layup": "pip install layup",
+}
+
+_BACKEND_AVAILABLE: dict[str, bool] = {
+    "adam": True,
+    "find_orb": FIND_ORB_AVAILABLE,
+    "orbfit": ORBFIT_AVAILABLE,
+    "layup": LAYUP_AVAILABLE,
+}
+
+
+# ---------------------------------------------------------------------------
+# Input validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_observations(observations: OrbitDeterminationObservations) -> None:
+    """Raise descriptive errors for invalid observation inputs.
+
+    Parameters
+    ----------
+    observations : OrbitDeterminationObservations
+        Observations to validate.
+
+    Raises
+    ------
+    ValueError
+        * If *observations* is empty.
+        * If any observation is missing covariance information (all-NaN
+          diagonal on RA/Dec dimensions).
+        * If observer states (Cartesian coordinates) are all-NaN.
+    """
+    n = len(observations)
+    if n == 0:
+        raise ValueError(
+            "fit_orbit received 0 observations.  "
+            "At least 3 observations are required for orbit determination."
+        )
+
+    # --- Check covariances ---------------------------------------------------
+    # We require non-NaN sigma on the RA (index 1) and Dec (index 2) dimensions
+    # at minimum.  A fully NaN covariance matrix means the backend cannot weight
+    # residuals correctly.
+    sigmas = observations.coordinates.covariance.sigmas  # (N, 6) array-like
+    ra_sigma = sigmas[:, 1].to_numpy(zero_copy_only=False)
+    dec_sigma = sigmas[:, 2].to_numpy(zero_copy_only=False)
+
+    import numpy as np
+
+    missing_cov_mask = np.isnan(ra_sigma) & np.isnan(dec_sigma)
+    if missing_cov_mask.all():
+        raise ValueError(
+            "fit_orbit: all observations are missing RA/Dec covariance information.  "
+            "Populate SphericalCoordinates.covariance with at least RA and Dec sigmas "
+            "before calling fit_orbit."
+        )
+    if missing_cov_mask.any():
+        bad_ids = observations.id.filter(
+            pc.equal(
+                observations.id,
+                observations.id,
+            )
+        ).to_pylist()
+        # Report up to the first 5 bad IDs
+        import numpy as np
+
+        bad_idx = list(np.where(missing_cov_mask)[0][:5])
+        bad_ids = [observations.id[i].as_py() for i in bad_idx]
+        logger.warning(
+            "fit_orbit: %d observation(s) are missing RA/Dec covariance "
+            "(e.g. ids: %s).  These will be treated as unconstrained by "
+            "backends that respect covariances.",
+            int(missing_cov_mask.sum()),
+            bad_ids,
+        )
+
+    # --- Check observer states -----------------------------------------------
+    # Observer Cartesian coordinates must be populated (not all NaN).
+    obs_x = observations.observers.coordinates.x.to_numpy(zero_copy_only=False)
+    if np.isnan(obs_x).all():
+        raise ValueError(
+            "fit_orbit: observer states (Observers.coordinates) are all NaN.  "
+            "Populate observer positions before calling fit_orbit, e.g. via "
+            "Observers.from_codes(codes, times)."
+        )
+
+    missing_state_mask = np.isnan(obs_x)
+    if missing_state_mask.any():
+        bad_idx = list(np.where(missing_state_mask)[0][:5])
+        bad_ids = [observations.id[i].as_py() for i in bad_idx]
+        raise ValueError(
+            f"fit_orbit: {int(missing_state_mask.sum())} observation(s) have "
+            f"missing observer states (e.g. obs ids: {bad_ids}).  "
+            f"Ensure every observation has a corresponding observer position."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def fit_orbit(
+    observations: OrbitDeterminationObservations,
+    backend: Literal["find_orb", "orbfit", "layup", "adam"] = "adam",
+    config: Optional[BackendConfig] = None,
+) -> Tuple[FittedOrbits, FittedOrbitMembers]:
+    """Fit an orbit to a set of observations using the specified backend.
+
+    This is the primary public entrypoint for orbit determination in
+    adam_core.  It validates the input observations, dispatches to the
+    requested backend wrapper, and returns standardised
+    :class:`~adam_core.orbit_determination.fitted_orbits.FittedOrbits` and
+    :class:`~adam_core.orbit_determination.fitted_orbits.FittedOrbitMembers`
+    tables regardless of which backend was used.
+
+    Parameters
+    ----------
+    observations : OrbitDeterminationObservations
+        All observations believed to belong to a **single** object.  The
+        table must contain:
+
+        * ``id`` — unique observation identifiers.
+        * ``coordinates`` — :class:`~adam_core.coordinates.SphericalCoordinates`
+          in the equatorial frame with at least RA/Dec sigmas populated.
+        * ``observers`` — :class:`~adam_core.observers.Observers` with
+          Cartesian states computed (e.g. via
+          :meth:`~adam_core.observers.Observers.from_codes`).
+
+    backend : {'adam', 'find_orb', 'orbfit', 'layup'}, optional
+        Which backend to use.  Defaults to ``'adam'`` (the native
+        adam_core IOD + differential-correction pipeline).  External backends
+        require the corresponding optional package to be installed:
+
+        * ``'find_orb'`` → ``pip install adam-fo`` then ``build-fo``
+        * ``'orbfit'`` → ``pip install orbfit`` *(not yet implemented)*
+        * ``'layup'`` → ``pip install layup`` *(not yet implemented)*
+
+    config : BackendConfig, optional
+        Runtime configuration controlling weighting policy and
+        backend-specific parameters.  If ``None``, a default
+        :class:`~adam_core.orbit_determination.config.BackendConfig` is used
+        (``WeightingPolicy.DELEGATE``, no extra kwargs).
+
+    Returns
+    -------
+    fitted_orbits : FittedOrbits
+        Best-fit orbit(s).  The ``backend`` and ``backend_version`` columns
+        record which backend produced each orbit.
+    fitted_orbit_members : FittedOrbitMembers
+        Per-observation table linking each observation to its orbit via
+        ``orbit_id``, with residuals and outlier flags where available.
+
+    Raises
+    ------
+    ValueError
+        If *observations* is empty, missing covariances, or missing observer
+        states; or if the backend requires a propagator that was not supplied.
+    ImportError
+        If the requested backend package is not installed, with an install
+        command in the error message.
+    RuntimeError
+        If the backend binary returns an error or produces no orbit.
+
+    Examples
+    --------
+    Using the native adam backend with ASSIST:
+
+    >>> from adam_core.orbit_determination import fit_orbit
+    >>> from adam_core.orbit_determination.config import BackendConfig
+    >>> from adam_assist import ASSISTPropagator
+    >>> fitted, members = fit_orbit(
+    ...     observations,
+    ...     backend="adam",
+    ...     config=BackendConfig(backend_kwargs={"propagator": ASSISTPropagator}),
+    ... )
+
+    Using Find_Orb with default DELEGATE weighting:
+
+    >>> fitted, members = fit_orbit(observations, backend="find_orb")
+
+    Using Find_Orb with adam-managed residuals:
+
+    >>> from adam_core.orbit_determination.config import WeightingPolicy
+    >>> fitted, members = fit_orbit(
+    ...     observations,
+    ...     backend="find_orb",
+    ...     config=BackendConfig(
+    ...         weighting_policy=WeightingPolicy.ADAM,
+    ...         backend_kwargs={"propagator": ASSISTPropagator},
+    ...     ),
+    ... )
+
+    Notes
+    -----
+    ``fit_orbit`` is designed for **single-object** orbit determination.  For
+    batch processing of many objects, call ``fit_orbit`` in a loop or use
+    the parallelism options available in the backend's own pipeline
+    (e.g. ``differential_correction`` with Ray).
+    """
+    if config is None:
+        config = BackendConfig()
+
+    # --- Validate backend name -----------------------------------------------
+    if backend not in _BACKEND_CLASSES:
+        raise ValueError(
+            f"Unknown backend {backend!r}.  "
+            f"Choose from: {sorted(_BACKEND_CLASSES.keys())}."
+        )
+
+    # --- Check availability --------------------------------------------------
+    if not _BACKEND_AVAILABLE[backend]:
+        install_cmd = _BACKEND_INSTALL_COMMANDS.get(backend, f"pip install {backend}")
+        raise ImportError(
+            f"The '{backend}' backend is not available in this environment.  "
+            f"Install it with:\n\n    {install_cmd}\n"
+        )
+
+    # --- Validate observations ------------------------------------------------
+    _validate_observations(observations)
+
+    logger.info(
+        "fit_orbit: dispatching %d observations to backend '%s'.",
+        len(observations),
+        backend,
+    )
+
+    # --- Dispatch ------------------------------------------------------------
+    backend_instance = _BACKEND_CLASSES[backend]()
+    fitted_orbits, fitted_members = backend_instance.fit(observations, config)
+
+    logger.info(
+        "fit_orbit: backend '%s' returned %d orbit(s) covering %d observation memberships.",
+        backend,
+        len(fitted_orbits),
+        len(fitted_members),
+    )
+
+    return fitted_orbits, fitted_members

--- a/src/adam_core/orbit_determination/fitted_orbits.py
+++ b/src/adam_core/orbit_determination/fitted_orbits.py
@@ -137,6 +137,10 @@ class FittedOrbits(qv.Table):
     iterations = qv.Int64Column(nullable=True)
     success = qv.BooleanColumn(nullable=True)
     status_code = qv.Int64Column(nullable=True)
+    # Provenance: which backend produced this orbit and its detected version.
+    # Nullable so that orbits created outside fit_orbit() are unaffected.
+    backend = qv.LargeStringColumn(nullable=True)
+    backend_version = qv.LargeStringColumn(nullable=True)
 
     def to_orbits(self) -> Orbits:
         """

--- a/src/adam_core/orbit_determination/tests/data/od/README.md
+++ b/src/adam_core/orbit_determination/tests/data/od/README.md
@@ -1,0 +1,63 @@
+# OD Integration Test Fixtures
+
+This directory holds small observation sets used by integration tests for
+the orbit-determination backends.
+
+## Adding fixtures
+
+Each fixture should be a Parquet file serialisable by a
+`OrbitDeterminationObservations` quivr table, e.g.
+
+```python
+from adam_core.orbit_determination import OrbitDeterminationObservations
+
+obs = OrbitDeterminationObservations.from_parquet("ceres_10obs.parquet")
+```
+
+### Naming convention
+
+`<object_name>_<n>obs.parquet` — e.g. `ceres_10obs.parquet`.
+
+### Recommended content
+
+* 5–20 observations for a well-characterised MPC object (e.g. 1 Ceres,
+  2 Pallas, or any numbered asteroid with a stable solution).
+* Observations must have:
+  * Non-NaN RA/Dec covariance sigmas.
+  * Observer states populated (`Observers.from_codes`).
+  * Time scale: UTC (observation times) with TDB observer states.
+
+### How to generate
+
+```python
+import numpy as np
+import pyarrow as pa
+from adam_core.coordinates import CoordinateCovariances, Origin, SphericalCoordinates
+from adam_core.observers import Observers
+from adam_core.orbit_determination import OrbitDeterminationObservations
+from adam_core.time import Timestamp
+
+# Example: pull 10 MPC observations for 1 Ceres from astroquery
+# (adapt as needed)
+times = Timestamp.from_mjd([...], scale="utc")
+sigmas = np.full((len(times), 6), np.nan)
+sigmas[:, 1] = ...  # RA sigma in degrees
+sigmas[:, 2] = ...  # Dec sigma in degrees
+coords = SphericalCoordinates.from_kwargs(
+    lon=[...], lat=[...], time=times,
+    origin=Origin.from_kwargs(code=["XXX"] * len(times)),
+    frame="equatorial",
+    covariance=CoordinateCovariances.from_sigmas(sigmas),
+)
+observers = Observers.from_codes(codes=["XXX"] * len(times), times=times)
+obs = OrbitDeterminationObservations.from_kwargs(
+    id=[...], coordinates=coords, observers=observers
+)
+obs.to_parquet("ceres_10obs.parquet")
+```
+
+## TODO(od-module)
+
+Add at least one fixture for integration regression tests:
+- `ceres_10obs.parquet` — 10 MPC observations for 1 Ceres
+  Expected reduced chi2 (find_orb ADAM mode): < 5.0

--- a/src/adam_core/orbit_determination/tests/test_backends/test_adam.py
+++ b/src/adam_core/orbit_determination/tests/test_backends/test_adam.py
@@ -1,0 +1,227 @@
+"""
+Unit tests for AdamBackend.
+
+The propagator and underlying IOD/DC functions are mocked so these tests
+run without adam-assist or any other propagator installed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from adam_core.coordinates import CartesianCoordinates, CoordinateCovariances, Origin, SphericalCoordinates
+from adam_core.observers import Observers
+from adam_core.orbit_determination.backends.adam import AdamBackend
+from adam_core.orbit_determination.config import BackendConfig, WeightingPolicy
+from adam_core.orbit_determination.evaluate import OrbitDeterminationObservations
+from adam_core.orbit_determination.fitted_orbits import FittedOrbitMembers, FittedOrbits
+from adam_core.time import Timestamp
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_observations(n: int = 8) -> OrbitDeterminationObservations:
+    times = Timestamp.from_mjd(np.linspace(59000, 59030, n), scale="utc")
+    sigmas = np.full((n, 6), np.nan)
+    sigmas[:, 1] = 1.0 / 3600.0
+    sigmas[:, 2] = 1.0 / 3600.0
+    coords = SphericalCoordinates.from_kwargs(
+        lon=np.full(n, 180.0),
+        lat=np.zeros(n),
+        time=times,
+        origin=Origin.from_kwargs(code=pa.repeat("X05", n)),
+        frame="equatorial",
+        covariance=CoordinateCovariances.from_sigmas(sigmas),
+    )
+    observers = Observers.from_codes(codes=pa.repeat("X05", n), times=times)
+    return OrbitDeterminationObservations.from_kwargs(
+        id=[f"obs{i:03d}" for i in range(n)],
+        coordinates=coords,
+        observers=observers,
+    )
+
+
+def _make_iod_result(n_orbits: int = 2, n_obs: int = 8) -> tuple:
+    coords = CartesianCoordinates.from_kwargs(
+        x=[1.0] * n_orbits,
+        y=[0.0] * n_orbits,
+        z=[0.0] * n_orbits,
+        vx=[0.0] * n_orbits,
+        vy=[0.01] * n_orbits,
+        vz=[0.0] * n_orbits,
+        time=Timestamp.from_mjd([59000.0] * n_orbits, scale="tdb"),
+        origin=Origin.from_kwargs(code=pa.repeat("SUN", n_orbits)),
+        frame="ecliptic",
+    )
+    iod_orbits = FittedOrbits.from_kwargs(
+        orbit_id=[f"iod_{i}" for i in range(n_orbits)],
+        object_id=pa.repeat(None, n_orbits),
+        coordinates=coords,
+        arc_length=pa.repeat(30.0, n_orbits),
+        num_obs=pa.repeat(n_obs, n_orbits),
+        chi2=pa.repeat(5.0, n_orbits),
+        reduced_chi2=pa.repeat(0.5, n_orbits),
+        success=pa.repeat(True, n_orbits),
+        status_code=pa.repeat(0, n_orbits),
+    )
+    iod_members = FittedOrbitMembers.from_kwargs(
+        orbit_id=pa.repeat("iod_0", n_obs),
+        obs_id=[f"obs{i:03d}" for i in range(n_obs)],
+        residuals=None,
+        solution=pa.repeat(True, n_obs),
+        outlier=pa.repeat(False, n_obs),
+    )
+    return iod_orbits, iod_members
+
+
+def _make_dc_result(n_obs: int = 8) -> tuple:
+    coords = CartesianCoordinates.from_kwargs(
+        x=[1.0],
+        y=[0.0],
+        z=[0.0],
+        vx=[0.0],
+        vy=[0.01],
+        vz=[0.0],
+        time=Timestamp.from_mjd([59000.0], scale="tdb"),
+        origin=Origin.from_kwargs(code=["SUN"]),
+        frame="ecliptic",
+    )
+    dc_orbits = FittedOrbits.from_kwargs(
+        orbit_id=["dc_orbit_0"],
+        object_id=pa.repeat(None, 1),
+        coordinates=coords,
+        arc_length=[30.0],
+        num_obs=[n_obs],
+        chi2=[4.8],
+        reduced_chi2=[0.48],
+        iterations=[10],
+        success=[True],
+        status_code=[0],
+    )
+    dc_members = FittedOrbitMembers.from_kwargs(
+        orbit_id=pa.repeat("dc_orbit_0", n_obs),
+        obs_id=[f"obs{i:03d}" for i in range(n_obs)],
+        residuals=None,
+        solution=pa.repeat(True, n_obs),
+        outlier=pa.repeat(False, n_obs),
+    )
+    return dc_orbits, dc_members
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdamBackend:
+    def test_always_available(self):
+        assert AdamBackend.AVAILABLE is True
+
+    def test_backend_name(self):
+        assert AdamBackend.BACKEND_NAME == "adam"
+
+    def test_missing_propagator_raises_value_error(self):
+        obs = _make_observations()
+        backend = AdamBackend()
+        cfg = BackendConfig()  # no propagator in backend_kwargs
+        with pytest.raises(ValueError, match="propagator"):
+            backend.fit(obs, cfg)
+
+    def test_successful_fit_shape(self):
+        obs = _make_observations(n=8)
+        iod_result = _make_iod_result(n_orbits=1, n_obs=8)
+        dc_result = _make_dc_result(n_obs=8)
+        mock_propagator = MagicMock()
+        cfg = BackendConfig(backend_kwargs={"propagator": mock_propagator})
+
+        with patch("adam_core.orbit_determination.backends.adam.iod", return_value=iod_result), \
+             patch("adam_core.orbit_determination.backends.adam.differential_correction", return_value=dc_result):
+            backend = AdamBackend()
+            fitted, members = backend.fit(obs, cfg)
+
+        assert isinstance(fitted, FittedOrbits)
+        assert isinstance(members, FittedOrbitMembers)
+        assert len(fitted) == 1
+        assert len(members) == 8
+
+    def test_provenance_set_after_fit(self):
+        obs = _make_observations(n=8)
+        iod_result = _make_iod_result(n_orbits=1, n_obs=8)
+        dc_result = _make_dc_result(n_obs=8)
+        mock_propagator = MagicMock()
+        cfg = BackendConfig(backend_kwargs={"propagator": mock_propagator})
+
+        with patch("adam_core.orbit_determination.backends.adam.iod", return_value=iod_result), \
+             patch("adam_core.orbit_determination.backends.adam.differential_correction", return_value=dc_result):
+            backend = AdamBackend()
+            fitted, _ = backend.fit(obs, cfg)
+
+        assert fitted.backend[0].as_py() == "adam"
+        assert fitted.backend_version[0].as_py() is not None
+
+    def test_iod_no_candidates_raises_value_error(self):
+        obs = _make_observations(n=8)
+        empty_iod = (FittedOrbits.empty(), FittedOrbitMembers.empty())
+        mock_propagator = MagicMock()
+        cfg = BackendConfig(backend_kwargs={"propagator": mock_propagator})
+
+        with patch("adam_core.orbit_determination.backends.adam.iod", return_value=empty_iod):
+            backend = AdamBackend()
+            with pytest.raises(ValueError, match="IOD found no valid orbit"):
+                backend.fit(obs, cfg)
+
+    def test_dc_no_orbits_raises_runtime_error(self):
+        obs = _make_observations(n=8)
+        iod_result = _make_iod_result(n_orbits=1, n_obs=8)
+        empty_dc = (FittedOrbits.empty(), FittedOrbitMembers.empty())
+        mock_propagator = MagicMock()
+        cfg = BackendConfig(backend_kwargs={"propagator": mock_propagator})
+
+        with patch("adam_core.orbit_determination.backends.adam.iod", return_value=iod_result), \
+             patch("adam_core.orbit_determination.backends.adam.differential_correction", return_value=empty_dc):
+            backend = AdamBackend()
+            with pytest.raises(RuntimeError, match="differential correction produced no orbits"):
+                backend.fit(obs, cfg)
+
+    def test_backend_kwargs_forwarded_to_iod(self):
+        obs = _make_observations(n=8)
+        iod_result = _make_iod_result(n_orbits=1, n_obs=8)
+        dc_result = _make_dc_result(n_obs=8)
+        mock_propagator = MagicMock()
+        cfg = BackendConfig(backend_kwargs={
+            "propagator": mock_propagator,
+            "min_obs": 4,
+            "rchi2_threshold": 500.0,
+        })
+
+        with patch("adam_core.orbit_determination.backends.adam.iod", return_value=iod_result) as mock_iod, \
+             patch("adam_core.orbit_determination.backends.adam.differential_correction", return_value=dc_result):
+            backend = AdamBackend()
+            backend.fit(obs, cfg)
+
+        call_kwargs = mock_iod.call_args[1]
+        assert call_kwargs["min_obs"] == 4
+        assert call_kwargs["rchi2_threshold"] == 500.0
+
+    def test_weighting_policy_has_no_effect(self):
+        """AdamBackend always computes residuals; WeightingPolicy is ignored."""
+        obs = _make_observations(n=8)
+        iod_result = _make_iod_result(n_orbits=1, n_obs=8)
+        dc_result = _make_dc_result(n_obs=8)
+        mock_propagator = MagicMock()
+
+        for policy in (WeightingPolicy.DELEGATE, WeightingPolicy.ADAM):
+            cfg = BackendConfig(
+                weighting_policy=policy,
+                backend_kwargs={"propagator": mock_propagator},
+            )
+            with patch("adam_core.orbit_determination.backends.adam.iod", return_value=iod_result), \
+                 patch("adam_core.orbit_determination.backends.adam.differential_correction", return_value=dc_result):
+                backend = AdamBackend()
+                fitted, _ = backend.fit(obs, cfg)
+            assert fitted.backend[0].as_py() == "adam"

--- a/src/adam_core/orbit_determination/tests/test_backends/test_find_orb.py
+++ b/src/adam_core/orbit_determination/tests/test_backends/test_find_orb.py
@@ -1,0 +1,280 @@
+"""
+Unit tests for FindOrbBackend.
+
+All calls to ``adam_fo.fo`` are mocked so these tests run without a Find_Orb
+binary installed.  Integration tests that require the actual binary are gated
+behind ``@pytest.mark.skipif(not FIND_ORB_AVAILABLE, ...)``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from adam_core.coordinates import CoordinateCovariances, Origin, SphericalCoordinates
+from adam_core.observations.ades import ADESObservations
+from adam_core.observers import Observers
+from adam_core.orbit_determination.backends import FIND_ORB_AVAILABLE, FindOrbBackend
+from adam_core.orbit_determination.backends.find_orb import _observations_to_ades
+from adam_core.orbit_determination.config import BackendConfig, WeightingPolicy
+from adam_core.orbit_determination.evaluate import OrbitDeterminationObservations
+from adam_core.orbit_determination.fitted_orbits import FittedOrbitMembers, FittedOrbits
+from adam_core.orbits import Orbits
+from adam_core.time import Timestamp
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_observations(n: int = 6) -> OrbitDeterminationObservations:
+    times = Timestamp.from_mjd(np.linspace(59000, 59030, n), scale="utc")
+    sigmas = np.full((n, 6), np.nan)
+    sigmas[:, 1] = 1.0 / 3600.0
+    sigmas[:, 2] = 1.0 / 3600.0
+    coords = SphericalCoordinates.from_kwargs(
+        lon=np.full(n, 180.0),
+        lat=np.zeros(n),
+        time=times,
+        origin=Origin.from_kwargs(code=pa.repeat("X05", n)),
+        frame="equatorial",
+        covariance=CoordinateCovariances.from_sigmas(sigmas),
+    )
+    observers = Observers.from_codes(codes=pa.repeat("X05", n), times=times)
+    return OrbitDeterminationObservations.from_kwargs(
+        id=[f"obs{i:03d}" for i in range(n)],
+        coordinates=coords,
+        observers=observers,
+    )
+
+
+def _make_raw_orbit(orbit_id: str = "obs000") -> Orbits:
+    """Return a minimal Orbits object as adam_fo.fo would produce."""
+    from adam_core.coordinates import CartesianCoordinates
+    from adam_core.coordinates.covariances import CoordinateCovariances
+
+    cov = CoordinateCovariances.from_matrix(np.eye(6).reshape(1, 6, 6) * 1e-10)
+    coords = CartesianCoordinates.from_kwargs(
+        x=[1.0],
+        y=[0.0],
+        z=[0.0],
+        vx=[0.0],
+        vy=[0.01],
+        vz=[0.0],
+        time=Timestamp.from_mjd([59000.0], scale="tt"),
+        origin=Origin.from_kwargs(code=["SUN"]),
+        frame="ecliptic",
+        covariance=cov,
+    )
+    return Orbits.from_kwargs(
+        orbit_id=[orbit_id],
+        object_id=[orbit_id],
+        coordinates=coords,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _observations_to_ades
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not FIND_ORB_AVAILABLE, reason="adam_fo not installed")
+class TestObservationsToAdes:
+    def test_returns_string_and_table(self):
+        obs = _make_observations(n=3)
+        ades_str, ades_table = _observations_to_ades(obs)
+        assert isinstance(ades_str, str)
+        assert len(ades_str) > 0
+        assert isinstance(ades_table, ADESObservations)
+        assert len(ades_table) == 3
+
+    def test_trk_sub_truncated_to_8_chars(self):
+        obs = _make_observations(n=3)
+        _, ades_table = _observations_to_ades(obs)
+        for trk in ades_table.trkSub.to_pylist():
+            assert len(trk) <= 8
+
+    def test_sigma_converted_to_arcsec(self):
+        """1-degree sigma in SphericalCoordinates → 3600 arcsec in ADES."""
+        n = 3
+        times = Timestamp.from_mjd(np.linspace(59000, 59010, n), scale="utc")
+        sigmas = np.zeros((n, 6))
+        sigmas[:, 1] = 1.0  # 1 degree RA
+        sigmas[:, 2] = 1.0  # 1 degree Dec
+        coords = SphericalCoordinates.from_kwargs(
+            lon=np.zeros(n),
+            lat=np.zeros(n),  # cos(0)=1 so RAcosDec = RA
+            time=times,
+            origin=Origin.from_kwargs(code=pa.repeat("X05", n)),
+            frame="equatorial",
+            covariance=CoordinateCovariances.from_sigmas(sigmas),
+        )
+        observers = Observers.from_codes(codes=pa.repeat("X05", n), times=times)
+        obs = OrbitDeterminationObservations.from_kwargs(
+            id=[f"obs{i}" for i in range(n)],
+            coordinates=coords,
+            observers=observers,
+        )
+        _, ades = _observations_to_ades(obs)
+        assert abs(ades.rmsRACosDec[0].as_py() - 3600.0) < 1e-6
+        assert abs(ades.rmsDec[0].as_py() - 3600.0) < 1e-6
+
+    def test_empty_raises(self):
+        empty = OrbitDeterminationObservations.empty()
+        with pytest.raises(ValueError, match="empty"):
+            _observations_to_ades(empty)
+
+
+# ---------------------------------------------------------------------------
+# FindOrbBackend.fit — mocked
+# ---------------------------------------------------------------------------
+
+
+class TestFindOrbBackendMocked:
+    """Tests that mock adam_fo.fo — run without a binary."""
+
+    def _patch_fo(self, orbit_raw, rejected_raw=None, error=None):
+        if rejected_raw is None:
+            rejected_raw = ADESObservations.empty()
+        return patch(
+            "adam_core.orbit_determination.backends.find_orb._fo",
+            return_value=(orbit_raw, rejected_raw, error),
+        )
+
+    @pytest.mark.skipif(not FIND_ORB_AVAILABLE, reason="adam_fo not installed")
+    def test_successful_fit_returns_fitted_orbits(self):
+        obs = _make_observations(n=6)
+        orbit_raw = _make_raw_orbit("obs000")
+
+        with self._patch_fo(orbit_raw):
+            backend = FindOrbBackend()
+            fitted, members = backend.fit(obs, BackendConfig())
+
+        assert isinstance(fitted, FittedOrbits)
+        assert isinstance(members, FittedOrbitMembers)
+        assert len(fitted) == 1
+        assert len(members) == 6
+
+    @pytest.mark.skipif(not FIND_ORB_AVAILABLE, reason="adam_fo not installed")
+    def test_provenance_set(self):
+        obs = _make_observations(n=6)
+        orbit_raw = _make_raw_orbit("obs000")
+
+        with self._patch_fo(orbit_raw):
+            backend = FindOrbBackend()
+            fitted, _ = backend.fit(obs, BackendConfig())
+
+        assert fitted.backend[0].as_py() == "find_orb"
+        # backend_version may be None if adam-fo metadata is absent — just
+        # check the column exists.
+        assert "backend_version" in fitted.schema.names
+
+    @pytest.mark.skipif(not FIND_ORB_AVAILABLE, reason="adam_fo not installed")
+    def test_fo_error_raises_runtime_error(self):
+        obs = _make_observations(n=6)
+
+        with self._patch_fo(Orbits.empty(), error="Find_Orb failed"):
+            backend = FindOrbBackend()
+            with pytest.raises(RuntimeError, match="Find_Orb failed"):
+                backend.fit(obs, BackendConfig())
+
+    @pytest.mark.skipif(not FIND_ORB_AVAILABLE, reason="adam_fo not installed")
+    def test_delegate_mode_chi2_nan(self):
+        obs = _make_observations(n=6)
+        orbit_raw = _make_raw_orbit("obs000")
+
+        with self._patch_fo(orbit_raw):
+            backend = FindOrbBackend()
+            fitted, _ = backend.fit(obs, BackendConfig())
+
+        import math
+        assert math.isnan(fitted.chi2[0].as_py())
+        assert math.isnan(fitted.reduced_chi2[0].as_py())
+
+    @pytest.mark.skipif(not FIND_ORB_AVAILABLE, reason="adam_fo not installed")
+    def test_delegate_mode_residuals_none(self):
+        obs = _make_observations(n=6)
+        orbit_raw = _make_raw_orbit("obs000")
+
+        with self._patch_fo(orbit_raw):
+            backend = FindOrbBackend()
+            _, members = backend.fit(obs, BackendConfig())
+
+        # In DELEGATE mode residuals column should be all-null
+        assert members.residuals is None or all(
+            v is None for v in members.residuals.chi2.to_pylist()
+        )
+
+    @pytest.mark.skipif(not FIND_ORB_AVAILABLE, reason="adam_fo not installed")
+    def test_outlier_flags_set_from_rejected(self):
+        obs = _make_observations(n=6)
+        orbit_raw = _make_raw_orbit("obs000")
+
+        # Mark the second observation as rejected by Find_Orb
+        t = obs.coordinates.time
+        rejected = ADESObservations.from_kwargs(
+            trkSub=["obs000"],
+            obsTime=Timestamp.from_mjd([t.mjd()[1].as_py()], scale="utc"),
+            ra=[180.0],
+            dec=[0.0],
+            stn=["X05"],
+            mode=["NA"],
+            astCat=["NA"],
+        )
+
+        with self._patch_fo(orbit_raw, rejected_raw=rejected):
+            backend = FindOrbBackend()
+            _, members = backend.fit(obs, BackendConfig())
+
+        outliers = members.outlier.to_pylist()
+        assert outliers[1] is True
+        assert sum(outliers) == 1
+
+    def test_unavailable_raises_import_error(self):
+        """Finding the backend available flag False should raise ImportError."""
+        backend = FindOrbBackend()
+        backend.AVAILABLE = False  # type: ignore[assignment]
+        with pytest.raises(ImportError):
+            backend.fit(_make_observations(), BackendConfig())
+
+    @pytest.mark.skipif(not FIND_ORB_AVAILABLE, reason="adam_fo not installed")
+    def test_adam_weighting_requires_propagator(self):
+        obs = _make_observations(n=6)
+        orbit_raw = _make_raw_orbit("obs000")
+        cfg = BackendConfig(weighting_policy=WeightingPolicy.ADAM)
+
+        with self._patch_fo(orbit_raw):
+            backend = FindOrbBackend()
+            with pytest.raises(ValueError, match="propagator"):
+                backend.fit(obs, cfg)
+
+
+# ---------------------------------------------------------------------------
+# Integration test — requires find_orb binary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not FIND_ORB_AVAILABLE, reason="find_orb not installed")
+class TestFindOrbBackendIntegration:
+    """
+    Integration tests that call the real Find_Orb binary.
+
+    These tests use fixtures stored in tests/data/od/.  They are skipped
+    automatically when ``adam_fo`` is not installed.
+    """
+
+    def test_placeholder(self):
+        """
+        Placeholder — replace with real integration test once fixture data
+        under tests/data/od/ is available.
+
+        TODO(od-module): add a real observation fixture (5–20 obs for a known
+        object) and assert:
+          - len(fitted) >= 1
+          - fitted.backend[0] == "find_orb"
+          - chi2 / reduced_chi2 within expected bounds (DELEGATE: NaN; ADAM: finite)
+          - residuals within expected bounds in ADAM mode
+        """
+        pytest.skip("Integration fixtures not yet populated under tests/data/od/")

--- a/src/adam_core/orbit_determination/tests/test_backends/test_layup.py
+++ b/src/adam_core/orbit_determination/tests/test_backends/test_layup.py
@@ -1,0 +1,65 @@
+"""
+Unit and integration tests for LayupBackend.
+
+The backend is a stub; the only substantive test is that it raises
+``NotImplementedError`` when ``.fit()`` is called.
+"""
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from adam_core.coordinates import CoordinateCovariances, Origin, SphericalCoordinates
+from adam_core.observers import Observers
+from adam_core.orbit_determination.backends import LAYUP_AVAILABLE, LayupBackend
+from adam_core.orbit_determination.config import BackendConfig
+from adam_core.orbit_determination.evaluate import OrbitDeterminationObservations
+from adam_core.time import Timestamp
+
+
+def _make_observations(n: int = 6) -> OrbitDeterminationObservations:
+    times = Timestamp.from_mjd(np.linspace(59000, 59030, n), scale="utc")
+    sigmas = np.full((n, 6), np.nan)
+    sigmas[:, 1] = 1.0 / 3600.0
+    sigmas[:, 2] = 1.0 / 3600.0
+    coords = SphericalCoordinates.from_kwargs(
+        lon=np.full(n, 180.0),
+        lat=np.zeros(n),
+        time=times,
+        origin=Origin.from_kwargs(code=pa.repeat("X05", n)),
+        frame="equatorial",
+        covariance=CoordinateCovariances.from_sigmas(sigmas),
+    )
+    observers = Observers.from_codes(codes=pa.repeat("X05", n), times=times)
+    return OrbitDeterminationObservations.from_kwargs(
+        id=[f"obs{i:03d}" for i in range(n)],
+        coordinates=coords,
+        observers=observers,
+    )
+
+
+class TestLayupBackend:
+    def test_backend_name(self):
+        assert LayupBackend.BACKEND_NAME == "layup"
+
+    def test_unavailable_raises_import_error(self):
+        backend = LayupBackend()
+        backend.AVAILABLE = False  # type: ignore[assignment]
+        with pytest.raises(ImportError):
+            backend.fit(_make_observations(), BackendConfig())
+
+    @pytest.mark.skipif(not LAYUP_AVAILABLE, reason="layup not installed")
+    def test_fit_raises_not_implemented(self):
+        backend = LayupBackend()
+        with pytest.raises(NotImplementedError):
+            backend.fit(_make_observations(), BackendConfig())
+
+
+@pytest.mark.skipif(not LAYUP_AVAILABLE, reason="layup not installed")
+class TestLayupBackendIntegration:
+    def test_placeholder(self):
+        """
+        TODO(od-module): implement Layup backend and replace this placeholder
+        with real integration tests.
+        """
+        pytest.skip("Layup backend not yet implemented.")

--- a/src/adam_core/orbit_determination/tests/test_backends/test_orbfit.py
+++ b/src/adam_core/orbit_determination/tests/test_backends/test_orbfit.py
@@ -1,0 +1,66 @@
+"""
+Unit and integration tests for OrbFitBackend.
+
+The backend is a stub; the only substantive test is that it raises
+``NotImplementedError`` when ``.fit()`` is called.
+"""
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from adam_core.coordinates import CoordinateCovariances, Origin, SphericalCoordinates
+from adam_core.observers import Observers
+from adam_core.orbit_determination.backends import ORBFIT_AVAILABLE, OrbFitBackend
+from adam_core.orbit_determination.config import BackendConfig
+from adam_core.orbit_determination.evaluate import OrbitDeterminationObservations
+from adam_core.time import Timestamp
+
+
+def _make_observations(n: int = 6) -> OrbitDeterminationObservations:
+    times = Timestamp.from_mjd(np.linspace(59000, 59030, n), scale="utc")
+    sigmas = np.full((n, 6), np.nan)
+    sigmas[:, 1] = 1.0 / 3600.0
+    sigmas[:, 2] = 1.0 / 3600.0
+    coords = SphericalCoordinates.from_kwargs(
+        lon=np.full(n, 180.0),
+        lat=np.zeros(n),
+        time=times,
+        origin=Origin.from_kwargs(code=pa.repeat("X05", n)),
+        frame="equatorial",
+        covariance=CoordinateCovariances.from_sigmas(sigmas),
+    )
+    observers = Observers.from_codes(codes=pa.repeat("X05", n), times=times)
+    return OrbitDeterminationObservations.from_kwargs(
+        id=[f"obs{i:03d}" for i in range(n)],
+        coordinates=coords,
+        observers=observers,
+    )
+
+
+class TestOrbFitBackend:
+    def test_backend_name(self):
+        assert OrbFitBackend.BACKEND_NAME == "orbfit"
+
+    def test_unavailable_raises_import_error(self):
+        backend = OrbFitBackend()
+        backend.AVAILABLE = False  # type: ignore[assignment]
+        with pytest.raises(ImportError):
+            backend.fit(_make_observations(), BackendConfig())
+
+    @pytest.mark.skipif(not ORBFIT_AVAILABLE, reason="orbfit not installed")
+    def test_fit_raises_not_implemented(self):
+        """Even when orbfit is installed the stub raises NotImplementedError."""
+        backend = OrbFitBackend()
+        with pytest.raises(NotImplementedError):
+            backend.fit(_make_observations(), BackendConfig())
+
+
+@pytest.mark.skipif(not ORBFIT_AVAILABLE, reason="orbfit not installed")
+class TestOrbFitBackendIntegration:
+    def test_placeholder(self):
+        """
+        TODO(od-module): implement OrbFit backend and replace this placeholder
+        with real integration tests.
+        """
+        pytest.skip("OrbFit backend not yet implemented.")

--- a/src/adam_core/orbit_determination/tests/test_config.py
+++ b/src/adam_core/orbit_determination/tests/test_config.py
@@ -1,0 +1,43 @@
+"""
+Tests for BackendConfig and WeightingPolicy.
+"""
+
+import pytest
+
+from adam_core.orbit_determination.config import BackendConfig, WeightingPolicy
+
+
+class TestWeightingPolicy:
+    def test_values(self):
+        assert WeightingPolicy.DELEGATE.value == "delegate"
+        assert WeightingPolicy.ADAM.value == "adam"
+
+    def test_membership(self):
+        assert WeightingPolicy("delegate") is WeightingPolicy.DELEGATE
+        assert WeightingPolicy("adam") is WeightingPolicy.ADAM
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(ValueError):
+            WeightingPolicy("unknown")
+
+
+class TestBackendConfig:
+    def test_defaults(self):
+        cfg = BackendConfig()
+        assert cfg.weighting_policy is WeightingPolicy.DELEGATE
+        assert cfg.backend_kwargs == {}
+
+    def test_custom_weighting_policy(self):
+        cfg = BackendConfig(weighting_policy=WeightingPolicy.ADAM)
+        assert cfg.weighting_policy is WeightingPolicy.ADAM
+
+    def test_backend_kwargs_independent(self):
+        """Each instance must have its own backend_kwargs dict."""
+        cfg1 = BackendConfig()
+        cfg2 = BackendConfig()
+        cfg1.backend_kwargs["key"] = "value"
+        assert "key" not in cfg2.backend_kwargs
+
+    def test_backend_kwargs_roundtrip(self):
+        cfg = BackendConfig(backend_kwargs={"propagator": object, "min_obs": 5})
+        assert cfg.backend_kwargs["min_obs"] == 5

--- a/src/adam_core/orbit_determination/tests/test_fit_orbit.py
+++ b/src/adam_core/orbit_determination/tests/test_fit_orbit.py
@@ -1,0 +1,276 @@
+"""
+Unit tests for fit_orbit().
+
+All backend calls are mocked so these tests exercise input validation and
+dispatch logic independently of any external binary or propagator.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from adam_core.coordinates import CoordinateCovariances, Origin, SphericalCoordinates
+from adam_core.coordinates.residuals import Residuals
+from adam_core.observers import Observers
+from adam_core.orbit_determination.backends import FIND_ORB_AVAILABLE
+from adam_core.orbit_determination.config import BackendConfig, WeightingPolicy
+from adam_core.orbit_determination.evaluate import OrbitDeterminationObservations
+from adam_core.orbit_determination.fit_orbit import fit_orbit
+from adam_core.orbit_determination.fitted_orbits import FittedOrbitMembers, FittedOrbits
+from adam_core.time import Timestamp
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_observations(n: int = 6, missing_cov: bool = False) -> OrbitDeterminationObservations:
+    """Build a minimal but valid OrbitDeterminationObservations for testing."""
+    times = Timestamp.from_mjd(np.linspace(59000, 59030, n), scale="utc")
+    sigmas = np.full((n, 6), np.nan)
+    if not missing_cov:
+        sigmas[:, 1] = 1.0 / 3600.0  # 1 arcsec in degrees
+        sigmas[:, 2] = 1.0 / 3600.0
+    coords = SphericalCoordinates.from_kwargs(
+        lon=np.full(n, 180.0),
+        lat=np.zeros(n),
+        time=times,
+        origin=Origin.from_kwargs(code=pa.repeat("X05", n)),
+        frame="equatorial",
+        covariance=CoordinateCovariances.from_sigmas(sigmas),
+    )
+    observers = Observers.from_codes(
+        codes=pa.repeat("X05", n),
+        times=times,
+    )
+    return OrbitDeterminationObservations.from_kwargs(
+        id=[f"obs{i:03d}" for i in range(n)],
+        coordinates=coords,
+        observers=observers,
+    )
+
+
+def _make_fitted_orbits() -> FittedOrbits:
+    from adam_core.coordinates import CartesianCoordinates
+    from adam_core.coordinates.origin import Origin
+
+    coords = CartesianCoordinates.from_kwargs(
+        x=[1.0],
+        y=[0.0],
+        z=[0.0],
+        vx=[0.0],
+        vy=[0.01],
+        vz=[0.0],
+        time=Timestamp.from_mjd([59000.0], scale="tdb"),
+        origin=Origin.from_kwargs(code=["SUN"]),
+        frame="ecliptic",
+    )
+    return FittedOrbits.from_kwargs(
+        orbit_id=["test_orbit_01"],
+        object_id=pa.repeat(None, 1),
+        coordinates=coords,
+        arc_length=[30.0],
+        num_obs=[6],
+        chi2=[float("nan")],
+        reduced_chi2=[float("nan")],
+        success=[True],
+        status_code=[0],
+        backend=["find_orb"],
+        backend_version=["1.0.0"],
+    )
+
+
+def _make_fitted_members(orbit_id: str = "test_orbit_01", n: int = 6) -> FittedOrbitMembers:
+    return FittedOrbitMembers.from_kwargs(
+        orbit_id=pa.repeat(orbit_id, n),
+        obs_id=[f"obs{i:03d}" for i in range(n)],
+        residuals=None,
+        solution=pa.repeat(True, n),
+        outlier=pa.repeat(False, n),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestFitOrbitValidation:
+    def test_empty_observations_raises(self):
+        empty = OrbitDeterminationObservations.empty()
+        with pytest.raises(ValueError, match="0 observations"):
+            fit_orbit(empty, backend="find_orb")
+
+    def test_all_missing_covariance_raises(self):
+        obs = _make_observations(n=6, missing_cov=True)
+        with pytest.raises(ValueError, match="missing RA/Dec covariance"):
+            fit_orbit(obs, backend="find_orb")
+
+    def test_missing_observer_states_raises(self):
+        """If all observer x-coords are NaN the call should fail."""
+        obs = _make_observations(n=6)
+        # Manually zero out observer coordinates by building a fake observers table
+        from adam_core.coordinates import CartesianCoordinates
+
+        bad_coords = CartesianCoordinates.from_kwargs(
+            x=pa.repeat(float("nan"), 6),
+            y=pa.repeat(float("nan"), 6),
+            z=pa.repeat(float("nan"), 6),
+            vx=pa.repeat(float("nan"), 6),
+            vy=pa.repeat(float("nan"), 6),
+            vz=pa.repeat(float("nan"), 6),
+            time=obs.observers.coordinates.time,
+            origin=obs.observers.coordinates.origin,
+            frame="equatorial",
+        )
+        bad_observers = Observers.from_kwargs(
+            code=obs.observers.code,
+            coordinates=bad_coords,
+        )
+        bad_obs = OrbitDeterminationObservations.from_kwargs(
+            id=obs.id,
+            coordinates=obs.coordinates,
+            observers=bad_observers,
+        )
+        with pytest.raises(ValueError, match="observer states"):
+            fit_orbit(bad_obs, backend="find_orb")
+
+    def test_unknown_backend_raises(self):
+        obs = _make_observations()
+        with pytest.raises(ValueError, match="Unknown backend"):
+            fit_orbit(obs, backend="not_a_backend")  # type: ignore[arg-type]
+
+    def test_unavailable_backend_raises_import_error(self):
+        obs = _make_observations()
+        # Temporarily pretend orbfit is unavailable
+        with patch(
+            "adam_core.orbit_determination.fit_orbit._BACKEND_AVAILABLE",
+            {"adam": True, "find_orb": False, "orbfit": False, "layup": False},
+        ):
+            with pytest.raises(ImportError, match="pip install"):
+                fit_orbit(obs, backend="find_orb")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — backend is mocked, output normalisation is tested
+# ---------------------------------------------------------------------------
+
+
+class TestFitOrbitDispatch:
+    def test_dispatches_to_find_orb_backend(self):
+        obs = _make_observations()
+        mock_fitted = _make_fitted_orbits()
+        mock_members = _make_fitted_members()
+
+        with patch(
+            "adam_core.orbit_determination.fit_orbit.FindOrbBackend"
+        ) as MockCls:
+            instance = MagicMock()
+            instance.fit.return_value = (mock_fitted, mock_members)
+            MockCls.return_value = instance
+
+            with patch(
+                "adam_core.orbit_determination.fit_orbit._BACKEND_AVAILABLE",
+                {"adam": True, "find_orb": True, "orbfit": False, "layup": False},
+            ):
+                result_orbits, result_members = fit_orbit(obs, backend="find_orb")
+
+            instance.fit.assert_called_once()
+            assert isinstance(result_orbits, FittedOrbits)
+            assert isinstance(result_members, FittedOrbitMembers)
+
+    def test_dispatches_to_adam_backend(self):
+        obs = _make_observations()
+        mock_fitted = _make_fitted_orbits()
+        mock_members = _make_fitted_members()
+
+        with patch(
+            "adam_core.orbit_determination.fit_orbit.AdamBackend"
+        ) as MockCls:
+            instance = MagicMock()
+            instance.fit.return_value = (mock_fitted, mock_members)
+            MockCls.return_value = instance
+
+            result_orbits, result_members = fit_orbit(obs, backend="adam")
+
+            instance.fit.assert_called_once()
+            assert len(result_orbits) == 1
+
+    def test_default_config_is_used_when_none(self):
+        obs = _make_observations()
+        mock_fitted = _make_fitted_orbits()
+        mock_members = _make_fitted_members()
+
+        with patch(
+            "adam_core.orbit_determination.fit_orbit.AdamBackend"
+        ) as MockCls:
+            instance = MagicMock()
+            instance.fit.return_value = (mock_fitted, mock_members)
+            MockCls.return_value = instance
+
+            fit_orbit(obs, backend="adam", config=None)
+
+            call_args = instance.fit.call_args
+            passed_config = call_args[0][1]
+            assert isinstance(passed_config, BackendConfig)
+            assert passed_config.weighting_policy is WeightingPolicy.DELEGATE
+
+    def test_custom_config_is_forwarded(self):
+        obs = _make_observations()
+        mock_fitted = _make_fitted_orbits()
+        mock_members = _make_fitted_members()
+        cfg = BackendConfig(
+            weighting_policy=WeightingPolicy.ADAM,
+            backend_kwargs={"propagator": object},
+        )
+
+        with patch(
+            "adam_core.orbit_determination.fit_orbit.AdamBackend"
+        ) as MockCls:
+            instance = MagicMock()
+            instance.fit.return_value = (mock_fitted, mock_members)
+            MockCls.return_value = instance
+
+            fit_orbit(obs, backend="adam", config=cfg)
+
+            call_args = instance.fit.call_args
+            passed_config = call_args[0][1]
+            assert passed_config.weighting_policy is WeightingPolicy.ADAM
+
+    def test_output_shapes(self):
+        obs = _make_observations(n=10)
+        mock_fitted = _make_fitted_orbits()
+        mock_members = _make_fitted_members(n=10)
+
+        with patch(
+            "adam_core.orbit_determination.fit_orbit.AdamBackend"
+        ) as MockCls:
+            instance = MagicMock()
+            instance.fit.return_value = (mock_fitted, mock_members)
+            MockCls.return_value = instance
+
+            fitted, members = fit_orbit(obs, backend="adam")
+
+        assert len(fitted) == 1
+        assert len(members) == 10
+
+    def test_provenance_columns_present(self):
+        obs = _make_observations()
+        mock_fitted = _make_fitted_orbits()
+        mock_members = _make_fitted_members()
+
+        with patch(
+            "adam_core.orbit_determination.fit_orbit.AdamBackend"
+        ) as MockCls:
+            instance = MagicMock()
+            instance.fit.return_value = (mock_fitted, mock_members)
+            MockCls.return_value = instance
+
+            fitted, _ = fit_orbit(obs, backend="adam")
+
+        # Provenance columns must exist (may be null if backend didn't set them)
+        assert "backend" in fitted.schema.names
+        assert "backend_version" in fitted.schema.names


### PR DESCRIPTION
Implements deliverables 1-9 of the OD module specification:

* **fitted_orbits.py**: Add nullable `backend` and `backend_version` columns to `FittedOrbits` for provenance tracking. Backward-compatible (nullable, existing callers unaffected).

* **config.py** (new): `WeightingPolicy` enum (DELEGATE / ADAM) and `BackendConfig` dataclass. DELEGATE passes weighting to the backend; ADAM calls `evaluate_orbits` post-fit with an adam propagator.

* **backends/** (new package):
  - `base.py`: `BackendWrapper` ABC with `AVAILABLE`, `BACKEND_NAME`, `fit()` contract, and `_check_available()` helper.
  - `find_orb.py`: `FindOrbBackend` — converts observations to ADES, calls `adam_fo.fo`, maps rejected observations to outlier flags. DELEGATE mode yields NaN chi2; ADAM mode calls `evaluate_orbits`.
  - `adam.py`: `AdamBackend` — chains existing `iod()` + `differential_correction()`; always available, requires a propagator via `BackendConfig.backend_kwargs["propagator"]`.
  - `orbfit.py`, `layup.py`: documented stubs raising `NotImplementedError`.
  - `__init__.py`: `FIND_ORB_AVAILABLE`, `ORBFIT_AVAILABLE`, `LAYUP_AVAILABLE` booleans set at import time.

* **fit_orbit.py** (new): `fit_orbit(observations, backend, config)` public entrypoint. Validates observations (empty, missing covariance, missing observer states), checks backend availability with install instructions on failure, dispatches to the correct backend, returns `(FittedOrbits, FittedOrbitMembers)`.

* **pyproject.toml**: Add `[find_orb]`, `[orbfit]`, `[layup]` optional extras following the existing `plots` / `oem` pattern.

* **Tests**:
  - `test_config.py`: WeightingPolicy and BackendConfig unit tests.
  - `test_fit_orbit.py`: input validation and dispatch tests (all backends mocked).
  - `test_backends/test_find_orb.py`: ADES conversion, mocked fit, outlier flags, ADAM-mode propagator requirement.
  - `test_backends/test_adam.py`: IOD/DC mocked, kwargs forwarding, error propagation, provenance stamping.
  - `test_backends/test_orbfit.py`, `test_backends/test_layup.py`: stub tests with skipif decorators.
  - `tests/data/od/README.md`: fixture generation instructions.

Design decisions:
- Provenance lives on `FittedOrbits` (two nullable columns) rather than a companion table, keeping the return type clean.
- `BackendWrapper` does not subclass `OrbitFitter` (different interface).
- `"adam"` backend is always available; no optional dependency needed.
- `WeightingPolicy.ADAM` has no effect on `AdamBackend` (it always computes full residuals via `evaluate_orbits`).

TODO(od-module): populate tests/data/od/ with real observation fixtures for regression testing once a fixture generation script is added.