### PR TITLE
Add typed Scout observation snapshots

### DIFF
--- a/src/adam_core/observations/__init__.py
+++ b/src/adam_core/observations/__init__.py
@@ -13,6 +13,7 @@ from .ades import (
 from .associations import Associations
 from .detections import PointSourceDetections
 from .exposures import Exposures
+from .obs80 import OpticalObs80, ScoutObservations
 from .photometry import Photometry
 from .source_catalog import SourceCatalog
 
@@ -20,6 +21,8 @@ __all__ = [
     "Associations",
     "Exposures",
     "PointSourceDetections",
+    "OpticalObs80",
+    "ScoutObservations",
     "Photometry",
     "SourceCatalog",
 ]

--- a/src/adam_core/observations/obs80.py
+++ b/src/adam_core/observations/obs80.py
@@ -1,15 +1,20 @@
-"""Parsing helpers for MPC's legacy 80-column observation format.
+"""Typed MPC 80-column optical observations.
 
-This module intentionally parses only self-contained optical astrometry rows.
+The parser intentionally supports only self-contained optical astrometry rows.
 Radar, satellite, and roving-observer records require companion lines and are
 rejected rather than partially interpreted.
 """
 
 from __future__ import annotations
 
-import dataclasses
 import datetime
 from decimal import Decimal, InvalidOperation, ROUND_FLOOR, ROUND_HALF_EVEN
+
+import pyarrow as pa
+import quivr as qv
+from quivr.validators import and_, ge, le
+
+from ..time import Timestamp
 
 NANOSECONDS_PER_DAY = 86_400_000_000_000
 _MJD_EPOCH = datetime.date(1858, 11, 17)
@@ -20,28 +25,42 @@ class Obs80ParseError(ValueError):
     """An MPC 80-column record is malformed or unsupported."""
 
 
-@dataclasses.dataclass(frozen=True)
-class OpticalObs80:
-    """One parsed, self-contained optical MPC 80-column observation."""
+class OpticalObs80(qv.Table):
+    """Self-contained optical observations parsed from MPC 80-column rows."""
 
-    raw_line: str
-    designation: str
-    discovery: bool
-    note1: str | None
-    note2: str | None
-    observatory_code: str
-    obstime_days_utc: int
-    obstime_nanos_utc: int
-    ra_deg: float
-    dec_deg: float
-    mag: float | None
-    band: str | None
-    astrometric_catalog: str | None
-    reference: str | None
+    raw_line = qv.LargeStringColumn()
+    designation = qv.LargeStringColumn()
+    discovery = qv.BooleanColumn()
+    note1 = qv.LargeStringColumn(nullable=True)
+    note2 = qv.LargeStringColumn(nullable=True)
+    observatory_code = qv.LargeStringColumn()
+    time = Timestamp.as_column()
+    ra_deg = qv.Float64Column(validator=and_(ge(0), le(360)))
+    dec_deg = qv.Float64Column(validator=and_(ge(-90), le(90)))
+    mag = qv.Float64Column(nullable=True)
+    band = qv.LargeStringColumn(nullable=True)
+    astrometric_catalog = qv.LargeStringColumn(nullable=True)
+    reference = qv.LargeStringColumn(nullable=True)
 
-    @property
-    def obstime_mjd_utc(self) -> float:
-        return self.obstime_days_utc + self.obstime_nanos_utc / NANOSECONDS_PER_DAY
+
+class ScoutObservations(qv.Table):
+    """One or more authoritative JPL Scout ``file=mpc`` snapshots.
+
+    Snapshot metadata is repeated per observation so filtered/sliced tables
+    retain their source hash, API signature, and ordering without side data.
+    ``declared_n_obs`` is Scout's summary metadata; membership is exclusively
+    defined by ``snapshot_observation_count`` and the nested observations.
+    """
+
+    object_id = qv.LargeStringColumn()
+    solution_date_utc = qv.LargeStringColumn(nullable=True)
+    declared_n_obs = qv.Int64Column(nullable=True)
+    snapshot_sha256 = qv.LargeStringColumn()
+    snapshot_observation_count = qv.Int64Column()
+    signature_version = qv.LargeStringColumn(nullable=True)
+    signature_source = qv.LargeStringColumn(nullable=True)
+    observation_index = qv.Int64Column()
+    observation = OpticalObs80.as_column()
 
 
 def _parse_decimal(raw: str, *, field: str) -> Decimal:
@@ -115,20 +134,7 @@ def _parse_dec(raw: str) -> float:
 
 
 def parse_optical_obs80(raw: str) -> OpticalObs80:
-    """Parse one self-contained optical MPC 80-column record.
-
-    Parameters
-    ----------
-    raw
-        A line containing at least the standard 80 columns. Trailing content
-        is ignored.
-
-    Raises
-    ------
-    Obs80ParseError
-        If the record is malformed or is a two-line radar, satellite, or
-        roving-observer record.
-    """
+    """Parse one self-contained optical MPC 80-column record."""
     if not isinstance(raw, str) or len(raw) < 80:
         raise Obs80ParseError("record is shorter than 80 columns")
     line = raw[:80]
@@ -150,37 +156,46 @@ def parse_optical_obs80(raw: str) -> OpticalObs80:
         raise Obs80ParseError("invalid magnitude") from exc
 
     obstime_days, obstime_nanos = _parse_obstime(line[15:32])
-    return OpticalObs80(
-        raw_line=line,
-        designation=designation,
-        discovery=line[12] == "*",
-        note1=line[13].strip() or None,
-        note2=note2,
-        observatory_code=observatory_code,
-        obstime_days_utc=obstime_days,
-        obstime_nanos_utc=obstime_nanos,
-        ra_deg=_parse_ra(line[32:44]),
-        dec_deg=_parse_dec(line[44:56]),
-        mag=magnitude,
-        band=line[70].strip() or None,
-        astrometric_catalog=line[71].strip() or None,
-        reference=line[72:77].strip() or None,
+    return OpticalObs80.from_kwargs(
+        raw_line=[line],
+        designation=[designation],
+        discovery=[line[12] == "*"],
+        note1=[line[13].strip() or None],
+        note2=[note2],
+        observatory_code=[observatory_code],
+        time=Timestamp.from_kwargs(
+            days=[obstime_days], nanos=[obstime_nanos], scale="utc"
+        ),
+        ra_deg=[_parse_ra(line[32:44])],
+        dec_deg=[_parse_dec(line[44:56])],
+        mag=pa.array([magnitude], type=pa.float64()),
+        band=[line[70].strip() or None],
+        astrometric_catalog=[line[71].strip() or None],
+        reference=[line[72:77].strip() or None],
     )
 
 
-def parse_optical_obs80_file(raw: str) -> list[OpticalObs80]:
+def parse_optical_obs80_file(raw: str, *, strict: bool = True) -> OpticalObs80:
     """Parse every nonblank optical row in an MPC-format text file.
 
-    Failure is row-local: unsupported or malformed records are omitted. Callers
-    that require strict completeness should compare the returned row count to
-    the source's declared observation count.
+    Parameters
+    ----------
+    raw
+        MPC-format file contents.
+    strict
+        Raise on the first malformed/unsupported row. If false, omit invalid
+        rows. Scout snapshot ingestion uses the strict default so it can never
+        expose a partial fitted observation set.
     """
     parsed: list[OpticalObs80] = []
-    for line in str(raw or "").splitlines():
+    for line_number, line in enumerate(str(raw or "").splitlines(), start=1):
         if not line.strip():
             continue
         try:
             parsed.append(parse_optical_obs80(line))
-        except Obs80ParseError:
-            continue
-    return parsed
+        except Obs80ParseError as exc:
+            if strict:
+                raise Obs80ParseError(f"line {line_number}: {exc}") from exc
+    if not parsed:
+        return OpticalObs80.empty()
+    return qv.concatenate(parsed)

--- a/src/adam_core/observations/obs80.py
+++ b/src/adam_core/observations/obs80.py
@@ -1,0 +1,186 @@
+"""Parsing helpers for MPC's legacy 80-column observation format.
+
+This module intentionally parses only self-contained optical astrometry rows.
+Radar, satellite, and roving-observer records require companion lines and are
+rejected rather than partially interpreted.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+from decimal import Decimal, InvalidOperation, ROUND_FLOOR, ROUND_HALF_EVEN
+
+NANOSECONDS_PER_DAY = 86_400_000_000_000
+_MJD_EPOCH = datetime.date(1858, 11, 17)
+_UNSUPPORTED_TWO_LINE_TYPES = frozenset({"R", "S", "V", "r", "s", "v"})
+
+
+class Obs80ParseError(ValueError):
+    """An MPC 80-column record is malformed or unsupported."""
+
+
+@dataclasses.dataclass(frozen=True)
+class OpticalObs80:
+    """One parsed, self-contained optical MPC 80-column observation."""
+
+    raw_line: str
+    designation: str
+    discovery: bool
+    note1: str | None
+    note2: str | None
+    observatory_code: str
+    obstime_days_utc: int
+    obstime_nanos_utc: int
+    ra_deg: float
+    dec_deg: float
+    mag: float | None
+    band: str | None
+    astrometric_catalog: str | None
+    reference: str | None
+
+    @property
+    def obstime_mjd_utc(self) -> float:
+        return self.obstime_days_utc + self.obstime_nanos_utc / NANOSECONDS_PER_DAY
+
+
+def _parse_decimal(raw: str, *, field: str) -> Decimal:
+    try:
+        return Decimal(raw.strip())
+    except (InvalidOperation, ValueError) as exc:
+        raise Obs80ParseError(f"invalid {field}") from exc
+
+
+def _parse_obstime(raw: str) -> tuple[int, int]:
+    parts = raw.strip().split()
+    if len(parts) != 3:
+        raise Obs80ParseError("invalid observation date")
+    try:
+        year = int(parts[0])
+        month = int(parts[1])
+    except ValueError as exc:
+        raise Obs80ParseError("invalid observation date") from exc
+
+    day_decimal = _parse_decimal(parts[2], field="observation day")
+    day = int(day_decimal.to_integral_value(rounding=ROUND_FLOOR))
+    fraction = day_decimal - Decimal(day)
+    if fraction < 0 or fraction >= 1:
+        raise Obs80ParseError("invalid observation day fraction")
+    try:
+        calendar_day = datetime.date(year, month, day)
+    except ValueError as exc:
+        raise Obs80ParseError("invalid observation date") from exc
+
+    nanos = int(
+        (fraction * Decimal(NANOSECONDS_PER_DAY)).to_integral_value(
+            rounding=ROUND_HALF_EVEN
+        )
+    )
+    if nanos == NANOSECONDS_PER_DAY:
+        calendar_day += datetime.timedelta(days=1)
+        nanos = 0
+    return (calendar_day - _MJD_EPOCH).days, nanos
+
+
+def _parse_ra(raw: str) -> float:
+    parts = raw.strip().split()
+    if len(parts) != 3:
+        raise Obs80ParseError("invalid right ascension")
+    try:
+        hours, minutes, seconds = (float(value) for value in parts)
+    except ValueError as exc:
+        raise Obs80ParseError("invalid right ascension") from exc
+    if not (0 <= hours < 24 and 0 <= minutes < 60 and 0 <= seconds < 60):
+        raise Obs80ParseError("right ascension outside valid range")
+    return 15.0 * (hours + minutes / 60.0 + seconds / 3600.0)
+
+
+def _parse_dec(raw: str) -> float:
+    parts = raw.strip().split()
+    if len(parts) != 3 or not parts[0] or parts[0][0] not in "+-":
+        raise Obs80ParseError("invalid declination")
+    sign = -1.0 if parts[0][0] == "-" else 1.0
+    try:
+        degrees = float(parts[0][1:])
+        minutes = float(parts[1])
+        seconds = float(parts[2])
+    except ValueError as exc:
+        raise Obs80ParseError("invalid declination") from exc
+    if not (0 <= degrees <= 90 and 0 <= minutes < 60 and 0 <= seconds < 60):
+        raise Obs80ParseError("declination outside valid range")
+    value = sign * (degrees + minutes / 60.0 + seconds / 3600.0)
+    if not -90.0 <= value <= 90.0:
+        raise Obs80ParseError("declination outside valid range")
+    return value
+
+
+def parse_optical_obs80(raw: str) -> OpticalObs80:
+    """Parse one self-contained optical MPC 80-column record.
+
+    Parameters
+    ----------
+    raw
+        A line containing at least the standard 80 columns. Trailing content
+        is ignored.
+
+    Raises
+    ------
+    Obs80ParseError
+        If the record is malformed or is a two-line radar, satellite, or
+        roving-observer record.
+    """
+    if not isinstance(raw, str) or len(raw) < 80:
+        raise Obs80ParseError("record is shorter than 80 columns")
+    line = raw[:80]
+    note2 = line[14].strip() or None
+    if note2 in _UNSUPPORTED_TWO_LINE_TYPES:
+        raise Obs80ParseError(f"unsupported two-line record type {note2}")
+
+    designation = line[5:12].strip()
+    observatory_code = line[77:80].strip()
+    if not designation:
+        raise Obs80ParseError("missing designation")
+    if len(observatory_code) != 3:
+        raise Obs80ParseError("invalid observatory code")
+
+    magnitude_raw = line[65:70].strip()
+    try:
+        magnitude = float(magnitude_raw) if magnitude_raw else None
+    except ValueError as exc:
+        raise Obs80ParseError("invalid magnitude") from exc
+
+    obstime_days, obstime_nanos = _parse_obstime(line[15:32])
+    return OpticalObs80(
+        raw_line=line,
+        designation=designation,
+        discovery=line[12] == "*",
+        note1=line[13].strip() or None,
+        note2=note2,
+        observatory_code=observatory_code,
+        obstime_days_utc=obstime_days,
+        obstime_nanos_utc=obstime_nanos,
+        ra_deg=_parse_ra(line[32:44]),
+        dec_deg=_parse_dec(line[44:56]),
+        mag=magnitude,
+        band=line[70].strip() or None,
+        astrometric_catalog=line[71].strip() or None,
+        reference=line[72:77].strip() or None,
+    )
+
+
+def parse_optical_obs80_file(raw: str) -> list[OpticalObs80]:
+    """Parse every nonblank optical row in an MPC-format text file.
+
+    Failure is row-local: unsupported or malformed records are omitted. Callers
+    that require strict completeness should compare the returned row count to
+    the source's declared observation count.
+    """
+    parsed: list[OpticalObs80] = []
+    for line in str(raw or "").splitlines():
+        if not line.strip():
+            continue
+        try:
+            parsed.append(parse_optical_obs80(line))
+        except Obs80ParseError:
+            continue
+    return parsed

--- a/src/adam_core/observations/tests/test_obs80.py
+++ b/src/adam_core/observations/tests/test_obs80.py
@@ -15,22 +15,24 @@ def test_parse_standard_scout_neocp_optical_record() -> None:
         "     A11EpSe*0C2026 07 08.17725719 41 24.185-30 19 19.42         19.35oVNEOCPW68"
     )
 
