### PR TITLE
Claim period-doubled folds when doubling is the sole remaining ambiguity

### DIFF
--- a/docs/source/cookbook/rotation_periods.rst
+++ b/docs/source/cookbook/rotation_periods.rst
@@ -55,6 +55,18 @@ Note that ``single_period`` is high-confidence but **not a zero-alias guarantee.
   ``single_period`` result against ``alternate_period_days`` and
   ``reliability_code`` rather than treating it as infallible.
 
+One disclosed assumption: when the best fit is a single-peaked fold whose only
+surviving ambiguity is the half/full octave, the solver doubles the period on
+the two-peaks-per-rotation shape prior and, by default, claims
+``single_period`` with the confidence flag ``doubled_fold_assumed``. Measured
+on the LCDB/DAMIT standard-candle sets this raises confident claims (76 to 83
+pooled) with strict precision improving and no new wrong-family claim; on the
+Rubin survey regression it raises claims from 6 to 11 of 76, all strictly
+correct. A genuinely single-peaked (spheroidal) body would make such a claim a
+2x alias, so pass ``claim_doubled_fold=False`` to keep these cases as
+``period_family`` (reason ``single_max_alias``). Filter on the flag to treat
+them separately in bulk results.
+
 Data Requirements
 -----------------
 

--- a/src/adam_core/photometry/rotation/estimator.py
+++ b/src/adam_core/photometry/rotation/estimator.py
@@ -982,6 +982,7 @@ def _classify_confidence(
     observation_count_sufficient: bool,
     is_reliable: bool,
     is_valid: bool,
+    claim_doubled_fold: bool,
 ) -> tuple[str, str, list[str], list[str]]:
     """Single deterministic verdict from the confidence classifier's decision tree.
 
@@ -1041,19 +1042,27 @@ def _classify_confidence(
     n_aliases = 0 if n_significant_aliases is None else int(n_significant_aliases)
     alias_ambiguous = n_aliases >= 2
     single_max_ambiguous = bool(is_period_doubled)
+    # A doubled (single-peaked) fold whose only remaining ambiguity is the
+    # half/full octave may claim under the two-peaks-per-rotation shape prior
+    # when ``claim_doubled_fold`` allows it; the assumption is disclosed via the
+    # ``doubled_fold_assumed`` confidence flag rather than hidden.
+    doubled_fold_assumed = (
+        claim_doubled_fold and single_max_ambiguous and not alias_ambiguous
+    )
+    if doubled_fold_assumed:
+        flags.append("doubled_fold_assumed")
+    single_max_blocking = single_max_ambiguous and not doubled_fold_assumed
     eligible_single = (
-        (not alias_ambiguous)
-        and (not single_max_ambiguous)
-        and good_coverage_for_single
+        (not alias_ambiguous) and (not single_max_blocking) and good_coverage_for_single
     )
 
     alias_gate: tuple[tuple[bool, str], ...] = (
         (alias_ambiguous, "conflicting_aliases"),
-        (single_max_ambiguous, "single_max_alias"),
+        (single_max_blocking, "single_max_alias"),
         (
             not good_coverage_for_single
             and not alias_ambiguous
-            and not single_max_ambiguous,
+            and not single_max_blocking,
             "phase_coverage_low",
         ),
     )
@@ -1147,6 +1156,7 @@ def _primary_from_method(
     span_days: float,
     min_rotations_in_span: float,
     residual_sigma_mag: float | None,
+    claim_doubled_fold: bool,
 ) -> _PrimaryResult:
     observation_count_sufficient = _observation_count_sufficient(filter_labels)
     n_fourier_aliases = int(len(fourier_solution.clusters))
@@ -1171,6 +1181,7 @@ def _primary_from_method(
             observation_count_sufficient=observation_count_sufficient,
             is_reliable=bool(fourier_solution.is_reliable),
             is_valid=bool(fourier_solution.is_valid),
+            claim_doubled_fold=claim_doubled_fold,
         )
     )
     return _primary_result(
@@ -1386,6 +1397,7 @@ def estimate_rotation_period(
     session_mode: str = "auto",
     auto_session_min_observations_per_group: int = 6,
     auto_session_bic_improvement: float = 10.0,
+    claim_doubled_fold: bool = True,
 ) -> RotationPeriodResult:
     """Estimate an asteroid rotation period with a measured confidence verdict.
 
