### PR TITLE
Add estimate_rotation_period_best_apparition: solve each apparition, keep the most confident result

### DIFF
--- a/docs/source/cookbook/rotation_periods.rst
+++ b/docs/source/cookbook/rotation_periods.rst
@@ -155,6 +155,36 @@ expected bad/insufficient data comes back as an ``insufficient_data`` row carryi
 id. Unexpected (programmer/contract) errors are re-raised with the offending object
 id attached rather than swallowed.
 
+Multiple Apparitions: Solve Each, Keep the Most Confident
+---------------------------------------------------------
+
+If your photometry spans more than one apparition (observing seasons separated
+by months), do not pool it into a single solve. Apparitions differ in viewing
+aspect, noise, and nightly cadence, so each has its own alias structure -- and
+one of them often samples the rotation cleanly where the densest one locks onto
+a sampling alias or hedges. ``estimate_rotation_period_best_apparition``
+partitions the observations at gaps longer than ``apparition_gap_days``
+(default 120), solves each apparition independently, and returns the most
+confident result (verdict rank, then amplitude SNR; the rule never sees any
+reference answer).
+
+.. code-block:: python
+
+   from adam_core.photometry import estimate_rotation_period_best_apparition
+
+   result = estimate_rotation_period_best_apparition(observations)
+   # result.confidence_flags[0] includes "apparition_selected_<k>_of_<n>"
+
+Measured on the 118-object LCDB standard-candle calibration set, this policy
+raised confident (``single_period``) results from 35 to 43 objects while the
+strict precision of those claims *improved* (0.80 to 0.84) and no new
+wrong-family claim appeared. The safety is measured on that set, not
+structural: a clean apparition can still be an alias, so the verdict semantics
+are unchanged. Requiring a second apparition to corroborate before claiming was
+also tested and is deliberately **not** applied: on the calibration set it only
+removed correct claims, because an object's systematic harmonic aliases repeat
+across apparitions and corroboration therefore does not catch them.
+
 Performance
 -----------
 
@@ -181,6 +211,8 @@ Entry Points
   exposures / heliocentric coordinates.
 * ``estimate_rotation_period_from_detections_grouped``: many objects; guarantees one
   result row per id.
+* ``estimate_rotation_period_best_apparition``: multi-apparition photometry of one
+  object; solves each apparition and keeps the most confident result.
 * ``RotationPeriodObservations.from_point_source_observations``: build the
   observations table (e.g. to inspect or reuse) without solving.
 

--- a/src/adam_core/photometry/__init__.py
+++ b/src/adam_core/photometry/__init__.py
@@ -19,6 +19,7 @@ from .rotation import (
     RotationPeriodResult,
     build_rotation_period_observations_from_detections,
     estimate_rotation_period,
+    estimate_rotation_period_best_apparition,
     estimate_rotation_period_from_detections,
     estimate_rotation_period_from_detections_grouped,
 )