-    assert parsed.designation == "A11EpSe"
-    assert parsed.discovery is True
-    assert parsed.note1 == "0"
-    assert parsed.note2 == "C"
-    assert parsed.observatory_code == "W68"
-    assert parsed.obstime_days_utc == 61229
-    assert parsed.obstime_nanos_utc == int(
-        (Decimal("0.177257") * Decimal(NANOSECONDS_PER_DAY)).to_integral_value()
-    )
-    assert parsed.ra_deg == pytest.approx(295.3507708333333)
-    assert parsed.dec_deg == pytest.approx(-30.32206111111111)
-    assert parsed.mag == pytest.approx(19.35)
-    assert parsed.band == "o"
-    assert parsed.astrometric_catalog == "V"
-    assert parsed.reference == "NEOCP"
-    assert parsed.obstime_mjd_utc == pytest.approx(61229.177257)
+    assert len(parsed) == 1
+    assert parsed.designation.to_pylist() == ["A11EpSe"]
+    assert parsed.discovery.to_pylist() == [True]
+    assert parsed.note1.to_pylist() == ["0"]
+    assert parsed.note2.to_pylist() == ["C"]
+    assert parsed.observatory_code.to_pylist() == ["W68"]
+    assert parsed.time.scale == "utc"
+    assert parsed.time.days.to_pylist() == [61229]
+    assert parsed.time.nanos.to_pylist() == [
+        int((Decimal("0.177257") * Decimal(NANOSECONDS_PER_DAY)).to_integral_value())
+    ]
+    assert parsed.ra_deg[0].as_py() == pytest.approx(295.3507708333333)
+    assert parsed.dec_deg[0].as_py() == pytest.approx(-30.32206111111111)
+    assert parsed.mag[0].as_py() == pytest.approx(19.35)
+    assert parsed.band.to_pylist() == ["o"]
+    assert parsed.astrometric_catalog.to_pylist() == ["V"]
+    assert parsed.reference.to_pylist() == ["NEOCP"]
+    assert parsed.time.mjd()[0].as_py() == pytest.approx(61229.177257)
 
 
 def test_parse_record_with_space_padded_precision() -> None:
