### PR TITLE
Add short-arc precovery module with ranging and sky-plane propagation

### DIFF
--- a/src/adam_core/dynamics/aberrations.py
+++ b/src/adam_core/dynamics/aberrations.py
@@ -105,10 +105,9 @@ def _add_light_time(
     t0_aberrated = p[1]  # noqa: F841
     lt = p[2]
     dlt = p[3]
-    iterations = p[4]
     # Return NaN light-time when convergence was not reached so host-side callers
     # can fail fast with row-level context.
-    lt = jnp.where((dlt > lt_tol) | (iterations >= max_lt_iter), jnp.nan, lt)
+    lt = jnp.where(dlt > lt_tol, jnp.nan, lt)
     return orbit_aberrated, lt
 
 

--- a/src/adam_core/dynamics/ephemeris.py
+++ b/src/adam_core/dynamics/ephemeris.py
@@ -157,8 +157,14 @@ _generate_ephemeris_2body_vmap = jit(
 
 
 def _first_non_finite(values: np.ndarray) -> Optional[int]:
-    bad = np.flatnonzero(~np.isfinite(values))
-    return int(bad[0]) if bad.size > 0 else None
+    values = np.asarray(values)
+    if values.ndim <= 1:
+        bad = np.flatnonzero(~np.isfinite(values))
+        return int(bad[0]) if bad.size > 0 else None
+
+    row_has_bad = np.any(~np.isfinite(values), axis=tuple(range(1, values.ndim)))
+    bad_rows = np.flatnonzero(row_has_bad)
+    return int(bad_rows[0]) if bad_rows.size > 0 else None
 
 
 def _raise_ephemeris_numerical_error(

--- a/src/adam_core/dynamics/tests/test_ephemeris.py
+++ b/src/adam_core/dynamics/tests/test_ephemeris.py
@@ -18,6 +18,7 @@ from ...photometry import calculate_phase_angle
 from ...time import Timestamp
 from ...utils import spice as spice_mod
 from ...utils.helpers.orbits import make_real_orbits
+from ..aberrations import _add_light_time
 from .. import ephemeris as ephemeris_module
 from ..ephemeris import generate_ephemeris_2body
 from ..propagation import propagate_2body
@@ -657,3 +658,30 @@ def test_generate_ephemeris_2body_failfast_nonfinite_light_time(monkeypatch) -> 
         generate_ephemeris_2body(
             orbits, observers, predict_magnitudes=False, max_processes=1
         )
+
+
+def test_first_non_finite_returns_row_index_for_matrix() -> None:
+    values = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [4.0, np.nan, 6.0],
+        ],
+        dtype=np.float64,
+    )
+    bad_row = ephemeris_module._first_non_finite(values)
+    assert bad_row == 1
+
+
+def test_add_light_time_converged_at_iteration_cap_is_not_nan() -> None:
+    orbit = np.array([1.2, 0.4, 0.1, 0.0, 0.0, 0.0], dtype=np.float64)
+    observer_position = np.array([0.0, 0.0, 0.0], dtype=np.float64)
+
+    _, lt = _add_light_time(
+        orbit,
+        t0=60000.0,
+        observer_position=observer_position,
+        lt_tol=1e29,
+        max_lt_iter=2,
+    )
+
+    assert np.isfinite(float(lt))

--- a/src/adam_core/orbit_determination/__init__.py
+++ b/src/adam_core/orbit_determination/__init__.py
@@ -12,3 +12,11 @@ from .iod import (
     sort_by_id_and_time,
 )
 from .outliers import calculate_max_outliers, remove_lowest_probability_observation
+from .short_arc import (
+    ShortArcRangingConfig,
+    SkyPropagationPredictions,
+    SkyPropagationResult,
+    ades_to_od_observations,
+    propagate_sky_plane,
+    systematic_ranging_short_arc,
+)

--- a/src/adam_core/orbit_determination/short_arc.py
+++ b/src/adam_core/orbit_determination/short_arc.py
@@ -1,0 +1,729 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional, Type, Union
+
+import numpy as np
+import numpy.typing as npt
+import pyarrow.compute as pc
+import quivr as qv
+
+from ..coordinates import (
+    CartesianCoordinates,
+    CoordinateCovariances,
+    Origin,
+    OriginCodes,
+    SphericalCoordinates,
+    transform_coordinates,
+)
+from ..observations.ades import ADESObservations
+from ..observers import Observers
+from ..orbits import Orbits
+from ..propagator.propagator import Propagator
+from ..time import Timestamp
+from .differential_correction import fit_least_squares
+from .evaluate import OrbitDeterminationObservations, evaluate_orbits
+from .fitted_orbits import FittedOrbitMembers, FittedOrbits, drop_duplicate_orbits
+
+DEFAULT_ASTROMETRIC_RMS_ARCSEC = 1.0
+
+
+@dataclass(frozen=True)
+class ShortArcRangingConfig:
+    rho_min: float = 0.02
+    rho_max: float = 8.0
+    n_rho: int = 80
+    rho_dot_min: float = -0.08
+    rho_dot_max: float = 0.08
+    n_rho_dot: int = 81
+    max_seed_candidates: int = 300
+    max_refine_candidates: int = 25
+
+
+class SkyPropagationPredictions(qv.Table):
+    time = Timestamp.as_column()
+    ra = qv.Float64Column()
+    dec = qv.Float64Column()
+    sigma_ra = qv.Float64Column(nullable=True)
+    sigma_dec = qv.Float64Column(nullable=True)
+    frame = qv.StringAttribute(default="equatorial")
+
+
+@dataclass(frozen=True)
+class SkyPropagationResult:
+    predictions: SkyPropagationPredictions
+    reference_time: Timestamp
+    order: int
+
+
+@dataclass(frozen=True)
+class _Attributable:
+    reference_index: int
+    reference_mjd: float
+    ra_deg: float
+    dec_deg: float
+    ra_rate_deg_per_day: float
+    dec_rate_deg_per_day: float
+    ra_acc_deg_per_day2: float
+    dec_acc_deg_per_day2: float
+
+
+def _coerce_propagator(
+    propagator: Union[Type[Propagator], Propagator],
+    propagator_kwargs: dict,
+) -> Propagator:
+    if isinstance(propagator, Propagator):
+        if propagator_kwargs:
+            raise ValueError(
+                "propagator_kwargs must be empty when passing an instantiated propagator."
+            )
+        return propagator
+
+    if isinstance(propagator, type) and issubclass(propagator, Propagator):
+        return propagator(**propagator_kwargs)
+
+    raise TypeError("propagator must be a Propagator instance or Propagator subclass.")
+
+
+def _make_obs_ids(ades: ADESObservations) -> npt.NDArray[np.str_]:
+    obs_sub_id = ades.obsSubID.to_numpy(zero_copy_only=False)
+    days = ades.obsTime.days.to_numpy(zero_copy_only=False)
+    nanos = ades.obsTime.nanos.to_numpy(zero_copy_only=False)
+    stn = ades.stn.to_numpy(zero_copy_only=False)
+
+    ids = np.empty(len(ades), dtype=object)
+    for i in range(len(ades)):
+        candidate = obs_sub_id[i]
+        if candidate is None or str(candidate).strip() == "":
+            candidate = f"{stn[i]}|{days[i]}|{nanos[i]}|{i}"
+        ids[i] = str(candidate)
+
+    _, inverse, counts = np.unique(ids, return_inverse=True, return_counts=True)
+    duplicate_mask = counts[inverse] > 1
+    if np.any(duplicate_mask):
+        occurrence = np.zeros(len(ids), dtype=np.int64)
+        for i, dup in enumerate(duplicate_mask):
+            if dup:
+                occurrence[i] += np.sum(inverse[:i] == inverse[i])
+                ids[i] = f"{ids[i]}#{occurrence[i]}"
+
+    return ids.astype(str)
+
+
+def _extract_astrometric_sigmas_deg(
+    observations: OrbitDeterminationObservations,
+    default_rms_arcsec: float = DEFAULT_ASTROMETRIC_RMS_ARCSEC,
+) -> tuple[np.ndarray, np.ndarray]:
+    if default_rms_arcsec <= 0:
+        raise ValueError("default_rms_arcsec must be positive.")
+
+    sigma_default = default_rms_arcsec / 3600.0
+    sigmas = observations.coordinates.covariance.sigmas[:, 1:3]
+    sigma_ra_deg = np.array(sigmas[:, 0], dtype=np.float64)
+    sigma_dec_deg = np.array(sigmas[:, 1], dtype=np.float64)
+
+    for sigma in (sigma_ra_deg, sigma_dec_deg):
+        invalid = ~np.isfinite(sigma) | (sigma <= 0)
+        sigma[invalid] = sigma_default
+
+    if np.any(~np.isfinite(sigma_ra_deg)) or np.any(~np.isfinite(sigma_dec_deg)):
+        raise ValueError("Astrometric uncertainties must be finite after fallback.")
+
+    return sigma_ra_deg, sigma_dec_deg
+
+
+def ades_to_od_observations(
+    ades: ADESObservations,
+    default_rms_arcsec: float = DEFAULT_ASTROMETRIC_RMS_ARCSEC,
+) -> OrbitDeterminationObservations:
+    """
+    Convert ADES observations to orbit-determination observations.
+
+    Parameters
+    ----------
+    ades
+        ADES observations containing optical RA/Dec astrometry.
+    default_rms_arcsec
+        Default 1-sigma uncertainty in arcseconds used when RMS columns are missing.
+
+    Returns
+    -------
+    OrbitDeterminationObservations
+    """
+    if len(ades) == 0:
+        return OrbitDeterminationObservations.empty()
+
+    if default_rms_arcsec <= 0:
+        raise ValueError("default_rms_arcsec must be positive.")
+
+    dec_deg = ades.dec.to_numpy(zero_copy_only=False)
+    dec_rad = np.radians(dec_deg)
+    cos_dec = np.cos(dec_rad)
+
+    rms_ra_cos = np.array(ades.rmsRACosDec.to_numpy(zero_copy_only=False), dtype=np.float64)
+    rms_dec = np.array(ades.rmsDec.to_numpy(zero_copy_only=False), dtype=np.float64)
+    rms_corr = np.array(ades.rmsCorr.to_numpy(zero_copy_only=False), dtype=np.float64)
+
+    sigma_ra_arcsec = np.full(len(ades), default_rms_arcsec, dtype=np.float64)
+    sigma_dec_arcsec = np.full(len(ades), default_rms_arcsec, dtype=np.float64)
+
+    has_ra = np.isfinite(rms_ra_cos)
+    has_dec = np.isfinite(rms_dec)
+
+    tiny_cos = np.abs(cos_dec) < 1e-10
+    if np.any(has_ra & tiny_cos):
+        raise ValueError(
+            "Cannot convert rmsRACosDec to RMS RA near dec=+/-90 deg where cos(dec) is ~0."
+        )
+
+    sigma_ra_arcsec[has_ra] = rms_ra_cos[has_ra] / np.abs(cos_dec[has_ra])
+    sigma_dec_arcsec[has_dec] = rms_dec[has_dec]
+
+    if np.any(~np.isfinite(sigma_ra_arcsec)) or np.any(~np.isfinite(sigma_dec_arcsec)):
+        raise ValueError("Astrometric RMS values must be finite.")
+    if np.any(sigma_ra_arcsec <= 0) or np.any(sigma_dec_arcsec <= 0):
+        raise ValueError("Astrometric RMS values must be positive.")
+
+    corr = np.where(np.isfinite(rms_corr), rms_corr, 0.0)
+    if np.any(np.abs(corr) > 1):
+        raise ValueError("rmsCorr must be in [-1, 1].")
+
+    sigma_ra_deg = sigma_ra_arcsec / 3600.0
+    sigma_dec_deg = sigma_dec_arcsec / 3600.0
+
+    covariance_matrix = np.full((len(ades), 6, 6), np.nan, dtype=np.float64)
+    covariance_matrix[:, 1, 1] = sigma_ra_deg**2
+    covariance_matrix[:, 2, 2] = sigma_dec_deg**2
+    covariance_matrix[:, 1, 2] = corr * sigma_ra_deg * sigma_dec_deg
+    covariance_matrix[:, 2, 1] = covariance_matrix[:, 1, 2]
+
+    coordinates = SphericalCoordinates.from_kwargs(
+        rho=None,
+        lon=ades.ra,
+        lat=ades.dec,
+        vrho=None,
+        vlon=None,
+        vlat=None,
+        time=ades.obsTime,
+        covariance=CoordinateCovariances.from_matrix(covariance_matrix),
+        origin=Origin.from_kwargs(code=ades.stn),
+        frame="equatorial",
+    )
+    observers = Observers.from_codes(codes=ades.stn, times=ades.obsTime)
+    return OrbitDeterminationObservations.from_kwargs(
+        id=_make_obs_ids(ades),
+        coordinates=coordinates,
+        observers=observers,
+    )
+
+
+def _coerce_od_observations(
+    observations: Union[ADESObservations, OrbitDeterminationObservations],
+    default_rms_arcsec: float = DEFAULT_ASTROMETRIC_RMS_ARCSEC,
+) -> OrbitDeterminationObservations:
+    if isinstance(observations, ADESObservations):
+        od_obs = ades_to_od_observations(
+            observations,
+            default_rms_arcsec=default_rms_arcsec,
+        )
+    elif isinstance(observations, OrbitDeterminationObservations):
+        od_obs = observations
+    else:
+        raise TypeError(
+            "observations must be ADESObservations or OrbitDeterminationObservations."
+        )
+
+    return od_obs.sort_by(
+        [
+            "coordinates.time.days",
+            "coordinates.time.nanos",
+            "coordinates.origin.code",
+        ]
+    )
+
+
+def _resolve_reference_index(num_obs: int, epoch: Literal["first", "middle", "last"]) -> int:
+    if epoch == "first":
+        return 0
+    if epoch == "middle":
+        return num_obs // 2
+    if epoch == "last":
+        return num_obs - 1
+    raise ValueError("epoch must be one of {'first', 'middle', 'last'}.")
+
+
+def _weighted_polyfit(
+    t_days: np.ndarray,
+    values: np.ndarray,
+    sigma: np.ndarray,
+    order: int,
+) -> tuple[np.ndarray, np.ndarray, float, np.ndarray]:
+    X = np.vander(t_days, N=order + 1, increasing=True)
+    w = 1.0 / np.square(sigma)
+    weighted_X = X * np.sqrt(w)[:, None]
+    weighted_y = values * np.sqrt(w)
+
+    coeff, *_ = np.linalg.lstsq(weighted_X, weighted_y, rcond=None)
+
+    normal = X.T @ (w[:, None] * X)
+    cov = np.linalg.pinv(normal)
+
+    residual = values - X @ coeff
+    dof = max(len(values) - len(coeff), 1)
+    residual_var = float(np.sum(np.square(residual)) / dof)
+    return coeff, cov, residual_var, residual
+
+
+def _fit_attributable(
+    observations: OrbitDeterminationObservations,
+    order: int = 2,
+    epoch: Literal["first", "middle", "last"] = "middle",
+    default_rms_arcsec: float = DEFAULT_ASTROMETRIC_RMS_ARCSEC,
+) -> _Attributable:
+    if len(observations) < 3:
+        raise ValueError("At least 3 observations are required for attributable fitting.")
+
+    reference_index = _resolve_reference_index(len(observations), epoch)
+    times_mjd = observations.coordinates.time.mjd().to_numpy(zero_copy_only=False)
+    reference_mjd = float(times_mjd[reference_index])
+    t_days = times_mjd - reference_mjd
+
+    sigma_ra_deg, sigma_dec_deg = _extract_astrometric_sigmas_deg(
+        observations,
+        default_rms_arcsec=default_rms_arcsec,
+    )
+
+    ra_rad = np.unwrap(np.radians(observations.coordinates.lon.to_numpy(zero_copy_only=False)))
+    dec_rad = np.radians(observations.coordinates.lat.to_numpy(zero_copy_only=False))
+
+    effective_order = min(order, len(observations) - 1)
+    coeff_ra, _, _, _ = _weighted_polyfit(
+        t_days,
+        ra_rad,
+        np.radians(sigma_ra_deg),
+        effective_order,
+    )
+    coeff_dec, _, _, _ = _weighted_polyfit(
+        t_days,
+        dec_rad,
+        np.radians(sigma_dec_deg),
+        effective_order,
+    )
+
+    ra0_rad = coeff_ra[0]
+    dec0_rad = coeff_dec[0]
+    ra_rate = coeff_ra[1] if len(coeff_ra) > 1 else 0.0
+    dec_rate = coeff_dec[1] if len(coeff_dec) > 1 else 0.0
+    ra_acc = 2 * coeff_ra[2] if len(coeff_ra) > 2 else 0.0
+    dec_acc = 2 * coeff_dec[2] if len(coeff_dec) > 2 else 0.0
+
+    return _Attributable(
+        reference_index=reference_index,
+        reference_mjd=reference_mjd,
+        ra_deg=float(np.degrees(ra0_rad) % 360.0),
+        dec_deg=float(np.degrees(dec0_rad)),
+        ra_rate_deg_per_day=float(np.degrees(ra_rate)),
+        dec_rate_deg_per_day=float(np.degrees(dec_rate)),
+        ra_acc_deg_per_day2=float(np.degrees(ra_acc)),
+        dec_acc_deg_per_day2=float(np.degrees(dec_acc)),
+    )
+
+
+def _line_of_sight_and_rate_ecliptic(
+    reference_time: Timestamp,
+    ra_deg: float,
+    dec_deg: float,
+    ra_rate_deg_per_day: float,
+    dec_rate_deg_per_day: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    los_equatorial = SphericalCoordinates.from_kwargs(
+        rho=[1.0],
+        lon=[ra_deg],
+        lat=[dec_deg],
+        vrho=[0.0],
+        vlon=[ra_rate_deg_per_day],
+        vlat=[dec_rate_deg_per_day],
+        time=reference_time,
+        origin=Origin.from_kwargs(code=["SUN"]),
+        frame="equatorial",
+    )
+    los_ecliptic = transform_coordinates(
+        los_equatorial,
+        representation_out=CartesianCoordinates,
+        frame_out="ecliptic",
+        origin_out=OriginCodes.SUN,
+    )
+    return los_ecliptic.r[0], los_ecliptic.v[0]
+
+
+def _construct_heliocentric_state(
+    observer_position: np.ndarray,
+    observer_velocity: np.ndarray,
+    line_of_sight: np.ndarray,
+    line_of_sight_rate: np.ndarray,
+    rho: float,
+    rho_dot: float,
+) -> np.ndarray:
+    position = observer_position + rho * line_of_sight
+    velocity = observer_velocity + rho_dot * line_of_sight + rho * line_of_sight_rate
+    return np.concatenate([position, velocity]).astype(np.float64)
+
+
+def _build_orbits_from_states(states: np.ndarray, reference_time: Timestamp) -> Orbits:
+    if len(states) == 0:
+        return Orbits.empty()
+
+    ref_day = reference_time.days[0].as_py()
+    ref_nano = reference_time.nanos[0].as_py()
+    time = Timestamp.from_kwargs(
+        days=np.full(len(states), ref_day, dtype=np.int64),
+        nanos=np.full(len(states), ref_nano, dtype=np.int64),
+        scale=reference_time.scale,
+    )
+
+    coordinates = CartesianCoordinates.from_kwargs(
+        x=states[:, 0],
+        y=states[:, 1],
+        z=states[:, 2],
+        vx=states[:, 3],
+        vy=states[:, 4],
+        vz=states[:, 5],
+        time=time,
+        origin=Origin.from_kwargs(code=np.full(len(states), "SUN", dtype=object)),
+        frame="ecliptic",
+    )
+    return Orbits.from_kwargs(coordinates=coordinates)
+
+
+def _approximate_candidate_chi2(
+    state: np.ndarray,
+    dt_days: np.ndarray,
+    observer_positions: np.ndarray,
+    observed_ra_deg: np.ndarray,
+    observed_dec_deg: np.ndarray,
+    sigma_ra_deg: np.ndarray,
+    sigma_dec_deg: np.ndarray,
+) -> float:
+    chi2 = 0.0
+    for i, dt in enumerate(dt_days):
+        object_position = state[:3] + dt * state[3:]
+        topocentric = object_position - observer_positions[i]
+        distance = np.linalg.norm(topocentric)
+        if not np.isfinite(distance) or distance <= 0:
+            return np.inf
+
+        ux, uy, uz = topocentric / distance
+        ra_pred = np.degrees(np.arctan2(uy, ux)) % 360.0
+        dec_pred = np.degrees(np.arcsin(np.clip(uz, -1.0, 1.0)))
+
+        ra_resid = ((observed_ra_deg[i] - ra_pred + 180.0) % 360.0) - 180.0
+        ra_resid *= np.cos(np.radians(observed_dec_deg[i]))
+        dec_resid = observed_dec_deg[i] - dec_pred
+
+        chi2 += (ra_resid / sigma_ra_deg[i]) ** 2 + (dec_resid / sigma_dec_deg[i]) ** 2
+
+    return float(chi2)
+
+
+def _set_members_solution_flags(orbit_members: FittedOrbitMembers) -> FittedOrbitMembers:
+    if len(orbit_members) == 0:
+        return orbit_members
+
+    outlier = pc.fill_null(orbit_members.outlier, False)
+    return orbit_members.set_column("solution", pc.invert(outlier))
+
+
+def _merge_refined_candidates(
+    seed_orbits: FittedOrbits,
+    seed_members: FittedOrbitMembers,
+    refined_orbits: list[FittedOrbits],
+    refined_members: list[FittedOrbitMembers],
+) -> tuple[FittedOrbits, FittedOrbitMembers]:
+    if len(refined_orbits) == 0:
+        return seed_orbits, seed_members
+
+    refined_orbits_table = qv.concatenate(refined_orbits)
+    refined_members_table = qv.concatenate(refined_members)
+    replace_ids = refined_orbits_table.orbit_id
+
+    keep_seed_orbits = seed_orbits.apply_mask(pc.invert(pc.is_in(seed_orbits.orbit_id, replace_ids)))
+    keep_seed_members = seed_members.apply_mask(
+        pc.invert(pc.is_in(seed_members.orbit_id, replace_ids))
+    )
+
+    merged_orbits = qv.concatenate([keep_seed_orbits, refined_orbits_table])
+    merged_members = qv.concatenate([keep_seed_members, refined_members_table])
+    return merged_orbits, merged_members
+
+
+def systematic_ranging_short_arc(
+    observations: Union[ADESObservations, OrbitDeterminationObservations],
+    propagator: Union[Type[Propagator], Propagator],
+    *,
+    config: Optional[ShortArcRangingConfig] = None,
+    max_candidates: int = 50,
+    refine_with_least_squares: bool = True,
+    propagator_kwargs: Optional[dict] = None,
+) -> tuple[FittedOrbits, FittedOrbitMembers]:
+    """
+    Generate short-arc state-vector candidates via systematic ranging and score them.
+    """
+    if max_candidates < 1:
+        raise ValueError("max_candidates must be >= 1.")
+
+    config = config or ShortArcRangingConfig()
+    propagator_kwargs = propagator_kwargs or {}
+
+    od_obs = _coerce_od_observations(observations)
+    if len(od_obs) < 3:
+        raise ValueError("At least 3 observations are required for systematic ranging.")
+
+    attributable = _fit_attributable(od_obs, order=2, epoch="middle")
+    ref_idx = attributable.reference_index
+    reference_time = od_obs.coordinates.time[ref_idx : ref_idx + 1]
+
+    observer_position = od_obs.observers.coordinates.r[ref_idx]
+    observer_velocity = od_obs.observers.coordinates.v[ref_idx]
+    line_of_sight, line_of_sight_rate = _line_of_sight_and_rate_ecliptic(
+        reference_time,
+        attributable.ra_deg,
+        attributable.dec_deg,
+        attributable.ra_rate_deg_per_day,
+        attributable.dec_rate_deg_per_day,
+    )
+
+    times_mjd = od_obs.coordinates.time.mjd().to_numpy(zero_copy_only=False)
+    dt_days = times_mjd - attributable.reference_mjd
+    observer_positions = od_obs.observers.coordinates.r
+
+    observed_ra_deg = od_obs.coordinates.lon.to_numpy(zero_copy_only=False)
+    observed_dec_deg = od_obs.coordinates.lat.to_numpy(zero_copy_only=False)
+    sigma_ra_deg, sigma_dec_deg = _extract_astrometric_sigmas_deg(od_obs)
+
+    rho_values = np.geomspace(config.rho_min, config.rho_max, num=config.n_rho)
+    rho_dot_values = np.linspace(config.rho_dot_min, config.rho_dot_max, num=config.n_rho_dot)
+
+    num_grid = config.n_rho * config.n_rho_dot
+    states = np.empty((num_grid, 6), dtype=np.float64)
+    approx_chi2 = np.empty(num_grid, dtype=np.float64)
+
+    k = 0
+    for rho in rho_values:
+        for rho_dot in rho_dot_values:
+            state = _construct_heliocentric_state(
+                observer_position,
+                observer_velocity,
+                line_of_sight,
+                line_of_sight_rate,
+                float(rho),
+                float(rho_dot),
+            )
+            states[k] = state
+            approx_chi2[k] = _approximate_candidate_chi2(
+                state,
+                dt_days,
+                observer_positions,
+                observed_ra_deg,
+                observed_dec_deg,
+                sigma_ra_deg,
+                sigma_dec_deg,
+            )
+            k += 1
+
+    candidate_order = np.argsort(approx_chi2)
+    candidate_order = candidate_order[np.isfinite(approx_chi2[candidate_order])]
+    if len(candidate_order) == 0:
+        return FittedOrbits.empty(), FittedOrbitMembers.empty()
+
+    n_seed = min(config.max_seed_candidates, len(candidate_order))
+    seed_states = states[candidate_order[:n_seed]]
+    seed_orbits = _build_orbits_from_states(seed_states, reference_time)
+
+    prop = _coerce_propagator(propagator, propagator_kwargs)
+    fitted_seed_orbits, fitted_seed_members = evaluate_orbits(seed_orbits, od_obs, prop)
+    fitted_seed_members = _set_members_solution_flags(fitted_seed_members)
+
+    if len(fitted_seed_orbits) == 0:
+        return fitted_seed_orbits, fitted_seed_members
+
+    refined_orbits: list[FittedOrbits] = []
+    refined_members: list[FittedOrbitMembers] = []
+    if refine_with_least_squares:
+        ranked = fitted_seed_orbits.sort_by([("reduced_chi2", "ascending"), ("chi2", "ascending")])
+        n_refine = min(config.max_refine_candidates, len(ranked))
+
+        for orbit_id in ranked.orbit_id[:n_refine]:
+            orbit_id_str = orbit_id.as_py()
+            seed_orbit = ranked.select("orbit_id", orbit_id_str).to_orbits()
+            seed_metric = ranked.select("orbit_id", orbit_id_str).reduced_chi2[0].as_py()
+            try:
+                refined_orbit, refined_member = fit_least_squares(seed_orbit, od_obs, prop)
+            except Exception:
+                continue
+
+            if len(refined_orbit) == 0:
+                continue
+            if refined_orbit.reduced_chi2[0].as_py() < seed_metric:
+                refined_orbits.append(refined_orbit)
+                refined_members.append(refined_member)
+
+    merged_orbits, merged_members = _merge_refined_candidates(
+        fitted_seed_orbits,
+        fitted_seed_members,
+        refined_orbits,
+        refined_members,
+    )
+
+    merged_orbits, merged_members = drop_duplicate_orbits(merged_orbits, merged_members)
+    merged_members = _set_members_solution_flags(merged_members)
+
+    ranked_orbits = merged_orbits.sort_by([("reduced_chi2", "ascending"), ("chi2", "ascending")])
+    top_orbits = ranked_orbits[:max_candidates]
+    top_members = merged_members.apply_mask(pc.is_in(merged_members.orbit_id, top_orbits.orbit_id))
+    top_members = _set_members_solution_flags(top_members)
+    return top_orbits, top_members
+
+
+def _gnomonic_forward(
+    ra_rad: np.ndarray,
+    dec_rad: np.ndarray,
+    ra0_rad: float,
+    dec0_rad: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    delta_ra = ra_rad - ra0_rad
+    sin_dec = np.sin(dec_rad)
+    cos_dec = np.cos(dec_rad)
+    sin_dec0 = np.sin(dec0_rad)
+    cos_dec0 = np.cos(dec0_rad)
+
+    denom = sin_dec0 * sin_dec + cos_dec0 * cos_dec * np.cos(delta_ra)
+    if np.any(np.abs(denom) < 1e-14):
+        raise ValueError("Projection singularity encountered in tangent-plane projection.")
+
+    xi = cos_dec * np.sin(delta_ra) / denom
+    eta = (cos_dec0 * sin_dec - sin_dec0 * cos_dec * np.cos(delta_ra)) / denom
+    return xi, eta
+
+
+def _gnomonic_inverse(
+    xi: np.ndarray,
+    eta: np.ndarray,
+    ra0_rad: float,
+    dec0_rad: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    sin_dec0 = np.sin(dec0_rad)
+    cos_dec0 = np.cos(dec0_rad)
+
+    denom = cos_dec0 - eta * sin_dec0
+    ra = ra0_rad + np.arctan2(xi, denom)
+    dec = np.arctan2(
+        sin_dec0 + eta * cos_dec0,
+        np.sqrt(np.square(denom) + np.square(xi)),
+    )
+
+    ra = np.mod(ra, 2 * np.pi)
+    return ra, dec
+
+
+def _build_design_matrix(t_days: np.ndarray, order: int) -> np.ndarray:
+    return np.vander(t_days, N=order + 1, increasing=True)
+
+
+def propagate_sky_plane(
+    observations: Union[ADESObservations, OrbitDeterminationObservations],
+    target_times: Timestamp,
+    *,
+    order: int = 2,
+    epoch: Literal["first", "middle", "last"] = "middle",
+) -> SkyPropagationResult:
+    """
+    Fit a weighted polynomial in the tangent plane and propagate to target times.
+    """
+    if order not in (1, 2):
+        raise ValueError("order must be 1 or 2.")
+
+    od_obs = _coerce_od_observations(observations)
+    if len(od_obs) < 3:
+        raise ValueError("At least 3 observations are required for sky-plane propagation.")
+    if len(target_times) == 0:
+        return SkyPropagationResult(
+            predictions=SkyPropagationPredictions.empty(),
+            reference_time=od_obs.coordinates.time[:1],
+            order=order,
+        )
+
+    if target_times.scale != od_obs.coordinates.time.scale:
+        target_times = target_times.rescale(od_obs.coordinates.time.scale)
+
+    reference_index = _resolve_reference_index(len(od_obs), epoch)
+    reference_time = od_obs.coordinates.time[reference_index : reference_index + 1]
+
+    times_mjd = od_obs.coordinates.time.mjd().to_numpy(zero_copy_only=False)
+    t_ref = float(times_mjd[reference_index])
+    t_obs = times_mjd - t_ref
+
+    ra_obs_rad = np.radians(od_obs.coordinates.lon.to_numpy(zero_copy_only=False))
+    dec_obs_rad = np.radians(od_obs.coordinates.lat.to_numpy(zero_copy_only=False))
+
+    ra0_rad = float(ra_obs_rad[reference_index])
+    dec0_rad = float(dec_obs_rad[reference_index])
+
+    xi_obs, eta_obs = _gnomonic_forward(ra_obs_rad, dec_obs_rad, ra0_rad, dec0_rad)
+
+    sigma_ra_deg, sigma_dec_deg = _extract_astrometric_sigmas_deg(od_obs)
+    sigma_xi = np.radians(sigma_ra_deg * np.cos(dec0_rad))
+    sigma_eta = np.radians(sigma_dec_deg)
+
+    effective_order = min(order, len(od_obs) - 1)
+    coeff_xi, cov_xi, residual_var_xi, _ = _weighted_polyfit(
+        t_obs,
+        xi_obs,
+        sigma_xi,
+        effective_order,
+    )
+    coeff_eta, cov_eta, residual_var_eta, _ = _weighted_polyfit(
+        t_obs,
+        eta_obs,
+        sigma_eta,
+        effective_order,
+    )
+
+    target_mjd = target_times.mjd().to_numpy(zero_copy_only=False)
+    t_target = target_mjd - t_ref
+    X_target = _build_design_matrix(t_target, effective_order)
+
+    xi_pred = X_target @ coeff_xi
+    eta_pred = X_target @ coeff_eta
+
+    var_xi = np.einsum("ij,jk,ik->i", X_target, cov_xi, X_target) + residual_var_xi
+    var_eta = np.einsum("ij,jk,ik->i", X_target, cov_eta, X_target) + residual_var_eta
+    sigma_xi_pred = np.sqrt(np.clip(var_xi, 0.0, np.inf))
+    sigma_eta_pred = np.sqrt(np.clip(var_eta, 0.0, np.inf))
+
+    ra_pred_rad, dec_pred_rad = _gnomonic_inverse(xi_pred, eta_pred, ra0_rad, dec0_rad)
+    sigma_dec_rad = sigma_eta_pred
+    sigma_ra_rad = sigma_xi_pred / np.maximum(np.cos(dec_pred_rad), 1e-8)
+
+    predictions = SkyPropagationPredictions.from_kwargs(
+        time=target_times,
+        ra=np.degrees(ra_pred_rad),
+        dec=np.degrees(dec_pred_rad),
+        sigma_ra=np.degrees(sigma_ra_rad),
+        sigma_dec=np.degrees(sigma_dec_rad),
+    )
+
+    return SkyPropagationResult(
+        predictions=predictions,
+        reference_time=reference_time,
+        order=effective_order,
+    )
+
+
+__all__ = [
+    "ShortArcRangingConfig",
+    "SkyPropagationPredictions",
+    "SkyPropagationResult",
+    "ades_to_od_observations",
+    "systematic_ranging_short_arc",
+    "propagate_sky_plane",
+]

--- a/src/adam_core/orbit_determination/short_arc.py
+++ b/src/adam_core/orbit_determination/short_arc.py
@@ -8,6 +8,7 @@ import numpy.typing as npt
 import pyarrow.compute as pc
 import quivr as qv
 
+from ..constants import Constants as c
 from ..coordinates import (
     CartesianCoordinates,
     CoordinateCovariances,
@@ -26,6 +27,7 @@ from .evaluate import OrbitDeterminationObservations, evaluate_orbits
 from .fitted_orbits import FittedOrbitMembers, FittedOrbits, drop_duplicate_orbits
 
 DEFAULT_ASTROMETRIC_RMS_ARCSEC = 1.0
+_TRANSFORM_EC2EQ = np.asarray(c.TRANSFORM_EC2EQ, dtype=np.float64)
 
 
 @dataclass(frozen=True)
@@ -420,7 +422,8 @@ def _approximate_candidate_chi2(
         if not np.isfinite(distance) or distance <= 0:
             return np.inf
 
-        ux, uy, uz = topocentric / distance
+        topocentric_equatorial = _TRANSFORM_EC2EQ @ topocentric
+        ux, uy, uz = topocentric_equatorial / distance
         ra_pred = np.degrees(np.arctan2(uy, ux)) % 360.0
         dec_pred = np.degrees(np.arcsin(np.clip(uz, -1.0, 1.0)))
 

--- a/src/adam_core/orbit_determination/short_arc.py
+++ b/src/adam_core/orbit_determination/short_arc.py
@@ -160,7 +160,9 @@ def ades_to_od_observations(
     dec_rad = np.radians(dec_deg)
     cos_dec = np.cos(dec_rad)
 
-    rms_ra_cos = np.array(ades.rmsRACosDec.to_numpy(zero_copy_only=False), dtype=np.float64)
+    rms_ra_cos = np.array(
+        ades.rmsRACosDec.to_numpy(zero_copy_only=False), dtype=np.float64
+    )
     rms_dec = np.array(ades.rmsDec.to_numpy(zero_copy_only=False), dtype=np.float64)
     rms_corr = np.array(ades.rmsCorr.to_numpy(zero_copy_only=False), dtype=np.float64)
 
@@ -242,7 +244,9 @@ def _coerce_od_observations(
     )
 
 
-def _resolve_reference_index(num_obs: int, epoch: Literal["first", "middle", "last"]) -> int:
+def _resolve_reference_index(
+    num_obs: int, epoch: Literal["first", "middle", "last"]
+) -> int:
     if epoch == "first":
         return 0
     if epoch == "middle":
@@ -281,7 +285,9 @@ def _fit_attributable(
     default_rms_arcsec: float = DEFAULT_ASTROMETRIC_RMS_ARCSEC,
 ) -> _Attributable:
     if len(observations) < 3:
-        raise ValueError("At least 3 observations are required for attributable fitting.")
+        raise ValueError(
+            "At least 3 observations are required for attributable fitting."
+        )
 
     reference_index = _resolve_reference_index(len(observations), epoch)
     times_mjd = observations.coordinates.time.mjd().to_numpy(zero_copy_only=False)
@@ -293,7 +299,9 @@ def _fit_attributable(
         default_rms_arcsec=default_rms_arcsec,
     )
 
-    ra_rad = np.unwrap(np.radians(observations.coordinates.lon.to_numpy(zero_copy_only=False)))
+    ra_rad = np.unwrap(
+        np.radians(observations.coordinates.lon.to_numpy(zero_copy_only=False))
+    )
     dec_rad = np.radians(observations.coordinates.lat.to_numpy(zero_copy_only=False))
 
     effective_order = min(order, len(observations) - 1)
@@ -425,7 +433,9 @@ def _approximate_candidate_chi2(
     return float(chi2)
 
 
-def _set_members_solution_flags(orbit_members: FittedOrbitMembers) -> FittedOrbitMembers:
+def _set_members_solution_flags(
+    orbit_members: FittedOrbitMembers,
+) -> FittedOrbitMembers:
     if len(orbit_members) == 0:
         return orbit_members
 
@@ -446,7 +456,9 @@ def _merge_refined_candidates(
     refined_members_table = qv.concatenate(refined_members)
     replace_ids = refined_orbits_table.orbit_id
 
-    keep_seed_orbits = seed_orbits.apply_mask(pc.invert(pc.is_in(seed_orbits.orbit_id, replace_ids)))
+    keep_seed_orbits = seed_orbits.apply_mask(
+        pc.invert(pc.is_in(seed_orbits.orbit_id, replace_ids))
+    )
     keep_seed_members = seed_members.apply_mask(
         pc.invert(pc.is_in(seed_members.orbit_id, replace_ids))
     )
@@ -501,7 +513,9 @@ def systematic_ranging_short_arc(
     sigma_ra_deg, sigma_dec_deg = _extract_astrometric_sigmas_deg(od_obs)
 
     rho_values = np.geomspace(config.rho_min, config.rho_max, num=config.n_rho)
-    rho_dot_values = np.linspace(config.rho_dot_min, config.rho_dot_max, num=config.n_rho_dot)
+    rho_dot_values = np.linspace(
+        config.rho_dot_min, config.rho_dot_max, num=config.n_rho_dot
+    )
 
     num_grid = config.n_rho * config.n_rho_dot
     states = np.empty((num_grid, 6), dtype=np.float64)
@@ -549,15 +563,21 @@ def systematic_ranging_short_arc(
     refined_orbits: list[FittedOrbits] = []
     refined_members: list[FittedOrbitMembers] = []
     if refine_with_least_squares:
-        ranked = fitted_seed_orbits.sort_by([("reduced_chi2", "ascending"), ("chi2", "ascending")])
+        ranked = fitted_seed_orbits.sort_by(
+            [("reduced_chi2", "ascending"), ("chi2", "ascending")]
+        )
         n_refine = min(config.max_refine_candidates, len(ranked))
 
         for orbit_id in ranked.orbit_id[:n_refine]:
             orbit_id_str = orbit_id.as_py()
             seed_orbit = ranked.select("orbit_id", orbit_id_str).to_orbits()
-            seed_metric = ranked.select("orbit_id", orbit_id_str).reduced_chi2[0].as_py()
+            seed_metric = (
+                ranked.select("orbit_id", orbit_id_str).reduced_chi2[0].as_py()
+            )
             try:
-                refined_orbit, refined_member = fit_least_squares(seed_orbit, od_obs, prop)
+                refined_orbit, refined_member = fit_least_squares(
+                    seed_orbit, od_obs, prop
+                )
             except Exception:
                 continue
 
@@ -577,9 +597,13 @@ def systematic_ranging_short_arc(
     merged_orbits, merged_members = drop_duplicate_orbits(merged_orbits, merged_members)
     merged_members = _set_members_solution_flags(merged_members)
 
-    ranked_orbits = merged_orbits.sort_by([("reduced_chi2", "ascending"), ("chi2", "ascending")])
+    ranked_orbits = merged_orbits.sort_by(
+        [("reduced_chi2", "ascending"), ("chi2", "ascending")]
+    )
     top_orbits = ranked_orbits[:max_candidates]
-    top_members = merged_members.apply_mask(pc.is_in(merged_members.orbit_id, top_orbits.orbit_id))
+    top_members = merged_members.apply_mask(
+        pc.is_in(merged_members.orbit_id, top_orbits.orbit_id)
+    )
     top_members = _set_members_solution_flags(top_members)
     return top_orbits, top_members
 
@@ -598,7 +622,9 @@ def _gnomonic_forward(
 
     denom = sin_dec0 * sin_dec + cos_dec0 * cos_dec * np.cos(delta_ra)
     if np.any(np.abs(denom) < 1e-14):
-        raise ValueError("Projection singularity encountered in tangent-plane projection.")
+        raise ValueError(
+            "Projection singularity encountered in tangent-plane projection."
+        )
 
     xi = cos_dec * np.sin(delta_ra) / denom
     eta = (cos_dec0 * sin_dec - sin_dec0 * cos_dec * np.cos(delta_ra)) / denom
@@ -644,7 +670,9 @@ def propagate_sky_plane(
 
     od_obs = _coerce_od_observations(observations)
     if len(od_obs) < 3:
-        raise ValueError("At least 3 observations are required for sky-plane propagation.")
+        raise ValueError(
+            "At least 3 observations are required for sky-plane propagation."
+        )
     if len(target_times) == 0:
         return SkyPropagationResult(
             predictions=SkyPropagationPredictions.empty(),

--- a/src/adam_core/orbit_determination/tests/test_short_arc.py
+++ b/src/adam_core/orbit_determination/tests/test_short_arc.py
@@ -6,9 +6,15 @@ try:
 except Exception:  # pragma: no cover
     ASSISTPropagator = None
 
-from ...coordinates import CartesianCoordinates, CoordinateCovariances, Origin, Residuals, SphericalCoordinates
-from ...observers import Observers
+from ...coordinates import (
+    CartesianCoordinates,
+    CoordinateCovariances,
+    Origin,
+    Residuals,
+    SphericalCoordinates,
+)
 from ...observations.ades import ADESObservations
+from ...observers import Observers
 from ...orbits import Orbits
 from ...time import Timestamp
 from ..short_arc import (
@@ -35,7 +41,9 @@ def _make_fake_observers(times: Timestamp) -> Observers:
         origin=Origin.from_kwargs(code=np.full(n, "SUN", dtype=object)),
         frame="ecliptic",
     )
-    return Observers.from_kwargs(code=np.full(n, "500", dtype=object), coordinates=coords)
+    return Observers.from_kwargs(
+        code=np.full(n, "500", dtype=object), coordinates=coords
+    )
 
 
 def _make_od_observations(
@@ -99,7 +107,9 @@ def test_ades_to_od_observations_covariance_conversion() -> None:
 
     od = ades_to_od_observations(ades)
     assert len(od) == 4
-    assert np.all(od.observers.code.to_numpy(zero_copy_only=False) == np.array(["W84"] * 4))
+    assert np.all(
+        od.observers.code.to_numpy(zero_copy_only=False) == np.array(["W84"] * 4)
+    )
 
     sig = od.coordinates.covariance.sigmas
     expected_ra0 = (0.6 / np.cos(np.radians(10.0))) / 3600.0
@@ -258,10 +268,14 @@ def test_short_arc_assist_integration_accuracy() -> None:
     od_all = ades_to_od_observations(ades_all)
     holdout = od_all[4:]
 
-    eph_holdout = prop.generate_ephemeris(best_orbit, holdout.observers, max_processes=1)
+    eph_holdout = prop.generate_ephemeris(
+        best_orbit, holdout.observers, max_processes=1
+    )
     residuals = Residuals.calculate(holdout.coordinates, eph_holdout.coordinates)
     residual_values = np.stack(residuals.values.to_numpy(zero_copy_only=False))
-    holdout_error = np.sqrt(residual_values[:, 1] ** 2 + residual_values[:, 2] ** 2) * 3600.0
+    holdout_error = (
+        np.sqrt(residual_values[:, 1] ** 2 + residual_values[:, 2] ** 2) * 3600.0
+    )
 
     assert np.max(holdout_error) < 120.0
 

--- a/src/adam_core/orbit_determination/tests/test_short_arc.py
+++ b/src/adam_core/orbit_determination/tests/test_short_arc.py
@@ -1,0 +1,322 @@
+import numpy as np
+import pytest
+
+try:
+    from adam_assist import ASSISTPropagator
+except Exception:  # pragma: no cover
+    ASSISTPropagator = None
+
+from ...coordinates import CartesianCoordinates, CoordinateCovariances, Origin, Residuals, SphericalCoordinates
+from ...observers import Observers
+from ...observations.ades import ADESObservations
+from ...orbits import Orbits
+from ...time import Timestamp
+from ..short_arc import (
+    ShortArcRangingConfig,
+    _construct_heliocentric_state,
+    _fit_attributable,
+    _gnomonic_inverse,
+    ades_to_od_observations,
+    propagate_sky_plane,
+    systematic_ranging_short_arc,
+)
+
+
+def _make_fake_observers(times: Timestamp) -> Observers:
+    n = len(times)
+    coords = CartesianCoordinates.from_kwargs(
+        x=np.linspace(1.0, 1.0 + 1e-3, n),
+        y=np.linspace(0.5, 0.5 + 1e-3, n),
+        z=np.linspace(0.1, 0.1 + 1e-3, n),
+        vx=np.full(n, 1e-4),
+        vy=np.full(n, -2e-4),
+        vz=np.full(n, 3e-4),
+        time=times,
+        origin=Origin.from_kwargs(code=np.full(n, "SUN", dtype=object)),
+        frame="ecliptic",
+    )
+    return Observers.from_kwargs(code=np.full(n, "500", dtype=object), coordinates=coords)
+
+
+def _make_od_observations(
+    ra_deg: np.ndarray,
+    dec_deg: np.ndarray,
+    times: Timestamp,
+    sigma_arcsec: float = 0.3,
+):
+    n = len(ra_deg)
+    cov = np.full((n, 6, 6), np.nan, dtype=np.float64)
+    sigma_deg = sigma_arcsec / 3600.0
+    cov[:, 1, 1] = sigma_deg**2
+    cov[:, 2, 2] = sigma_deg**2
+
+    coordinates = SphericalCoordinates.from_kwargs(
+        rho=None,
+        lon=ra_deg,
+        lat=dec_deg,
+        vrho=None,
+        vlon=None,
+        vlat=None,
+        time=times,
+        covariance=CoordinateCovariances.from_matrix(cov),
+        origin=Origin.from_kwargs(code=np.full(n, "500", dtype=object)),
+        frame="equatorial",
+    )
+
+    from ..evaluate import OrbitDeterminationObservations
+
+    return OrbitDeterminationObservations.from_kwargs(
+        id=np.array([f"obs{i}" for i in range(n)], dtype=object),
+        coordinates=coordinates,
+        observers=_make_fake_observers(times),
+    )
+
+
+def _angular_error_arcsec(ra1_deg, dec1_deg, ra2_deg, dec2_deg):
+    dra = ((ra1_deg - ra2_deg + 180.0) % 360.0) - 180.0
+    dra *= np.cos(np.radians(dec2_deg))
+    ddec = dec1_deg - dec2_deg
+    return np.sqrt(dra**2 + ddec**2) * 3600.0
+
+
+def test_ades_to_od_observations_covariance_conversion() -> None:
+    times = Timestamp.from_mjd([60200.0, 60200.01, 60200.02, 60200.03], scale="utc")
+    ades = ADESObservations.from_kwargs(
+        permID=[None, None, None, None],
+        provID=[None, None, None, None],
+        trkSub=["trk1", "trk1", "trk1", "trk1"],
+        obsSubID=["a", "b", "c", "d"],
+        obsTime=times,
+        ra=[120.0, 120.01, 120.02, 120.03],
+        dec=[10.0, 10.01, 10.02, 10.03],
+        rmsRACosDec=[0.6, 0.7, None, 0.8],
+        rmsDec=[0.5, None, 0.6, 0.7],
+        rmsCorr=[0.1, None, -0.2, 0.0],
+        stn=["W84", "W84", "W84", "W84"],
+        mode=["CCD", "CCD", "CCD", "CCD"],
+        astCat=["Gaia2", "Gaia2", "Gaia2", "Gaia2"],
+    )
+
+    od = ades_to_od_observations(ades)
+    assert len(od) == 4
+    assert np.all(od.observers.code.to_numpy(zero_copy_only=False) == np.array(["W84"] * 4))
+
+    sig = od.coordinates.covariance.sigmas
+    expected_ra0 = (0.6 / np.cos(np.radians(10.0))) / 3600.0
+    expected_dec0 = 0.5 / 3600.0
+    assert np.isclose(sig[0, 1], expected_ra0)
+    assert np.isclose(sig[0, 2], expected_dec0)
+
+    # Missing RMS should fall back to 1 arcsec.
+    assert np.isclose(sig[1, 2], 1.0 / 3600.0)
+    assert np.isclose(sig[2, 1], 1.0 / 3600.0)
+
+
+def test_fit_attributable_recovers_quadratic_rates() -> None:
+    t_days = np.array([0.0, 0.01, 0.02, 0.03, 0.04], dtype=np.float64)
+    times = Timestamp.from_mjd(60000.0 + t_days, scale="utc")
+
+    ra = 20.0 + 0.30 * t_days + 0.04 * t_days**2
+    dec = -5.0 + 0.10 * t_days - 0.03 * t_days**2
+    observations = _make_od_observations(ra, dec, times, sigma_arcsec=0.1)
+
+    attributable = _fit_attributable(observations, order=2, epoch="first")
+
+    assert np.isclose(attributable.ra_deg, 20.0, atol=5e-6)
+    assert np.isclose(attributable.dec_deg, -5.0, atol=5e-6)
+    assert np.isclose(attributable.ra_rate_deg_per_day, 0.30, atol=5e-5)
+    assert np.isclose(attributable.dec_rate_deg_per_day, 0.10, atol=5e-5)
+    assert np.isclose(attributable.ra_acc_deg_per_day2, 0.08, atol=5e-4)
+    assert np.isclose(attributable.dec_acc_deg_per_day2, -0.06, atol=5e-4)
+
+
+def test_construct_heliocentric_state() -> None:
+    observer_position = np.array([1.0, 2.0, 3.0])
+    observer_velocity = np.array([0.1, 0.2, 0.3])
+    line_of_sight = np.array([1.0, 0.0, 0.0])
+    line_of_sight_rate = np.array([0.0, 1.0, 0.0])
+
+    state = _construct_heliocentric_state(
+        observer_position,
+        observer_velocity,
+        line_of_sight,
+        line_of_sight_rate,
+        rho=2.0,
+        rho_dot=0.5,
+    )
+
+    expected = np.array([3.0, 2.0, 3.0, 0.6, 2.2, 0.3])
+    np.testing.assert_allclose(state, expected)
+
+
+def test_propagate_sky_plane_order2_beats_order1() -> None:
+    t_obs = np.array([0.0, 0.01, 0.02, 0.03, 0.04], dtype=np.float64)
+    t_target = np.array([0.06, 0.07, 0.08], dtype=np.float64)
+    times_obs = Timestamp.from_mjd(60250.0 + t_obs, scale="utc")
+    times_target = Timestamp.from_mjd(60250.0 + t_target, scale="utc")
+
+    ra0_rad = np.radians(120.0)
+    dec0_rad = np.radians(-5.0)
+
+    xi_obs = 1.5e-3 * t_obs + 2.0e-4 * t_obs**2
+    eta_obs = -8.0e-4 * t_obs + 1.0e-4 * t_obs**2
+    ra_obs_rad, dec_obs_rad = _gnomonic_inverse(xi_obs, eta_obs, ra0_rad, dec0_rad)
+
+    xi_true = 1.5e-3 * t_target + 2.0e-4 * t_target**2
+    eta_true = -8.0e-4 * t_target + 1.0e-4 * t_target**2
+    ra_true_rad, dec_true_rad = _gnomonic_inverse(xi_true, eta_true, ra0_rad, dec0_rad)
+
+    observations = _make_od_observations(
+        np.degrees(ra_obs_rad),
+        np.degrees(dec_obs_rad),
+        times_obs,
+        sigma_arcsec=0.05,
+    )
+
+    linear = propagate_sky_plane(observations, times_target, order=1, epoch="first")
+    quadratic = propagate_sky_plane(observations, times_target, order=2, epoch="first")
+
+    err_linear = _angular_error_arcsec(
+        linear.predictions.ra.to_numpy(zero_copy_only=False),
+        linear.predictions.dec.to_numpy(zero_copy_only=False),
+        np.degrees(ra_true_rad),
+        np.degrees(dec_true_rad),
+    )
+    err_quadratic = _angular_error_arcsec(
+        quadratic.predictions.ra.to_numpy(zero_copy_only=False),
+        quadratic.predictions.dec.to_numpy(zero_copy_only=False),
+        np.degrees(ra_true_rad),
+        np.degrees(dec_true_rad),
+    )
+
+    assert np.mean(err_quadratic) < np.mean(err_linear)
+    assert np.max(err_quadratic) < 0.5
+
+    sigma_ra = quadratic.predictions.sigma_ra.to_numpy(zero_copy_only=False)
+    sigma_dec = quadratic.predictions.sigma_dec.to_numpy(zero_copy_only=False)
+    assert np.all(np.isfinite(sigma_ra))
+    assert np.all(np.isfinite(sigma_dec))
+
+
+@pytest.mark.skipif(ASSISTPropagator is None, reason="ASSISTPropagator not available")
+def test_short_arc_assist_integration_accuracy() -> None:
+    orbit = Orbits.from_kwargs(
+        orbit_id=["orbit0"],
+        object_id=["test-object"],
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=[0.85],
+            y=[-0.32],
+            z=[0.14],
+            vx=[0.012],
+            vy=[0.008],
+            vz=[-0.003],
+            time=Timestamp.from_mjd([60300.0], scale="utc"),
+            origin=Origin.from_kwargs(code=["SUN"]),
+            frame="ecliptic",
+        ),
+    )
+
+    dt_minutes = np.array([0.0, 6.0, 12.0, 18.0, 24.0, 30.0], dtype=np.float64)
+    times = Timestamp.from_mjd(60300.0 + dt_minutes / 1440.0, scale="utc")
+    observers = Observers.from_code("W84", times)
+
+    prop = ASSISTPropagator()
+    eph = prop.generate_ephemeris(orbit, observers, max_processes=1, covariance=False)
+
+    ra = eph.coordinates.lon.to_numpy(zero_copy_only=False)
+    dec = eph.coordinates.lat.to_numpy(zero_copy_only=False)
+
+    ades_all = ADESObservations.from_kwargs(
+        trkSub=["T0001"] * len(times),
+        obsSubID=[f"obs{i}" for i in range(len(times))],
+        obsTime=times,
+        ra=ra,
+        dec=dec,
+        rmsRACosDec=[0.4] * len(times),
+        rmsDec=[0.4] * len(times),
+        stn=["W84"] * len(times),
+        mode=["CCD"] * len(times),
+        astCat=["Gaia2"] * len(times),
+    )
+
+    fitted_orbits, _ = systematic_ranging_short_arc(
+        ades_all[:4],
+        ASSISTPropagator,
+        config=ShortArcRangingConfig(
+            n_rho=20,
+            n_rho_dot=21,
+            max_seed_candidates=80,
+            max_refine_candidates=10,
+        ),
+        max_candidates=5,
+        refine_with_least_squares=True,
+    )
+
+    assert len(fitted_orbits) >= 1
+    best_orbit = fitted_orbits.sort_by([("reduced_chi2", "ascending")])[:1].to_orbits()
+
+    od_all = ades_to_od_observations(ades_all)
+    holdout = od_all[4:]
+
+    eph_holdout = prop.generate_ephemeris(best_orbit, holdout.observers, max_processes=1)
+    residuals = Residuals.calculate(holdout.coordinates, eph_holdout.coordinates)
+    residual_values = np.stack(residuals.values.to_numpy(zero_copy_only=False))
+    holdout_error = np.sqrt(residual_values[:, 1] ** 2 + residual_values[:, 2] ** 2) * 3600.0
+
+    assert np.max(holdout_error) < 120.0
+
+    sky = propagate_sky_plane(od_all[:4], holdout.coordinates.time, order=2)
+    sky_error = _angular_error_arcsec(
+        sky.predictions.ra.to_numpy(zero_copy_only=False),
+        sky.predictions.dec.to_numpy(zero_copy_only=False),
+        holdout.coordinates.lon.to_numpy(zero_copy_only=False),
+        holdout.coordinates.lat.to_numpy(zero_copy_only=False),
+    )
+
+    assert np.max(sky_error) < 120.0
+    assert np.all(np.isfinite(sky.predictions.sigma_ra.to_numpy(zero_copy_only=False)))
+    assert np.all(np.isfinite(sky.predictions.sigma_dec.to_numpy(zero_copy_only=False)))
+
+
+def test_validation_errors() -> None:
+    times_short = Timestamp.from_mjd([60100.0, 60100.01], scale="utc")
+    obs_short = _make_od_observations(
+        np.array([15.0, 15.01]),
+        np.array([-10.0, -10.01]),
+        times_short,
+    )
+
+    with pytest.raises(ValueError, match="At least 3 observations"):
+        systematic_ranging_short_arc(obs_short, object())
+
+    with pytest.raises(ValueError, match="At least 3 observations"):
+        propagate_sky_plane(obs_short, times_short, order=2)
+
+    times_ok = Timestamp.from_mjd([60110.0, 60110.01, 60110.02], scale="utc")
+    obs_ok = _make_od_observations(
+        np.array([30.0, 30.01, 30.02]),
+        np.array([5.0, 5.01, 5.02]),
+        times_ok,
+    )
+
+    with pytest.raises(ValueError, match="order must be 1 or 2"):
+        propagate_sky_plane(obs_ok, times_ok, order=3)
+
+    pole_ades = ADESObservations.from_kwargs(
+        trkSub=["POLE"],
+        obsSubID=["pole-1"],
+        obsTime=Timestamp.from_mjd([60120.0], scale="utc"),
+        ra=[10.0],
+        dec=[90.0],
+        rmsRACosDec=[0.2],
+        rmsDec=[0.2],
+        stn=["W84"],
+        mode=["CCD"],
+        astCat=["Gaia2"],
+    )
+
+    with pytest.raises(ValueError, match=r"cos\(dec\)"):
+        ades_to_od_observations(pole_ades)
+
+    with pytest.raises(ValueError, match="default_rms_arcsec must be positive"):
+        ades_to_od_observations(pole_ades, default_rms_arcsec=0.0)

--- a/src/adam_core/orbit_determination/tests/test_short_arc.py
+++ b/src/adam_core/orbit_determination/tests/test_short_arc.py
@@ -13,12 +13,14 @@ from ...coordinates import (
     Residuals,
     SphericalCoordinates,
 )
+from ...constants import Constants as c
 from ...observations.ades import ADESObservations
 from ...observers import Observers
 from ...orbits import Orbits
 from ...time import Timestamp
 from ..short_arc import (
     ShortArcRangingConfig,
+    _approximate_candidate_chi2,
     _construct_heliocentric_state,
     _fit_attributable,
     _gnomonic_inverse,
@@ -157,6 +159,33 @@ def test_construct_heliocentric_state() -> None:
 
     expected = np.array([3.0, 2.0, 3.0, 0.6, 2.2, 0.3])
     np.testing.assert_allclose(state, expected)
+
+
+def test_approximate_candidate_chi2_rotates_ecliptic_to_equatorial() -> None:
+    state = np.array([0.0, 1.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+    dt_days = np.array([0.0], dtype=np.float64)
+    observer_positions = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
+
+    topocentric_equatorial = c.TRANSFORM_EC2EQ @ state[:3]
+    distance = np.linalg.norm(topocentric_equatorial)
+    ux, uy, uz = topocentric_equatorial / distance
+
+    observed_ra_deg = np.array([np.degrees(np.arctan2(uy, ux)) % 360.0], dtype=np.float64)
+    observed_dec_deg = np.array(
+        [np.degrees(np.arcsin(np.clip(uz, -1.0, 1.0)))], dtype=np.float64
+    )
+
+    chi2 = _approximate_candidate_chi2(
+        state,
+        dt_days,
+        observer_positions,
+        observed_ra_deg,
+        observed_dec_deg,
+        sigma_ra_deg=np.array([1e-4], dtype=np.float64),
+        sigma_dec_deg=np.array([1e-4], dtype=np.float64),
+    )
+
+    assert chi2 < 1e-10
 
 
 def test_propagate_sky_plane_order2_beats_order1() -> None:


### PR DESCRIPTION
## Summary
- add a new `orbit_determination.short_arc` module with dual short-arc workflows:
  - `systematic_ranging_short_arc(...)` for state-vector candidate generation/evaluation
  - `propagate_sky_plane(...)` for weighted tangent-plane sky propagation
- add `ades_to_od_observations(...)` conversion for ADES input, including covariance construction from ADES RMS fields
- export new APIs/types from `adam_core.orbit_determination.__init__`
- add `test_short_arc.py` with deterministic unit tests plus an ASSIST integration test (skip-guarded)

## New Public APIs
- `ShortArcRangingConfig`
- `SkyPropagationPredictions`
- `SkyPropagationResult`
- `ades_to_od_observations(...)`
- `systematic_ranging_short_arc(...)`
- `propagate_sky_plane(...)`

## Validation
- `pdm run ruff check src/adam_core/orbit_determination/short_arc.py src/adam_core/orbit_determination/tests/test_short_arc.py`
- `pdm run pytest -q src/adam_core/orbit_determination/tests/test_short_arc.py -m 'not profile'`
- result: `5 passed, 1 skipped` (ASSIST integration skipped in this environment due missing ASSIST shared-library runtime)