@@ -40,6 +41,7 @@ __all__ = [
     # Rotation-period analysis
     "build_rotation_period_observations_from_detections",
     "estimate_rotation_period",
+    "estimate_rotation_period_best_apparition",
     "estimate_rotation_period_from_detections",
     "estimate_rotation_period_from_detections_grouped",
     "RotationPeriodObservations",

--- a/src/adam_core/photometry/rotation/__init__.py
+++ b/src/adam_core/photometry/rotation/__init__.py
@@ -17,6 +17,7 @@ from .core import (
 from .estimator import estimate_rotation_period
 from .wrappers import (
     build_rotation_period_observations_from_detections,
+    estimate_rotation_period_best_apparition,
     estimate_rotation_period_from_detections,
     estimate_rotation_period_from_detections_grouped,
 )

--- a/src/adam_core/photometry/rotation/wrappers.py
+++ b/src/adam_core/photometry/rotation/wrappers.py
@@ -24,6 +24,7 @@ from .core import (
 
 __all__ = [
     "build_rotation_period_observations_from_detections",
+    "estimate_rotation_period_best_apparition",
     "estimate_rotation_period_from_detections",
     "estimate_rotation_period_from_detections_grouped",
 ]
@@ -303,3 +304,125 @@ def estimate_rotation_period_from_detections_grouped(
     return GroupedRotationPeriodResults.from_kwargs(
         object_id=out_object_id, result=result
     )
+
+
+def _apparition_index_groups(
+    mjd: np.ndarray,
+    gap_days: float,
+) -> list[np.ndarray]:
+    """Group observation indices into apparitions.
+
+    An apparition is a maximal run of (time-sorted) observations in which no
+    consecutive pair is separated by more than ``gap_days``. Returns one int64
+    index array per apparition, in chronological order; indices refer to the
+    ORIGINAL (unsorted) observation order.
+    """
+    order = np.argsort(np.asarray(mjd, dtype=np.float64), kind="stable")
+    sorted_t = np.asarray(mjd, dtype=np.float64)[order]
+    breaks = np.nonzero(np.diff(sorted_t) > float(gap_days))[0]
+    return [np.asarray(group, dtype=np.int64) for group in np.split(order, breaks + 1)]
+
+
+_VERDICT_RANK = {"single_period": 2, "period_family": 1, "insufficient_data": 0}
+
+
+def estimate_rotation_period_best_apparition(
+    observations: RotationPeriodObservations,
+    *,
+    apparition_gap_days: float = 120.0,
+    **solver_kwargs: Any,
+) -> RotationPeriodResult:
+    """Solve each apparition separately and keep the highest-confidence result.
+
+    Ground-based lightcurves of the same asteroid from different apparitions
+    differ in viewing aspect (and therefore amplitude), photometric noise, and
+    nightly cadence, so the diurnal-alias structure of each apparition differs
+    too. An apparition that happens to sample the rotation cleanly can yield a
+    confident, correct period where the densest apparition -- or all
+    apparitions pooled -- locks onto a sampling alias or hedges. This helper
+    partitions the observations into apparitions (separated by more than
+    ``apparition_gap_days``), runs :func:`estimate_rotation_period` on each
+    independently, and returns the result of the most confident apparition.
+
+    The selection rule uses no knowledge of any reference answer: rank the
+    verdicts ``single_period`` > ``period_family`` > ``insufficient_data``,
+    tie-break on higher ``amplitude_snr``, then on more observations, then on
+    the earlier apparition. Measured on the 118-object LCDB standard-candle
+    calibration set, this policy raised confident (``single_period``) claims
+    from 35 to 43 while the strict precision of those claims improved (0.800 ->
+    0.837) and the wrong-family count was unchanged -- selection shopping did
+    not introduce false confidence on that set, but the guarantee is
+    empirical, not structural.
+
+    The chosen row is returned with a ``apparition_selected_<k>_of_<n>``
+    confidence flag appended (1-based, chronological). An apparition whose
+    solve fails with an expected ``ValueError`` participates as an
+    ``insufficient_data`` candidate flagged ``solve_error``; an unexpected
+    error is re-raised with the apparition attached. Apparitions solve
+    serially; for large batches, parallelize per apparition yourself.
+    """
+    n_obs = len(observations)
+    mjd = np.asarray(
+        observations.time.rescale("tdb").mjd().to_numpy(False), dtype=np.float64
+    )
+    groups = _apparition_index_groups(mjd, apparition_gap_days)
+
+    # Lazy import keeps this wrapper module importable without the solver kernel.
+    from .estimator import estimate_rotation_period as _estimate_rotation_period
+
+    if n_obs == 0 or len(groups) <= 1:
+        # Single apparition (or empty, where the solver raises its canonical
+        # error): delegate wholesale so behavior matches the direct call.
+        result = _estimate_rotation_period(observations, **solver_kwargs)
+        return _with_apparition_flag(result, selected=1, total=1)
+
+    candidates: list[tuple[int, RotationPeriodResult]] = []
+    for k, indices in enumerate(groups):
+        subset = observations.take(pa.array(indices, type=pa.int64()))
+        try:
+            result_k = _estimate_rotation_period(subset, **solver_kwargs)
+        except ValueError as exc:
+            # Expected per-apparition data failure: keep it as a candidate so
+            # a fully-unsolvable object still returns one insufficient row.
+            result_k = RotationPeriodResult.single_insufficient(
+                reasons=[f"solve_error: {exc}"],
+                confidence_flags=["solve_error"],
+                n_observations=int(len(indices)),
+            )
+        except Exception as exc:  # noqa: BLE001 - attach apparition context
+            raise RuntimeError(
+                f"rotation-period solve failed for apparition {k + 1} of "
+                f"{len(groups)}"
+            ) from exc
+        candidates.append((k, result_k))
+
+    def _score(
+        item: tuple[int, RotationPeriodResult],
+    ) -> tuple[float, float, float, float]:
+        k, result_k = item
+        verdict = str(result_k.period_verdict[0].as_py())
+        snr = result_k.amplitude_snr[0].as_py()
+        return (
+            float(_VERDICT_RANK.get(verdict, 0)),
+            float("-inf") if snr is None else float(snr),
+            float(result_k.n_observations[0].as_py() or 0),
+            -float(k),
+        )
+
+    best_k, best = max(candidates, key=_score)
+    return _with_apparition_flag(best, selected=best_k + 1, total=len(groups))
+
+
+def _with_apparition_flag(
+    result: RotationPeriodResult, *, selected: int, total: int
+) -> RotationPeriodResult:
+    """Append an ``apparition_selected_<k>_of_<n>`` confidence flag to a row."""
+    flags = list(result.confidence_flags[0].as_py() or [])
+    flags.append(f"apparition_selected_{selected}_of_{total}")
+    column_index = result.table.schema.get_field_index("confidence_flags")
+    table = result.table.set_column(
+        column_index,
+        result.table.schema.field("confidence_flags"),
+        pa.array([flags], type=pa.large_list(pa.large_string())),
+    )
+    return RotationPeriodResult.from_pyarrow(table)

--- a/src/adam_core/photometry/tests/test_rotation_period_apparitions.py
+++ b/src/adam_core/photometry/tests/test_rotation_period_apparitions.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from ...time import Timestamp
+from ..rotation.core import RotationPeriodObservations, RotationPeriodResult
+from ..rotation.wrappers import (
+    _apparition_index_groups,
+    estimate_rotation_period_best_apparition,
+)
+
+# Fast, deterministic solver settings used throughout (mirrors the other
+# rotation tests: small exact grid, no staged search).
+_FAST: dict[str, Any] = dict(
+    search_fidelity="exact_grid",
+    max_frequency_cycles_per_day=120.0,
+    frequency_grid_scale=40.0,
+)
+
+
+def _make_apparition(
+    *,
+    t0_mjd: float,
+    n: int = 60,
+    span_days: float = 0.08,
+    period_days: float | None = 0.02,
+    amplitude: float = 0.35,
+    noise_sigma: float = 0.01,
+) -> dict[str, np.ndarray]:
+    """Raw column arrays for one apparition; period_days=None means flat noise."""
+    mjd = np.linspace(t0_mjd, t0_mjd + span_days, n, dtype=np.float64)
+    t_rel = mjd - mjd.min()
+    r_au = np.full(n, 2.0, dtype=np.float64)
+    delta_au = np.full(n, 1.5, dtype=np.float64)
+    phase_angle = np.full(n, 12.0, dtype=np.float64)
+    baseline = 15.0 + 5.0 * np.log10(r_au * delta_au) + 0.015 * phase_angle
+    rng = np.random.default_rng(int(t0_mjd))
+    if period_days is None:
+        rotation = np.zeros(n, dtype=np.float64)
+        noise = rng.normal(0.0, 0.005, size=n)  # scatter below mag_sigma
+    else:
+        phase = 2.0 * np.pi * t_rel / period_days
+        rotation = (
+            0.10 * np.cos(phase)
+            + amplitude * np.cos(2.0 * phase)
+            + 0.07 * np.sin(2.0 * phase)
+        )
+        noise = rng.normal(0.0, noise_sigma, size=n)
+    return {
+        "mjd": mjd,
+        "mag": baseline + rotation + noise,
+        "mag_sigma": np.full(n, 0.03 if period_days is not None else 0.05),
+        "r_au": r_au,
+        "delta_au": delta_au,
+        "phase_angle_deg": phase_angle,
+    }
+
+
+def _to_observations(*apparitions: dict[str, np.ndarray]) -> RotationPeriodObservations:
+    cols = {
+        key: np.concatenate([a[key] for a in apparitions])
+        for key in apparitions[0].keys()
+    }
+    n = len(cols["mjd"])
+    return RotationPeriodObservations.from_kwargs(
+        time=Timestamp.from_mjd(cols["mjd"], scale="tdb"),
+        mag=pa.array(cols["mag"], type=pa.float64()),
+        mag_sigma=pa.array(cols["mag_sigma"], type=pa.float64()),
+        filter=pa.array(["LSST_r"] * n, type=pa.large_string()),
+        session_id=pa.array(
+            [f"X05:{int(m)}" for m in cols["mjd"]], type=pa.large_string()
+        ),
+        r_au=pa.array(cols["r_au"], type=pa.float64()),
+        delta_au=pa.array(cols["delta_au"], type=pa.float64()),
+        phase_angle_deg=pa.array(cols["phase_angle_deg"], type=pa.float64()),
+    )
+
+
+def test_apparition_index_groups_partitions_on_gaps():
+    # Unsorted input; gaps of >120 d split into three chronological groups whose
+    # indices refer to the ORIGINAL order.
+    mjd = np.array([60300.0, 60000.0, 60001.5, 60301.0, 60900.0])
+    groups = _apparition_index_groups(mjd, 120.0)
+    assert [list(g) for g in groups] == [[1, 2], [0, 3], [4]]
+    # One group when no gap exceeds the threshold.
+    assert len(_apparition_index_groups(np.array([60000.0, 60100.0]), 120.0)) == 1
+
+
+def test_best_apparition_picks_the_clean_apparition():
+    clean = _make_apparition(t0_mjd=60000.0, period_days=0.02)
+    flat = _make_apparition(t0_mjd=60200.0, period_days=None)  # signal-free
+    combined = _to_observations(clean, flat)
+
+    result = estimate_rotation_period_best_apparition(combined, **_FAST)
+    alone = estimate_rotation_period_best_apparition(_to_observations(clean), **_FAST)
+
+    assert isinstance(result, RotationPeriodResult)
+    assert len(result) == 1
+    # The chosen row is the clean apparition's solve: same period, same verdict.
+    assert result.period_hours[0].as_py() == pytest.approx(
+        alone.period_hours[0].as_py(), rel=1e-9
+    )
+    assert result.period_verdict[0].as_py() == alone.period_verdict[0].as_py()
+    # The clean apparition is chronologically first of two.
+    flags = result.confidence_flags[0].as_py() or []
+    assert "apparition_selected_1_of_2" in flags
+
+
+def test_single_apparition_matches_direct_solve():
+    clean = _make_apparition(t0_mjd=60000.0, period_days=0.02)
+    observations = _to_observations(clean)
+
+    from ..rotation.estimator import estimate_rotation_period
+
+    direct = estimate_rotation_period(observations, **_FAST)
+    via_helper = estimate_rotation_period_best_apparition(observations, **_FAST)
+
+    assert via_helper.period_hours[0].as_py() == pytest.approx(
+        direct.period_hours[0].as_py(), rel=1e-9
+    )
+    assert via_helper.period_verdict[0].as_py() == direct.period_verdict[0].as_py()
+    flags = via_helper.confidence_flags[0].as_py() or []
+    assert "apparition_selected_1_of_1" in flags
+    # Aside from the appended flag, the row is the direct result.
+    direct_flags = direct.confidence_flags[0].as_py() or []
+    assert flags == direct_flags + ["apparition_selected_1_of_1"]
+
+
+def test_all_apparitions_failing_returns_single_insufficient(monkeypatch):
+    import adam_core.photometry.rotation.estimator as rpe
+
+    def always_fail(observations, **kwargs):
+        raise ValueError("simulated insufficient data")
+
+    monkeypatch.setattr(rpe, "estimate_rotation_period", always_fail)
+
+    combined = _to_observations(
+        _make_apparition(t0_mjd=60000.0, period_days=0.02),
+        _make_apparition(t0_mjd=60200.0, period_days=None),
+    )
+    result = estimate_rotation_period_best_apparition(combined, **_FAST)
+
+    assert result.period_verdict[0].as_py() == "insufficient_data"
+    flags = result.confidence_flags[0].as_py() or []
+    assert "solve_error" in flags
+    assert any(f.startswith("apparition_selected_") for f in flags)
+
+
+def test_unexpected_error_reraised_with_apparition_context(monkeypatch):
+    import adam_core.photometry.rotation.estimator as rpe
+
+    def boom(observations, **kwargs):
+        raise RuntimeError("unexpected solver bug")
+
+    monkeypatch.setattr(rpe, "estimate_rotation_period", boom)
+
+    combined = _to_observations(
+        _make_apparition(t0_mjd=60000.0, period_days=0.02),
+        _make_apparition(t0_mjd=60200.0, period_days=None),
+    )
+    with pytest.raises(RuntimeError, match="apparition 1 of 2"):
+        estimate_rotation_period_best_apparition(combined, **_FAST)


### PR DESCRIPTION
## What

Adds `estimate_rotation_period_best_apparition`, a public helper that partitions multi-apparition photometry at long time gaps (default 120 days), runs `estimate_rotation_period` on each apparition independently, and returns the most confident result — verdict rank (`single_period` > `period_family` > `insufficient_data`), tie-broken by amplitude SNR, then observation count. The chosen row carries an `apparition_selected_<k>_of_<n>` confidence flag. Also adds a cookbook section and five tests.

## Why

While writing up the rotation-period subsystem we asked why a fully automated solver misses periods that human observers recovered from similar data. One structural reason: apparitions differ in viewing aspect, noise, and nightly cadence, so each has its own sampling-alias structure — and our calibration policy solved only the densest apparition per object. Pooling apparitions is usually worse, not better; picking the cleanest one is the win.

## Measured results (118-object LCDB standard-candle calibration set)

Every ALCDEF apparition of every calibration object was solved (186 apparitions; 58 beyond the baseline set), and four selection policies were scored against the LCDB reference periods using the shipped tolerance functions:

| policy | strictly right | right family | `single_period` claims | strict precision | wrong-family |
|---|---:|---:|---:|---:|---|
| baseline (densest apparition) | 60 | 84 | 35 | 0.800 | 1 (3295 Murakami) |
| **best-confidence apparition (this PR)** | **63** | 84 | **43** | **0.837** | 1 (same) |
| oracle upper bound | 69 | 87 | 43 | 0.837 | 1 (same) |
| corroborated (2nd apparition must agree) | 63 | 84 | 40 | 0.825 | 1 (same) |

- The selection rule never sees a reference answer; all 8 net-new confident claims are strictly correct, and no new wrong-family claim appears.
- 1627 Ivar — the documented diurnal-alias expected-failure pinned in CI — is recovered at the correct 4.795 h: all four of its non-densest apparitions land there.
- Corroboration-as-a-gate was evaluated and deliberately **not** included: an object's harmonic aliases repeat across apparitions, so on this set the gate only removed correct claims.
- The safety is measured, not structural (two alternate apparitions produced confident half-period aliases and were excluded only by the SNR tie-break), so the helper's docstring states this and the verdict semantics are unchanged.

## Behavior details

- Single-apparition (or empty) input delegates wholesale to `estimate_rotation_period`, so results match the direct call (plus the flag).
- An apparition failing with an expected `ValueError` participates as an `insufficient_data` candidate flagged `solve_error` (mirroring the grouped API's no-silent-drop semantics); unexpected errors re-raise with apparition context.
- Apparitions solve serially; batch users can parallelize per apparition themselves.

## Testing

- 5 new tests: gap partitioning (unsorted input), clean-vs-flat apparition selection, single-apparition passthrough equivalence, all-apparitions-fail returns one insufficient row, unexpected-error context.
- Full rotation suite: 28 passed, 1 xfailed (the known Ivar sparse-fixture gate, unchanged). `mypy --strict` clean on the subsystem; ruff/black/isort clean; docs build clean under `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZNKbKYQR3hFiP9vLdzZU4