@@ -38,23 +40,25 @@ def test_parse_record_with_space_padded_precision() -> None:
         "     A11EpSe KC2026 07 14.53636 19 37 22.30 -29 16 44.5          19.0 GVNEOCPE23"
     )
 
-    assert parsed.designation == "A11EpSe"
-    assert parsed.note1 == "K"
-    assert parsed.note2 == "C"
-    assert parsed.observatory_code == "E23"
-    assert parsed.mag == pytest.approx(19.0)
+    assert parsed.designation.to_pylist() == ["A11EpSe"]
+    assert parsed.note1.to_pylist() == ["K"]
+    assert parsed.note2.to_pylist() == ["C"]
+    assert parsed.observatory_code.to_pylist() == ["E23"]
+    assert parsed.mag[0].as_py() == pytest.approx(19.0)
 
 
-def test_file_parser_omits_unsupported_two_line_rows() -> None:
+def test_file_parser_is_strict_by_default() -> None:
     optical = "     ST26G06  C2026 07 08.33794520 25 33.638-00 47 36.82         19.62GVNEOCPU68"
     satellite = optical[:14] + "S" + optical[15:]
 
-    parsed = parse_optical_obs80_file(f"{optical}\n{satellite}\n")
+    with pytest.raises(Obs80ParseError, match="line 2.*two-line"):
+        parse_optical_obs80_file(f"{optical}\n{satellite}\n")
 
