### PR TITLE
observatory-bias: add reference_orbit warm-start to OrbitFitter ABC (…

### DIFF
--- a/src/adam_core/orbit_determination/orbit_fitter.py
+++ b/src/adam_core/orbit_determination/orbit_fitter.py
@@ -1,9 +1,10 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Tuple
+from typing import Optional, Tuple
 
 import pyarrow as pa
 
+from ..orbits.orbits import Orbits
 from .evaluate import FittedOrbitMembers, FittedOrbits, OrbitDeterminationObservations
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,7 @@ class OrbitFitter(ABC):
         self,
         object_id: str | pa.LargeStringScalar,
         observations: OrbitDeterminationObservations,
+        reference_orbit: Optional[Orbits] = None,
     ) -> Tuple[FittedOrbits, FittedOrbitMembers]:
         """Initial orbit fit for a single object.
 
@@ -61,6 +63,15 @@ class OrbitFitter(ABC):
             id of the object we are fitting for to be used in the output
         observations: OrbitDeterminationObservations
             observations to fit, assuming all observations correspond to the same object
+        reference_orbit: Orbits, optional
+            Optional warm-start seed (length-1 Orbits) for the fit. When provided,
+            implementations should use it as the starting point for differential
+            correction instead of cold-bootstrapping via IOD. Callers such as the
+            LOOO evaluation pipeline pass the MPC nominal orbit here so each
+            hold-in fit converges from a known-good neighborhood. When ``None``,
+            implementations must fall back to their default cold-start behavior
+            (e.g. Gauss IOD) so the API remains backward-compatible for callers
+            that have no seed available.
 
         Returns:
         --------

--- a/src/adam_core/orbit_determination/orbit_fitter.py
+++ b/src/adam_core/orbit_determination/orbit_fitter.py
@@ -66,9 +66,7 @@ class OrbitFitter(ABC):
         reference_orbit: Orbits, optional
             Optional warm-start seed (length-1 Orbits) for the fit. When provided,
             implementations should use it as the starting point for differential
-            correction instead of cold-bootstrapping via IOD. Callers such as the
-            LOOO evaluation pipeline pass the MPC nominal orbit here so each
-            hold-in fit converges from a known-good neighborhood. When ``None``,
+            correction instead of cold-bootstrapping via IOD. When ``None``,
             implementations must fall back to their default cold-start behavior
             (e.g. Gauss IOD) so the API remains backward-compatible for callers
             that have no seed available.


### PR DESCRIPTION
Extend OrbitFitter.initial_fit() with an optional reference_orbit kwarg so backends can be passed a warm-start seed instead of cold-bootstrapping via IOD on every call. Defaults to None to preserve the existing contract for callers that have no seed.

Backward-compatible at the call-site for existing implementations (FindOrbOrbitFitter on its current signature still satisfies the ABC), but callers who pass reference_orbit will get a TypeError until the backend is updated. 