### PR TITLE
Docs: bound hyperbolic parity claims, reference conversion issue #210

### DIFF
--- a/docs/source/non_grav_support.rst
+++ b/docs/source/non_grav_support.rst
@@ -104,6 +104,14 @@ Current limits:
 - NEOCC non-grav solutions are decoded only for the Yarkovsky model
   (``AMRAT``/``A2``); the ``AMRAT`` dimension is marginalized out with a
   warning and other models are degraded to value-free rows with a warning.
+- Near-parabolic orbits (e close to 1, e.g. C/2022 E3) currently convert to
+  wildly wrong Cartesian states through the pre-existing
+  cometary-to-Cartesian defect tracked in issue #210. Until that is fixed,
+  element-based SBDB/NEOCC imports of such objects cannot be propagated
+  meaningfully: the non-gravitational force model itself is validated
+  against JPL Horizons from Cartesian starting states (see the adam-assist
+  regression suite), so parity claims for hyperbolic comets are bounded to
+  that force-integration path, not the element-conversion path.
 
 Two-Body Note
 -------------


### PR DESCRIPTION
Follow-up to #201, which merged while this commit was in flight: the reviewer asked that hyperbolic/near-parabolic parity claims be bounded and the pre-existing cometary→Cartesian conversion defect (#210) be documented before any SBDB-state-to-ASSIST parity claims.

Adds a "Current limits" entry to the non-grav support docs stating that near-parabolic element imports (e.g. C/2022 E3) hit #210, and that force-model parity is validated from Cartesian starting states (adam-assist Horizons regression suite), bounding claims to that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)