+    parsed = parse_optical_obs80_file(
+        f"{optical}\n{satellite}\n", strict=False
+    )
     assert len(parsed) == 1
-    assert parsed[0].designation == "ST26G06"
-    with pytest.raises(Obs80ParseError, match="two-line"):
-        parse_optical_obs80(satellite)
+    assert parsed.designation.to_pylist() == ["ST26G06"]
 
 
 def test_parser_rejects_malformed_rows() -> None:

--- a/src/adam_core/observations/tests/test_obs80.py
+++ b/src/adam_core/observations/tests/test_obs80.py
@@ -1,0 +1,65 @@
+from decimal import Decimal
+
+import pytest
+
+from adam_core.observations.obs80 import (
+    NANOSECONDS_PER_DAY,
+    Obs80ParseError,
+    parse_optical_obs80,
+    parse_optical_obs80_file,
+)
+
+
+def test_parse_standard_scout_neocp_optical_record() -> None:
+    parsed = parse_optical_obs80(
+        "     A11EpSe*0C2026 07 08.17725719 41 24.185-30 19 19.42         19.35oVNEOCPW68"
+    )
+
+    assert parsed.designation == "A11EpSe"
+    assert parsed.discovery is True
+    assert parsed.note1 == "0"
+    assert parsed.note2 == "C"
+    assert parsed.observatory_code == "W68"
+    assert parsed.obstime_days_utc == 61229
+    assert parsed.obstime_nanos_utc == int(
+        (Decimal("0.177257") * Decimal(NANOSECONDS_PER_DAY)).to_integral_value()
+    )
+    assert parsed.ra_deg == pytest.approx(295.3507708333333)
+    assert parsed.dec_deg == pytest.approx(-30.32206111111111)
+    assert parsed.mag == pytest.approx(19.35)
+    assert parsed.band == "o"
+    assert parsed.astrometric_catalog == "V"
+    assert parsed.reference == "NEOCP"
+    assert parsed.obstime_mjd_utc == pytest.approx(61229.177257)
+
+
+def test_parse_record_with_space_padded_precision() -> None:
+    parsed = parse_optical_obs80(
+        "     A11EpSe KC2026 07 14.53636 19 37 22.30 -29 16 44.5          19.0 GVNEOCPE23"
+    )
+
+    assert parsed.designation == "A11EpSe"
+    assert parsed.note1 == "K"
+    assert parsed.note2 == "C"
+    assert parsed.observatory_code == "E23"
+    assert parsed.mag == pytest.approx(19.0)
+
+
+def test_file_parser_omits_unsupported_two_line_rows() -> None:
+    optical = "     ST26G06  C2026 07 08.33794520 25 33.638-00 47 36.82         19.62GVNEOCPU68"
+    satellite = optical[:14] + "S" + optical[15:]
+
+    parsed = parse_optical_obs80_file(f"{optical}\n{satellite}\n")
+
+    assert len(parsed) == 1
+    assert parsed[0].designation == "ST26G06"
+    with pytest.raises(Obs80ParseError, match="two-line"):
+        parse_optical_obs80(satellite)
+
+
+def test_parser_rejects_malformed_rows() -> None:
+    optical = "     ST26G06  C2026 07 08.33794520 25 33.638-00 47 36.82         19.62GVNEOCPU68"
+    with pytest.raises(Obs80ParseError, match="shorter"):
+        parse_optical_obs80("too short")
+    with pytest.raises(Obs80ParseError, match="observation date"):
+        parse_optical_obs80(optical[:15] + "not a valid date!" + optical[32:])