@@ -1410,6 +1422,20 @@ def estimate_rotation_period(
     session_mode : {"ignore", "use", "auto"}, default "auto"
         Per-session magnitude-offset handling. ``"auto"`` adopts offsets only when
         a BIC test clears ``auto_session_bic_improvement``.
+    claim_doubled_fold : bool, default True
+        When the ONLY remaining ambiguity is the half/full octave of a
+        single-peaked fold (the solver has already doubled the period on the
+        two-peaks-per-rotation shape prior and no rival alias cluster survives),
+        allow the verdict ``single_period`` and append the confidence flag
+        ``doubled_fold_assumed`` disclosing the assumption. Measured on the
+        LCDB/DAMIT standard-candle sets this raises confident claims (76 -> 83
+        pooled) with strict precision improving (0.895 -> 0.904) and no new
+        wrong-family claim; on the Rubin survey regression it raises claims
+        from 6 to 11 of 76, all strictly correct. A genuinely single-peaked
+        (spheroidal) body would make such a claim a 2x alias, so set False to
+        restore the strictly agnostic behavior (verdict ``period_family`` with
+        reason ``single_max_alias``). The long-period and sub-harmonic
+        guardrails still apply to these claims.
     exact_evaluation_backend : {"numpy", "jax"}, default "numpy"
         Backend for exact frequency fits; ``"jax"`` is faster on large grids and
         gives identical results (imported lazily, so ``"numpy"`` needs no JAX).
@@ -1595,6 +1621,7 @@ def estimate_rotation_period(
         span_days=span_days,
         min_rotations_in_span=min_rotations_in_span,
         residual_sigma_mag=float(fourier_solution.fit_summary.residual_sigma),
+        claim_doubled_fold=claim_doubled_fold,
     )
     period_days = float(primary.period_days)
     period_hours = float(period_days * 24.0)

--- a/src/adam_core/photometry/tests/test_rotation_period.py
+++ b/src/adam_core/photometry/tests/test_rotation_period.py
@@ -458,3 +458,73 @@ def test_hg_phase_correction_matches_magnitude_module() -> None:
         np.testing.assert_allclose(
             phase_term_rotation, phase_term_ref, rtol=0.0, atol=1e-9
         )
+
+
+def _load_committed_fixture(name: str) -> RotationPeriodObservations:
+    from pathlib import Path
+
+    import numpy as np
+    import pyarrow as pa
+
+    from ...time import Timestamp as _Timestamp
+
+    z = np.load(
+        Path(__file__).parent / "data" / name,
+        allow_pickle=True,
+    )
+    sigma = np.asarray(z["mag_sigma"], dtype=np.float64)
+    return RotationPeriodObservations.from_kwargs(
+        time=_Timestamp.from_iso8601(
+            np.asarray(z["time_iso"], dtype=object).tolist(), scale="utc"
+        ),
+        mag=np.asarray(z["mag_obs"], dtype=np.float64),
+        mag_sigma=pa.array(sigma, mask=~np.isfinite(sigma), type=pa.float64()),
+        filter=[str(v) for v in np.asarray(z["filter"], dtype=object).tolist()],
+        session_id=[str(v) for v in np.asarray(z["session_id"], dtype=object).tolist()],
+        r_au=np.asarray(z["r_au"], dtype=np.float64),
+        delta_au=np.asarray(z["delta_au"], dtype=np.float64),
+        phase_angle_deg=np.asarray(z["phase_angle_deg"], dtype=np.float64),
+    )
+
+
+def test_doubled_fold_claims_by_default_and_hedges_when_disabled():
+    # 1323 Tugela is the canonical doubled-only case: the grid best fit is the
+    # single-peaked 9.72 h fold, the solver doubles it to 19.44 h on the
+    # two-peaks-per-rotation shape prior, and no rival alias cluster survives.
+    # Default: claim single_period with the assumption disclosed via the
+    # doubled_fold_assumed flag. claim_doubled_fold=False restores the strictly
+    # agnostic period_family / single_max_alias contract. Either way the period
+    # is the same doubled fold (LCDB reference: 19.5 h).
+    import numpy as np
+
+    observations = _load_committed_fixture(
+        "rotation_period_validation_fixture_1323_Tugela.npz"
+    )
+    # The committed fixture's own search knobs (same as the validation gates):
+    # a 24 cycles/day cap keeps the grid small enough for the fast suite.
+    z_kwargs = dict(
+        search_fidelity="validated_staged",
+        exact_evaluation_backend="jax",
+        max_frequency_cycles_per_day=24.0,
+        frequency_grid_scale=30.0,
+    )
+
+    claimed = estimate_rotation_period(observations, **z_kwargs)
+    hedged = estimate_rotation_period(
+        observations, claim_doubled_fold=False, **z_kwargs
+    )
+
+    assert claimed.period_hours[0].as_py() == pytest.approx(19.444, abs=0.05)
+    assert hedged.period_hours[0].as_py() == pytest.approx(
+        claimed.period_hours[0].as_py(), rel=1e-9
+    )
+    assert claimed.is_period_doubled[0].as_py() is True
+
+    assert claimed.period_verdict[0].as_py() == "single_period"
+    assert "doubled_fold_assumed" in (claimed.confidence_flags[0].as_py() or [])
+    assert "single_max_alias" not in (claimed.insufficiency_reasons[0].as_py() or [])
+
+    assert hedged.period_verdict[0].as_py() == "period_family"
+    assert "single_max_alias" in (hedged.insufficiency_reasons[0].as_py() or [])
+    assert "doubled_fold_assumed" not in (hedged.confidence_flags[0].as_py() or [])
+    assert np.isfinite(hedged.period_hours[0].as_py())


### PR DESCRIPTION
## What

When the best fit is a single-peaked fold that the solver has already doubled on the two-peaks-per-rotation shape prior, and no rival alias cluster survives the 95% competitiveness cut, the verdict may now be `single_period`, with a new `doubled_fold_assumed` confidence flag disclosing the assumption. Previously such cases were always demoted to `period_family` with reason `single_max_alias`. A new parameter `claim_doubled_fold` (default `True`) restores the strictly agnostic behavior when `False`. The long-period and sub-harmonic guardrails still apply to these claims, and the period search itself is untouched (recovered periods are bit-identical; only the verdict and disclosure change).

## Why

A gate-attribution study on the validation sets asked why the solver claims so few periods on sparse survey cadence. The dominant binder (multiple surviving alias clusters) is not a tuning knob, but a clean secondary population emerged: objects whose *only* remaining ambiguity is the half/full octave of a doubled fold. For an elongated body, the doubled period is the physical answer; refusing to claim it costs correct claims without preventing any wrong ones on the measured sets.

## Measured effect (validation sets, offline counterfactual + live confirmation)

| set | claims before | claims after | strict precision | wrong-family |
|---|---:|---:|---|---|
| LCDB standard candles (115 solved) | 43 | 48 | 36/43 -> 41/48 | 1 (unchanged: 3295 Murakami) |
| DAMIT shape models (60) | 33 | 35 | 32/33 -> 34/35 | 1 (unchanged: 478 Tergeste) |
| Rubin survey regression (76) | 6 | 11 | 6/6 -> 11/11 | 0 |

Pooled calibration precision rises 0.895 -> 0.904; no new wrong-family claim on any set.

**All 12 predicted verdict flips were then confirmed live with this branch** (validated_staged + JAX, each source's stored knobs): 209 Dido, 829 Academia, 3055 Annapavlova, 3975 Verdi, 1323 Tugela (LCDB); 18 Melpomene, 896 Sphinx (DAMIT); 2025 MD76, MG56, MO35, MP71, MT24 (survey). Every one claims `single_period` with `doubled_fold_assumed` set, strictly within its tolerance (worst error 0.17%), and no guardrail intervened.

## Risk and disclosure

A genuinely single-peaked (spheroidal) body would make a doubled-fold claim a 2x alias — the cardinal failure mode. That is why the assumption is a *flag*, not silence: bulk consumers can filter `doubled_fold_assumed` and treat these claims separately, and `claim_doubled_fold=False` restores the pure hedge. On the measured sets the failure did not occur.

## Testing

- New behavioral test on the committed 1323 Tugela fixture (the canonical doubled-only case): default claims with the flag; `claim_doubled_fold=False` reproduces the previous `period_family` / `single_max_alias` contract with an identical period. Runs in ~11 s.
- Full rotation suite green under the new default: 29 passed, 1 xfailed — the zero-false-confidence CI gate still xfails on the known 1627 Ivar sparse-fixture alias, and Tugela's new claim is within tolerance, so the gate's semantics are unchanged.
- `mypy --strict` clean on the subsystem; ruff/black/isort clean; docs build clean under `-W` (cookbook section added documenting the assumption, the measured numbers, and the opt-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZNKbKYQR3hFiP9vLdzZU4
