### PR TITLE
Override ASSIST dependency for CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,10 @@ docs = [
     "sphinx-sitemap>=2.8.0",
 ]
 
+[tool.pdm.resolution.overrides]
+# Temporary CI unblocker until adam-assist publishes metadata depending on assist>=1.2.3.
+assist = "==1.2.3"
+
 [tool.black]
 line-length = 88
 


### PR DESCRIPTION
## Summary
- add a temporary PDM resolver override for `assist==1.2.3`
- unblock adam-core CI while waiting for an adam-assist release with corrected ASSIST dependency metadata

## Validation
- temp PDM install/import check with `adam-assist==0.3.8`, `assist==1.2.3`, and `rebound==4.6.0`
- `pdm lock -G test`
- pyproject TOML parse
- `git diff --check`
- standalone local-wheel install with adam-core + adam-assist resolved `assist==1.2.3` and `rebound==4.6.0`
- standalone installed adam-assist non-Horizons subset passed
- standalone installed Horizons-backed accuracy tests with retry for intermittent JPL TCP failures: 55 passed

## Notes
This is intended as a temporary CI unblocker. Once adam-assist publishes fixed metadata requiring `assist>=1.2.3,<1.3`, this override can be removed.