--- a/src/adam_core/orbits/query/__init__.py
+++ b/src/adam_core/orbits/query/__init__.py
@@ -2,4 +2,4 @@
 from .horizons import query_horizons
 from .neocc import query_neocc
 from .sbdb import query_sbdb, query_sbdb_new
-from .scout import query_scout
+from .scout import query_scout, query_scout_observations

--- a/src/adam_core/orbits/query/scout.py
+++ b/src/adam_core/orbits/query/scout.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -20,6 +21,31 @@ from ...time import Timestamp
 from ..variants import VariantOrbits
 
 logger = logging.getLogger(__name__)
+_SCOUT_API_URL = "https://ssd-api.jpl.nasa.gov/scout.api"
+
+
+def _request_scout_json(
+    *,
+    params: dict[str, Any] | None = None,
+    timeout_s: float = 30.0,
+    max_attempts: int = 3,
+    retry_delay_s: float = 0.5,
+    http_get: Callable[..., Any] = requests.get,
+) -> Any:
+    """Fetch Scout JSON with bounded retries for transient HTTP failures."""
+    attempts = max(1, int(max_attempts))
+    for attempt in range(attempts):
+        try:
+            response = http_get(_SCOUT_API_URL, params=params, timeout=timeout_s)
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as exc:
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            retryable = status is None or status == 429 or status >= 500
+            if not retryable or attempt + 1 >= attempts:
+                raise
+            time.sleep(retry_delay_s * (2**attempt))
+    raise RuntimeError("unreachable Scout retry state")
 
 
 class ScoutObjectSummary(qv.Table):
@@ -90,10 +116,7 @@ def get_scout_objects() -> ScoutObjectSummary:
     scout_objects : `~adam_core.orbits.query.scout.ScoutObjectSummary`
         Table containing the summary of all objects.
     """
-    url = "https://ssd-api.jpl.nasa.gov/scout.api"
-    response = requests.get(url)
-    response.raise_for_status()
-    data = response.json()
+    data = _request_scout_json()
     data = data["data"]
     table = pa.Table.from_pylist(data, schema=ScoutObjectSummary.schema)
     return ScoutObjectSummary.from_pyarrow(table)
@@ -198,16 +221,13 @@ def query_scout_observations(
     """
     object_ids = [ids] if isinstance(ids, str) else list(ids)
     snapshots: list[ScoutObservations] = []
-    url = "https://ssd-api.jpl.nasa.gov/scout.api"
     for object_id_value in object_ids:
         object_id = str(object_id_value)
-        response = http_get(
-            url,
+        payload = _request_scout_json(
             params={"tdes": object_id, "file": "mpc"},
-            timeout=timeout_s,
+            timeout_s=timeout_s,
+            http_get=http_get,
         )
-        response.raise_for_status()
-        payload = response.json()
         if not isinstance(payload, dict) or payload.get("error"):
             detail = payload.get("error") if isinstance(payload, dict) else None
             raise RuntimeError(f"Scout observation lookup failed for {object_id}: {detail}")
@@ -294,13 +314,11 @@ def query_scout(ids: npt.ArrayLike) -> VariantOrbits:
     orbits : `~adam_core.orbits.VariantOrbits`
         Table containing the orbits of the objects
     """
-    url = "https://ssd-api.jpl.nasa.gov/scout.api?tdes={}&orbits=1"
-
     variant_orbits = VariantOrbits.empty()
     for object_id in ids:
-        response = requests.get(url.format(object_id))
-        response.raise_for_status()
-        data = response.json()
+        data = _request_scout_json(
+            params={"tdes": str(object_id), "orbits": "1"}
+        )
         data = data["orbits"]["data"]
 
         # Convert from list of rows to list of columns

--- a/src/adam_core/orbits/query/scout.py
+++ b/src/adam_core/orbits/query/scout.py
@@ -1,4 +1,7 @@
+import hashlib
 import logging
+from collections.abc import Callable
+from typing import Any
 
 import numpy.typing as npt
 import pyarrow as pa
@@ -8,6 +11,11 @@ import requests
 
 from ...coordinates.cometary import CometaryCoordinates
 from ...coordinates.origin import Origin
+from ...observations.obs80 import (
+    Obs80ParseError,
+    ScoutObservations,
+    parse_optical_obs80_file,
+)
 from ...time import Timestamp
 from ..variants import VariantOrbits
 
@@ -174,6 +182,96 @@ def scout_orbits_to_variant_orbits(
     )
 
     return variants
+
+
+def query_scout_observations(
+    ids: npt.ArrayLike,
+    *,
+    timeout_s: float = 30.0,
+    http_get: Callable[..., Any] = requests.get,
+) -> ScoutObservations:
+    """Query authoritative fitted observations from JPL Scout.
+
+    Scout's ``file=mpc`` payload exclusively defines snapshot membership.
+    ``nObs`` is retained as metadata but is not used to add/remove records: in
+    live Scout data it can differ from the file row count.
+    """
+    object_ids = [ids] if isinstance(ids, str) else list(ids)
+    snapshots: list[ScoutObservations] = []
+    url = "https://ssd-api.jpl.nasa.gov/scout.api"
+    for object_id_value in object_ids:
+        object_id = str(object_id_value)
+        response = http_get(
+            url,
+            params={"tdes": object_id, "file": "mpc"},
+            timeout=timeout_s,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict) or payload.get("error"):
+            detail = payload.get("error") if isinstance(payload, dict) else None
+            raise RuntimeError(f"Scout observation lookup failed for {object_id}: {detail}")
+
+        raw_file = payload.get("fileMPC")
+        if not isinstance(raw_file, str) or not raw_file.strip():
+            raise RuntimeError(f"Scout returned no file=mpc snapshot for {object_id}")
+        try:
+            observations = parse_optical_obs80_file(raw_file)
+        except Obs80ParseError as exc:
+            raise RuntimeError(
+                f"Scout returned an invalid file=mpc snapshot for {object_id}: {exc}"
+            ) from exc
+        if len(observations) == 0:
+            raise RuntimeError(f"Scout returned an empty file=mpc snapshot for {object_id}")
+        if any(value != object_id for value in observations.designation.to_pylist()):
+            raise RuntimeError(
+                f"Scout file=mpc designation mismatch for requested object {object_id}"
+            )
+
+        declared_n_obs_raw = payload.get("nObs")
+        try:
+            declared_n_obs = (
+                int(declared_n_obs_raw) if declared_n_obs_raw is not None else None
+            )
+        except (TypeError, ValueError):
+            declared_n_obs = None
+        if declared_n_obs is not None and declared_n_obs != len(observations):
+            logger.warning(
+                "Scout nObs differs from file=mpc membership for %s: "
+                "nObs=%d file=%d; file=mpc remains authoritative",
+                object_id,
+                declared_n_obs,
+                len(observations),
+            )
+
+        signature = payload.get("signature")
+        if not isinstance(signature, dict):
+            signature = {}
+        n = len(observations)
+        snapshots.append(
+            ScoutObservations.from_kwargs(
+                object_id=pa.repeat(object_id, n),
+                solution_date_utc=pa.array(
+                    [payload.get("lastRun")] * n, type=pa.large_string()
+                ),
+                declared_n_obs=pa.array([declared_n_obs] * n, type=pa.int64()),
+                snapshot_sha256=pa.repeat(
+                    hashlib.sha256(raw_file.encode("utf-8")).hexdigest(), n
+                ),
+                snapshot_observation_count=pa.repeat(n, n),
+                signature_version=pa.array(
+                    [signature.get("version")] * n, type=pa.large_string()
+                ),
+                signature_source=pa.array(
+                    [signature.get("source")] * n, type=pa.large_string()
+                ),
+                observation_index=pa.array(range(n), type=pa.int64()),
+                observation=observations,
+            )
+        )
+    if not snapshots:
+        return ScoutObservations.empty()
+    return qv.concatenate(snapshots)
 
 
 def query_scout(ids: npt.ArrayLike) -> VariantOrbits:

--- a/src/adam_core/orbits/query/scout.py
+++ b/src/adam_core/orbits/query/scout.py
@@ -265,8 +265,11 @@ def query_scout_observations(
             )
 
         signature = payload.get("signature")
-        if not isinstance(signature, dict):
-            signature = {}
+        if not isinstance(signature, dict) or str(signature.get("version")) != "1.3":
+            raise RuntimeError(
+                "Unsupported or missing Scout API signature for "
+                f"{object_id}: {signature!r}"
+            )
         n = len(observations)
         snapshots.append(
             ScoutObservations.from_kwargs(

--- a/src/adam_core/orbits/query/tests/test_scout.py
+++ b/src/adam_core/orbits/query/tests/test_scout.py
@@ -4,7 +4,57 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 
-from ..scout import ScoutOrbit, scout_orbits_to_variant_orbits
+from ..scout import (
+    ScoutOrbit,
+    query_scout_observations,
+    scout_orbits_to_variant_orbits,
+)
+
+
+def test_query_scout_observations_uses_file_membership() -> None:
+    lines = [
+        "     A11EpSe*0C2026 07 08.17725719 41 24.185-30 19 19.42         19.35oVNEOCPW68",
+        "     A11EpSe KC2026 07 14.53636 19 37 22.30 -29 16 44.5          19.0 GVNEOCPE23",
+    ]
+
+    class Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {
+                "objectName": "A11EpSe",
+                # Deliberately differs: file=mpc, not nObs, is authoritative.
+                "nObs": 1,
+                "lastRun": "2026-07-14 13:33",
+                "signature": {
+                    "version": "1.3",
+                    "source": "NASA/JPL Scout API",
+                },
+                "fileMPC": "\n".join(lines) + "\n",
+            }
+
+    calls = []
+
+    def get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return Response()
+
+    observations = query_scout_observations(["A11EpSe"], http_get=get)
+
+    assert len(observations) == 2
+    assert observations.object_id.to_pylist() == ["A11EpSe", "A11EpSe"]
+    assert observations.declared_n_obs.to_pylist() == [1, 1]
+    assert observations.snapshot_observation_count.to_pylist() == [2, 2]
+    assert observations.observation_index.to_pylist() == [0, 1]
+    assert observations.observation.designation.to_pylist() == [
+        "A11EpSe",
+        "A11EpSe",
+    ]
+    assert observations.observation.time.scale == "utc"
+    assert len(set(observations.snapshot_sha256.to_pylist())) == 1
+    assert observations.signature_version.to_pylist() == ["1.3", "1.3"]
+    assert calls[0][1]["params"] == {"tdes": "A11EpSe", "file": "mpc"}
 
 
 def test_scout_orbits_to_variant_orbits():

--- a/src/adam_core/orbits/query/tests/test_scout.py
+++ b/src/adam_core/orbits/query/tests/test_scout.py
@@ -3,12 +3,33 @@
 import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
+import requests
 
 from ..scout import (
+    _request_scout_json,
     ScoutOrbit,
     query_scout_observations,
     scout_orbits_to_variant_orbits,
 )
+
+
+def test_scout_request_retries_transient_failure() -> None:
+    class Response:
+        def __init__(self, status_code: int):
+            self.status_code = status_code
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise requests.HTTPError(response=self)
+
+        def json(self) -> dict:
+            return {"ok": True}
+
+    responses = iter([Response(502), Response(200)])
+    payload = _request_scout_json(
+        http_get=lambda *args, **kwargs: next(responses), retry_delay_s=0
+    )
+    assert payload == {"ok": True}
 
 
 def test_query_scout_observations_uses_file_membership() -> None:


### PR DESCRIPTION
## Summary
- add strict optical MPC Obs80 parsing backed by quivr tables and UTC Timestamp columns
- add typed ScoutObservations snapshots with file hash, API signature, declared/file counts, and stable row order
- add query_scout_observations to adam-core and bounded retries for transient Scout failures
- keep Scout file=mpc as the authoritative observation-membership source

## Validation
- 7 targeted parser/Scout tests pass
- Ruff and diff checks pass
- live A11EpSe query returned 24 typed observations, API v1.3, UTC times, and the expected snapshot hash
