### PR TITLE
Integrate adam-core 0.5.6rc6 successors

### DIFF
--- a/.github/workflows/pip-build-lint-test-coverage.yml
+++ b/.github/workflows/pip-build-lint-test-coverage.yml
@@ -133,7 +133,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: B612-Asteroid-Institute/adam-assist
-          ref: 9aae5c04240cdc76f839da05dc98d35ebfdfa311
+          ref: 4009c154da52b06b9f24724027c6a78e17ec8c7c
           path: .ci/adam-assist
       - name: Build compatible downstream adam-assist
         env:
@@ -191,7 +191,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: B612-Asteroid-Institute/adam-assist
-          ref: 9aae5c04240cdc76f839da05dc98d35ebfdfa311
+          ref: 4009c154da52b06b9f24724027c6a78e17ec8c7c
           path: .ci/adam-assist
       - name: Build compatible downstream adam-assist
         env:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -10,7 +10,7 @@ on:
       expected_version:
         description: Exact prerelease shared by all six crates
         required: true
-        default: 0.1.0-rc.4
+        default: 0.1.0-rc.5
         type: string
       authentication:
         description: crates.io OIDC trusted publishing (bootstrap token was revoked after rc.1)
@@ -30,7 +30,7 @@ permissions:
   id-token: write
 
 env:
-  PYTHON_PREVIEW_VERSION: "0.5.6rc4"
+  PYTHON_SOURCE_VERSION: "0.5.6rc5"
 
 jobs:
   publish:
@@ -48,12 +48,12 @@ jobs:
           EXPECTED_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          test "$GITHUB_REF" = "refs/tags/v$PYTHON_PREVIEW_VERSION"
+          test "$GITHUB_REF" = "refs/tags/v$EXPECTED_VERSION"
           test "$CONFIRMATION" = "publish $EXPECTED_VERSION from $EXPECTED_SHA to crates.io"
       - name: Verify source prerelease versions and exact internal pins
         run: |
           python migration/scripts/verify_preview_versions.py \
-            --python-version "$PYTHON_PREVIEW_VERSION" \
+            --python-version "$PYTHON_SOURCE_VERSION" \
             --rust-version "${{ inputs.expected_version }}"
       - name: Verify candidate run provenance and success
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,18 +10,10 @@ on:
       expected_version:
         description: Exact PEP 440 release-candidate version
         required: true
-        default: 0.5.6rc5
+        default: 0.5.6rc6
         type: string
-      repository:
-        description: Destination index
-        required: true
-        default: testpypi
-        type: choice
-        options:
-          - testpypi
-          - pypi
       confirmation:
-        description: Type "publish adam-core <version> from <sha> to <repository>"
+        description: Type "publish adam-core <version> from <sha> to pypi"
         required: true
         type: string
 
@@ -31,7 +23,7 @@ permissions:
   id-token: write
 
 env:
-  RUST_PREVIEW_VERSION: "0.1.0-rc.4"
+  RUST_PREVIEW_VERSION: "0.1.0-rc.5"
 
 jobs:
   collect-tested-artifacts:
@@ -55,11 +47,10 @@ jobs:
           CONFIRMATION: ${{ inputs.confirmation }}
           EXPECTED_VERSION: ${{ inputs.expected_version }}
           EXPECTED_SHA: ${{ github.sha }}
-          DESTINATION: ${{ inputs.repository }}
         run: |
           set -euo pipefail
           test "$GITHUB_REF" = "refs/tags/v$EXPECTED_VERSION"
-          test "$CONFIRMATION" = "publish adam-core $EXPECTED_VERSION from $EXPECTED_SHA to $DESTINATION"
+          test "$CONFIRMATION" = "publish adam-core $EXPECTED_VERSION from $EXPECTED_SHA to pypi"
 
       - name: Verify source prerelease versions and exact Rust pins
         run: |
@@ -176,28 +167,8 @@ jobs:
           path: dist/
           if-no-files-found: error
 
-  publish-testpypi:
-    name: Publish exact preview wheels to TestPyPI
-    if: inputs.repository == 'testpypi'
-    needs: collect-tested-artifacts
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi-preview
-      url: https://test.pypi.org/p/adam-core
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: adam-core-${{ inputs.expected_version }}-tested-publication-set
-          path: dist
-      - name: Remove checksum manifest from upload directory
-        run: rm dist/SHA256SUMS
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
   publish-pypi:
     name: Publish exact preview wheels to PyPI
-    if: inputs.repository == 'pypi'
     needs: collect-tested-artifacts
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/release-candidate-wheel-matrix.yml
+++ b/.github/workflows/release-candidate-wheel-matrix.yml
@@ -10,7 +10,7 @@ on:
       adam_assist_ref:
         description: adam-assist revision to test with this adam-core revision
         required: true
-        default: release-candidate/adam-assist-0.4.0rc6
+        default: release-candidate/adam-assist-0.4.0rc7
 
 permissions:
   contents: read
@@ -20,9 +20,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ADAM_ASSIST_REF: ${{ inputs.adam_assist_ref || 'release-candidate/adam-assist-0.4.0rc6' }}
+  ADAM_ASSIST_REF: ${{ inputs.adam_assist_ref || 'release-candidate/adam-assist-0.4.0rc7' }}
   PIP_ONLY_BINARY: ":all:"
-  PYTHON_PREVIEW_VERSION: "0.5.6rc5"
+  PYTHON_PREVIEW_VERSION: "0.5.6rc6"
 
 jobs:
   artifact-acceptance:

--- a/.github/workflows/rust-crate-release-candidate.yml
+++ b/.github/workflows/rust-crate-release-candidate.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   PYTHON_PREVIEW_VERSION: "0.5.6rc5"
-  RUST_PREVIEW_VERSION: "0.1.0-rc.4"
+  RUST_PREVIEW_VERSION: "0.1.0-rc.5"
 
 jobs:
   package-and-test:
@@ -73,6 +73,57 @@ jobs:
           python migration/scripts/publish_crate_archives.py \
             --archives crate-dist \
             --expected-version "$RUST_PREVIEW_VERSION"
+      - name: Verify clean no-lock Rust 1.87 consumer resolution
+        run: |
+          set -euo pipefail
+          consumer="$(mktemp -d)"
+          trap 'rm -rf "$consumer"' EXIT
+          mkdir -p "$consumer/src"
+          printf 'fn main() {}\n' > "$consumer/src/main.rs"
+          cat > "$consumer/Cargo.toml" <<EOF
+          [package]
+          name = "adam-core-msrv-consumer"
+          version = "0.0.0"
+          edition = "2021"
+
+          [dependencies]
+          adam_core = "=$RUST_PREVIEW_VERSION"
+
+          [patch.crates-io]
+          adam_core = { path = "$GITHUB_WORKSPACE/rust/adam_core" }
+          adam_core_rs_autodiff = { path = "$GITHUB_WORKSPACE/rust/adam_core_rs_autodiff" }
+          adam_core_rs_coords = { path = "$GITHUB_WORKSPACE/rust/adam_core_rs_coords" }
+          adam_core_rs_kernel_data = { path = "$GITHUB_WORKSPACE/rust/adam_core_rs_kernel_data" }
+          adam_core_rs_orbit_determination = { path = "$GITHUB_WORKSPACE/rust/adam_core_rs_orbit_determination" }
+          adam_core_rs_spice = { path = "$GITHUB_WORKSPACE/rust/adam_core_rs_spice" }
+          EOF
+          test ! -e "$consumer/Cargo.lock"
+          rustc --version | grep -F "rustc 1.87.0"
+          cargo check --manifest-path "$consumer/Cargo.toml"
+          cargo metadata --format-version 1 --manifest-path "$consumer/Cargo.toml" \
+            > "$consumer/metadata.json"
+          python - "$consumer/metadata.json" <<'PY'
+          import json
+          import sys
+
+          expected = {
+              "icu_collections",
+              "icu_locale_core",
+              "icu_normalizer",
+              "icu_normalizer_data",
+              "icu_properties",
+              "icu_properties_data",
+              "icu_provider",
+          }
+          packages = json.load(open(sys.argv[1], encoding="utf-8"))["packages"]
+          resolved = {
+              package["name"]: package["version"]
+              for package in packages
+              if package["name"] in expected
+          }
+          assert resolved == {name: "2.2.0" for name in expected}, resolved
+          print("clean Rust 1.87 consumer resolved ICU4X 2.2.0 exactly")
+          PY
       - name: Upload exact crate publication set
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rust-crate-release-candidate.yml
+++ b/.github/workflows/rust-crate-release-candidate.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_PREVIEW_VERSION: "0.5.6rc5"
+  PYTHON_PREVIEW_VERSION: "0.5.6rc6"
   RUST_PREVIEW_VERSION: "0.1.0-rc.5"
 
 jobs:
@@ -130,3 +130,54 @@ jobs:
           name: rust-crate-publication-set
           path: crate-dist/
           if-no-files-found: error
+
+  latest-stable-compatibility:
+    name: Latest-stable Rust compatibility (non-authoritative)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Check and test supported feature configurations
+        run: |
+          set -euo pipefail
+          cargo check --workspace --locked
+          cargo test --workspace --locked
+          cargo check --workspace --locked --all-features
+          cargo test --workspace --locked --all-features
+          cargo check --manifest-path rust/adam_core_rs_kernel_data/Cargo.toml \
+            --locked --no-default-features
+          cargo test --manifest-path rust/adam_core_rs_kernel_data/Cargo.toml \
+            --locked --no-default-features
+      - name: Check and test clean no-lock consumers
+        run: |
+          set -euo pipefail
+          consumer="$(mktemp -d)"
+          trap 'rm -rf "$consumer"' EXIT
+          for mode in default no-default; do
+            mkdir -p "$consumer/$mode/src"
+            printf 'fn main() {}\n' > "$consumer/$mode/src/main.rs"
+          done
+          cat > "$consumer/default/Cargo.toml" <<EOF
+          [package]
+          name = "adam-core-latest-stable-consumer"
+          version = "0.0.0"
+          edition = "2021"
+
+          [dependencies]
+          adam_core = "=$RUST_PREVIEW_VERSION"
+          EOF
+          cat > "$consumer/no-default/Cargo.toml" <<EOF
+          [package]
+          name = "adam-core-kernel-data-latest-stable-consumer"
+          version = "0.0.0"
+          edition = "2021"
+
+          [dependencies]
+          adam_core_rs_kernel_data = { version = "=$RUST_PREVIEW_VERSION", default-features = false }
+          EOF
+          test ! -e "$consumer/default/Cargo.lock"
+          test ! -e "$consumer/no-default/Cargo.lock"
+          cargo check --manifest-path "$consumer/default/Cargo.toml"
+          cargo test --manifest-path "$consumer/default/Cargo.toml"
+          cargo check --manifest-path "$consumer/no-default/Cargo.toml"
+          cargo test --manifest-path "$consumer/no-default/Cargo.toml"

--- a/.github/workflows/tier1-dependent-smoke.yml
+++ b/.github/workflows/tier1-dependent-smoke.yml
@@ -34,13 +34,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: B612-Asteroid-Institute/adam-assist
-          ref: 9aae5c04240cdc76f839da05dc98d35ebfdfa311
+          ref: 4009c154da52b06b9f24724027c6a78e17ec8c7c
           path: dependent
       - name: Install dependent and adam_core wheel
         run: |
           python -m pip install --upgrade pip
           python -m pip install dist/*.whl
-          python -m pip install -e dependent
+          python -m pip install --no-deps -e dependent
       - name: Verify exact candidate installations
         run: |
           python - <<'PY'
@@ -49,7 +49,7 @@ jobs:
           import adam_core
           from adam_assist.version import __version__ as assist_version
 
-          assert version("adam-core") == adam_core.__version__ == "0.5.6rc5"
+          assert version("adam-core") == adam_core.__version__ == "0.5.6rc6"
           assert version("adam-assist") == assist_version == "0.4.0rc6"
           PY
       - name: Run dependent import smoke

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adam_core"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 dependencies = [
  "adam_core_rs_autodiff",
  "adam_core_rs_coords",
@@ -39,11 +39,11 @@ dependencies = [
 
 [[package]]
 name = "adam_core_rs_autodiff"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 
 [[package]]
 name = "adam_core_rs_coords"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 dependencies = [
  "adam_core_rs_autodiff",
  "adam_core_rs_orbit_determination",
@@ -61,9 +61,13 @@ dependencies = [
 
 [[package]]
 name = "adam_core_rs_kernel_data"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 dependencies = [
  "adam_core_rs_spice",
+ "icu_locale_core",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
  "sha2",
  "tempfile",
  "ureq",
@@ -72,11 +76,11 @@ dependencies = [
 
 [[package]]
 name = "adam_core_rs_orbit_determination"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 
 [[package]]
 name = "adam_core_rs_spice"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 dependencies = [
  "adam_core_rs_coords",
  "faer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "adam_core_py"
-version = "0.5.6-rc.5"
+version = "0.5.6-rc.6"
 dependencies = [
  "adam_core_rs_coords",
  "adam_core_rs_orbit_determination",

--- a/docs/source/getting_started/releasing.rst
+++ b/docs/source/getting_started/releasing.rst
@@ -21,15 +21,14 @@ memory-mapping implementation; musllinux is also deliberately unsupported.
 Preview versions and opt-in installation
 ----------------------------------------
 
-The currently published migration preview is ``adam-core==0.5.6rc2`` on
-PyPI. The corrected promotion candidate is ``adam-core==0.5.6rc5`` with the already
-published public Rust crates ``0.1.0-rc.4`` and exact internal requirements
-such as ``=0.1.0-rc.4``; it is not published until its exact artifacts complete
-the separately authorized hosted matrix and post-download inspection. Pip and
-Cargo exclude prereleases from ordinary resolution;
-preview consumers must opt in with an exact pin. The Python wheel contains the
-Python veneer and compiled ``adam_core._rust_native`` extension, so Python
-consumers do not need to install the component crates from crates.io.
+The currently published Python preview is ``adam-core==0.5.6rc5``. The
+corrective Python successor is ``adam-core==0.5.6rc6``. All six public Rust
+crates ``0.1.0-rc.5`` are published with exact internal requirements such as
+``=0.1.0-rc.5`` and keep clean consumers compatible with the declared Rust
+1.87 MSRV. Pip and Cargo exclude prereleases from ordinary resolution; preview
+consumers must opt in with an exact pin. The Python wheel contains the Python
+veneer and compiled ``adam_core._rust_native`` extension, so Python consumers
+do not need to install the component crates from crates.io.
 
 The current stable PyPI release remains the default for ``pip install
 adam-core``. A public preview is still visible and intentionally installable by
@@ -39,32 +38,39 @@ instead if public visibility is unacceptable.
 Trusted publishing
 ------------------
 
-``publish.yml`` uses GitHub/PyPI OIDC with protected ``testpypi-preview`` and
-``pypi-preview`` environments. Its manual inputs include the successful
+``publish.yml`` uses GitHub/PyPI OIDC with the protected ``pypi-preview``
+environment. TestPyPI is not available for this release sequence. Its manual
+inputs include the successful
 release-candidate run ID, exact version, and a confirmation containing the
 version, commit SHA, and destination. The collector verifies the run name,
 successful conclusion, exact head SHA, RC-only version, wheel metadata, and the
 complete 12-wheel matrix before assembling only ``adam_core`` wheels.
 
-The six public Rust crates ``0.1.0-rc.4`` were published through crates.io OIDC
+The six public Rust crates ``0.1.0-rc.5`` were published through crates.io OIDC
 trusted publishing from the exact hosted candidate archives. Crate publication
 verified explicit confirmation, candidate provenance, checksums, archive
 metadata, prerelease versions, and exact internal dependency pins, then
 uploaded the accepted ``.crate`` archives in dependency order without
-repackaging or compiling.
+repackaging or compiling. Rust 1.87 remains authoritative for formatting,
+strict Clippy, tests, documentation, packaging, wheels, and clean consumer
+resolution. A separate non-authoritative latest-stable lane checks and tests
+default, all-feature, no-default, and fresh no-lock consumer configurations;
+it does not run moving-stable Clippy or change the declared MSRV.
 
 Release order
 -------------
 
-The six Rust crates are already published. After review and approval:
+The six Core Rust ``0.1.0-rc.5`` crates are already published. Successor
+promotion remains separately approval-gated and proceeds in dependency order:
 
-#. publish the exact accepted ``adam-core==0.5.6rc5`` wheel set and verify it
-   from the public index;
-#. resolve adam-assist against exact public RC dependencies and test the
-   prepared ``adam-assist==0.4.0rc6`` candidate against
-   ``adam-core==0.5.6rc5``;
-#. publish the exact accepted ``adam-assist`` RC wheel set; and
-#. run the precovery-v2 clean package-manager smoke test with exact pins.
+#. build and accept the paired ``adam-core==0.5.6rc6`` and
+   ``adam-assist==0.4.0rc7`` wheel matrices at exact source SHAs;
+#. publish and verify the exact accepted Core Python RC6 wheel set;
+#. rerun ordinary ASSIST CI against public Core RC6, then publish and verify
+   ``adam_assist 0.4.0-rc.7``;
+#. publish and verify the exact accepted ASSIST Python RC7 wheel set; and
+#. run clean no-lock Cargo 1.87/latest-stable and clean Python package-manager
+   smoke tests with exact pins.
 
 ``adam-assist`` owns ASSIST orchestration and consumes released
 ``libassist-sys`` and ``librebound-sys`` directly. Do not publish an

--- a/migration/packaging.md
+++ b/migration/packaging.md
@@ -1,6 +1,6 @@
 # adam-core Rust Packaging Notes
 
-Last updated: 2026-08-20.
+Last updated: 2026-08-27.
 
 ## Supported Build Path
 
@@ -18,7 +18,8 @@ Last updated: 2026-08-20.
 - Stable versions are identical in both systems. Supported Cargo prereleases are normalized explicitly, for example `0.5.6-rc.1` to PEP 440 `0.5.6rc1`.
 - `pyproject.toml` does not declare `[tool.pdm.version]`; PDM SCM versioning is not part of the native wheel path.
 - If the checkout is exactly on a `vX.Y.Z` or prerelease tag, `write_maturin_version.py` fails when the normalized tag and Cargo versions differ.
-- `migration/scripts/verify_preview_versions.py` requires all six public Rust crates to share the candidate version (`0.1.0-rc.4`) and every internal prerelease dependency to use the exact requirement `=0.1.0-rc.4`.
+- `migration/scripts/verify_preview_versions.py` requires all six public Rust crates to share the candidate version (`0.1.0-rc.5`) and every internal prerelease dependency to use the exact requirement `=0.1.0-rc.5`.
+- Rust crate publication uses the Rust-version tag `v0.1.0-rc.5`, independently of Python wheel tags, so immutable registry ordering does not force a premature Python release commit.
 
 ## uv Status
 

--- a/migration/scripts/write_maturin_version.py
+++ b/migration/scripts/write_maturin_version.py
@@ -26,6 +26,9 @@ CARGO_SEMVER = re.compile(
     r"(?:-(?P<phase>alpha|beta|rc)\.(?P<number>0|[1-9][0-9]*))?$"
 )
 VERSION_TAG = re.compile(r"^v(?P<version>.+)$")
+VERSION_RELEASE_PREFIX = re.compile(
+    r"^(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\."
+)
 
 
 def cargo_version_to_pep440(version: str) -> str:
@@ -55,10 +58,26 @@ def _cargo_versions() -> tuple[str, str]:
     return version, python_version
 
 
-def _exact_version_tag() -> str | None:
+def _python_version_tag_glob(python_version: str) -> str:
+    match = VERSION_RELEASE_PREFIX.match(python_version)
+    if match is None:
+        raise SystemExit(
+            f"Python version {python_version!r} has no major/minor release"
+        )
+    return f"v{match.group('major')}.{match.group('minor')}.*"
+
+
+def _exact_version_tag(python_version: str) -> str | None:
     try:
         result = subprocess.run(
-            ["git", "describe", "--tags", "--exact-match", "--match", "v[0-9]*"],
+            [
+                "git",
+                "describe",
+                "--tags",
+                "--exact-match",
+                "--match",
+                _python_version_tag_glob(python_version),
+            ],
             cwd=REPO_ROOT,
             check=False,
             text=True,
@@ -87,7 +106,7 @@ def _exact_version_tag() -> str | None:
 
 
 def _validate_exact_tag(python_version: str) -> None:
-    tag_version = _exact_version_tag()
+    tag_version = _exact_version_tag(python_version)
     if tag_version is None:
         return
     if tag_version != python_version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ docs = { cmd = "sphinx-build -b html docs/source docs/build", env = { LC_ALL = "
 docs-check = { cmd = "sphinx-build -E -b html -W --keep-going docs/source docs/build_ci", env = { LC_ALL = "C", LANG = "C" } }
 rust-build = "pdm run wheel-build"
 rust-develop = { composite = [
+  "pdm run wheel-version",
   "python -m ensurepip --upgrade",
   "maturin develop --manifest-path rust/adam_core_py/Cargo.toml --release",
 ] }

--- a/rust/adam_core/Cargo.toml
+++ b/rust/adam_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adam_core"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -11,8 +11,8 @@ keywords = ["astronomy", "asteroids", "orbits", "spice"]
 categories = ["science"]
 
 [dependencies]
-adam_core_rs_autodiff = { version = "=0.1.0-rc.4", path = "../adam_core_rs_autodiff" }
-adam_core_rs_coords = { version = "=0.1.0-rc.4", path = "../adam_core_rs_coords" }
-adam_core_rs_kernel_data = { version = "=0.1.0-rc.4", path = "../adam_core_rs_kernel_data" }
-adam_core_rs_orbit_determination = { version = "=0.1.0-rc.4", path = "../adam_core_rs_orbit_determination" }
-adam_core_rs_spice = { version = "=0.1.0-rc.4", path = "../adam_core_rs_spice" }
+adam_core_rs_autodiff = { version = "=0.1.0-rc.5", path = "../adam_core_rs_autodiff" }
+adam_core_rs_coords = { version = "=0.1.0-rc.5", path = "../adam_core_rs_coords" }
+adam_core_rs_kernel_data = { version = "=0.1.0-rc.5", path = "../adam_core_rs_kernel_data" }
+adam_core_rs_orbit_determination = { version = "=0.1.0-rc.5", path = "../adam_core_rs_orbit_determination" }
+adam_core_rs_spice = { version = "=0.1.0-rc.5", path = "../adam_core_rs_spice" }

--- a/rust/adam_core_py/Cargo.toml
+++ b/rust/adam_core_py/Cargo.toml
@@ -28,6 +28,6 @@ chrono = { version = "0.4", default-features = false, features = ["std"] }
 chrono-tz = "0.10"
 tzf-rs = { version = "1.3.6", default-features = false, features = ["bundled"] }
 ureq = { version = "2.12", default-features = false, features = ["tls"] }
-adam_core_rs_coords = { version = "=0.1.0-rc.4", path = "../adam_core_rs_coords" }
-adam_core_rs_orbit_determination = { version = "=0.1.0-rc.4", path = "../adam_core_rs_orbit_determination" }
-adam_core_rs_spice = { version = "=0.1.0-rc.4", path = "../adam_core_rs_spice" }
+adam_core_rs_coords = { version = "=0.1.0-rc.5", path = "../adam_core_rs_coords" }
+adam_core_rs_orbit_determination = { version = "=0.1.0-rc.5", path = "../adam_core_rs_orbit_determination" }
+adam_core_rs_spice = { version = "=0.1.0-rc.5", path = "../adam_core_rs_spice" }

--- a/rust/adam_core_py/Cargo.toml
+++ b/rust/adam_core_py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adam_core_py"
-version = "0.5.6-rc.5"
+version = "0.5.6-rc.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/rust/adam_core_rs_autodiff/Cargo.toml
+++ b/rust/adam_core_rs_autodiff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adam_core_rs_autodiff"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/rust/adam_core_rs_coords/Cargo.toml
+++ b/rust/adam_core_rs_coords/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adam_core_rs_coords"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,8 +15,8 @@ arrow-buffer = "54"
 arrow-schema = "54"
 parquet = { version = "54", default-features = false, features = ["arrow", "snap", "zstd"] }
 erfars = "0.2"
-adam_core_rs_autodiff = { version = "=0.1.0-rc.4", path = "../adam_core_rs_autodiff" }
-adam_core_rs_orbit_determination = { version = "=0.1.0-rc.4", path = "../adam_core_rs_orbit_determination" }
+adam_core_rs_autodiff = { version = "=0.1.0-rc.5", path = "../adam_core_rs_autodiff" }
+adam_core_rs_orbit_determination = { version = "=0.1.0-rc.5", path = "../adam_core_rs_orbit_determination" }
 # Pure-rust dense linalg with hand-tuned SIMD (NEON, AVX2/512). Used for
 # weighted_mean / weighted_covariance GEMV/GEMM and unblocks future
 # Cholesky/LU/QR/eigen kernels (sigma-point sampling, ATWA solve, etc.).

--- a/rust/adam_core_rs_kernel_data/Cargo.toml
+++ b/rust/adam_core_rs_kernel_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adam_core_rs_kernel_data"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,8 +15,14 @@ spice = ["dep:adam_core_rs_spice"]
 [dependencies]
 sha2 = "0.10"
 ureq = { version = "2.12", default-features = false, features = ["tls"] }
+# Keep ureq's URL/IDNA stack compatible with the declared Rust 1.87 MSRV for
+# downstream consumers that resolve without this workspace's Cargo.lock.
+icu_locale_core = { version = "=2.2.0", default-features = false }
+icu_normalizer = { version = "=2.2.0", default-features = false }
+icu_properties = { version = "=2.2.0", default-features = false }
+icu_provider = { version = "=2.2.0", default-features = false }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-adam_core_rs_spice = { version = "=0.1.0-rc.4", path = "../adam_core_rs_spice", optional = true }
+adam_core_rs_spice = { version = "=0.1.0-rc.5", path = "../adam_core_rs_spice", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/adam_core_rs_orbit_determination/Cargo.toml
+++ b/rust/adam_core_rs_orbit_determination/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adam_core_rs_orbit_determination"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/rust/adam_core_rs_spice/Cargo.toml
+++ b/rust/adam_core_rs_spice/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adam_core_rs_spice"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -9,7 +9,7 @@ rust-version.workspace = true
 description = "SPICE kernel loading, state queries, and SPK products for adam-core"
 
 [dependencies]
-adam_core_rs_coords = { version = "=0.1.0-rc.4", path = "../adam_core_rs_coords" }
+adam_core_rs_coords = { version = "=0.1.0-rc.5", path = "../adam_core_rs_coords" }
 rayon = "1"
 faer = "0.22"
 serde_json = "1"

--- a/src/adam_core/_rust/api.py
+++ b/src/adam_core/_rust/api.py
@@ -120,7 +120,8 @@ if _missing_native_symbols:  # pragma: no cover - depends on broken install stat
     missing = ", ".join(_missing_native_symbols)
     raise ImportError(
         "adam_core._rust_native is present but incomplete; missing required "
-        f"native symbol(s): {missing}"
+        f"native symbol(s): {missing}. Reinstall the wheel or, for a source "
+        "checkout, run `pdm install -G test && pdm run rust-develop`."
     )
 
 RUST_BACKEND_AVAILABLE = True

--- a/src/adam_core/tests/test_preview_release_versions.py
+++ b/src/adam_core/tests/test_preview_release_versions.py
@@ -27,6 +27,7 @@ SPEC.loader.exec_module(MODULE)
         ("0.5.6-rc.3", "0.5.6rc3"),
         ("0.5.6-rc.4", "0.5.6rc4"),
         ("0.5.6-rc.5", "0.5.6rc5"),
+        ("0.5.6-rc.6", "0.5.6rc6"),
     ],
 )
 def test_cargo_version_to_pep440(cargo: str, python: str) -> None:
@@ -42,14 +43,18 @@ def test_cargo_version_to_pep440_rejects_unsupported_forms(version: str) -> None
         MODULE.cargo_version_to_pep440(version)
 
 
+def test_python_tag_validation_ignores_independent_rust_release_line() -> None:
+    assert MODULE._python_version_tag_glob("0.5.6rc6") == "v0.5.*"
+
+
 def test_runtime_versions_must_match_distribution_metadata() -> None:
-    versions = {"adam-core": "0.5.6rc5", "adam-assist": "0.4.0rc6"}
+    versions = {"adam-core": "0.5.6rc6", "adam-assist": "0.4.0rc7"}
     assert _validate_runtime_versions(versions, versions.copy()) == versions
 
     with pytest.raises(AssertionError, match="runtime package version mismatch"):
         _validate_runtime_versions(
             versions,
-            {"adam-core": "0.0.0dev0", "adam-assist": "0.4.0rc6"},
+            {"adam-core": "0.0.0dev0", "adam-assist": "0.4.0rc7"},
         )
 
 
@@ -62,7 +67,7 @@ def test_release_matrix_generates_and_inspects_runtime_version() -> None:
     inspector = "python migration/scripts/check_wheel_artifacts.py"
 
     assert workflow.index(writer) < workflow.index(builder) < workflow.index(inspector)
-    assert 'PYTHON_PREVIEW_VERSION: "0.5.6rc5"' in workflow
+    assert 'PYTHON_PREVIEW_VERSION: "0.5.6rc6"' in workflow
 
 
 def test_kernel_data_constrains_icu_for_clean_rust_1_87_consumers() -> None:
@@ -84,6 +89,16 @@ def test_kernel_data_constrains_icu_for_clean_rust_1_87_consumers() -> None:
     assert 'test ! -e "$consumer/Cargo.lock"' in workflow
     assert 'rustc --version | grep -F "rustc 1.87.0"' in workflow
     assert "clean Rust 1.87 consumer resolved ICU4X 2.2.0 exactly" in workflow
+    assert "Latest-stable Rust compatibility (non-authoritative)" in workflow
+    assert "dtolnay/rust-toolchain@stable" in workflow
+    assert "cargo test --workspace --locked --all-features" in workflow
+    assert "--locked --no-default-features" in workflow
+    assert 'test ! -e "$consumer/default/Cargo.lock"' in workflow
+    assert 'test ! -e "$consumer/no-default/Cargo.lock"' in workflow
+
+    python_publisher = (ROOT / ".github/workflows/publish.yml").read_text()
+    assert "testpypi" not in python_publisher.lower()
+    assert "to pypi" in python_publisher
 
     publisher = (ROOT / ".github/workflows/publish-crates.yml").read_text()
     assert "default: 0.1.0-rc.5" in publisher
@@ -91,12 +106,22 @@ def test_kernel_data_constrains_icu_for_clean_rust_1_87_consumers() -> None:
     assert 'test "$GITHUB_REF" = "refs/tags/v$EXPECTED_VERSION"' in publisher
 
 
+def test_rust_develop_refreshes_version_and_explains_stale_extensions() -> None:
+    pyproject = (ROOT / "pyproject.toml").read_text()
+    writer = '"pdm run wheel-version"'
+    builder = '"maturin develop --manifest-path rust/adam_core_py/Cargo.toml --release"'
+    assert pyproject.index(writer) < pyproject.index(builder)
+
+    rust_api = (ROOT / "src/adam_core/_rust/api.py").read_text()
+    assert "pdm install -G test && pdm run rust-develop" in rust_api
+
+
 def test_rust_ci_is_reproducible_and_downstream_sources_are_exact() -> None:
     workflows = ROOT / ".github/workflows"
     normal_ci = (workflows / "pip-build-lint-test-coverage.yml").read_text()
     crate_ci = (workflows / "rust-crate-release-candidate.yml").read_text()
     tier1 = (workflows / "tier1-dependent-smoke.yml").read_text()
-    assist_sha = "9aae5c04240cdc76f839da05dc98d35ebfdfa311"
+    assist_sha = "4009c154da52b06b9f24724027c6a78e17ec8c7c"
 
     assert "dtolnay/rust-toolchain@1.87.0" in normal_ci
     assert "components: rustfmt, clippy" in normal_ci
@@ -105,13 +130,17 @@ def test_rust_ci_is_reproducible_and_downstream_sources_are_exact() -> None:
     assert "dtolnay/rust-toolchain@1.87.0" in tier1
     assert assist_sha in normal_ci
     assert assist_sha in tier1
-    assert 'version("adam-core") == adam_core.__version__ == "0.5.6rc5"' in tier1
+    assert "python -m pip install --no-deps -e dependent" in tier1
+    assert 'version("adam-core") == adam_core.__version__ == "0.5.6rc6"' in tier1
     assert 'version("adam-assist") == assist_version == "0.4.0rc6"' in tier1
 
     for workflow in workflows.glob("*.yml"):
         source = workflow.read_text()
         if "dtolnay/rust-toolchain@" not in source:
             continue
-        assert "dtolnay/rust-toolchain@stable" not in source, workflow.name
+        if workflow.name == "rust-crate-release-candidate.yml":
+            assert "dtolnay/rust-toolchain@stable" in source
+        else:
+            assert "dtolnay/rust-toolchain@stable" not in source, workflow.name
         assert "dtolnay/rust-toolchain@1.87.0" in source, workflow.name
         assert "components: rustfmt, clippy" in source, workflow.name

--- a/src/adam_core/tests/test_preview_release_versions.py
+++ b/src/adam_core/tests/test_preview_release_versions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -62,6 +63,32 @@ def test_release_matrix_generates_and_inspects_runtime_version() -> None:
 
     assert workflow.index(writer) < workflow.index(builder) < workflow.index(inspector)
     assert 'PYTHON_PREVIEW_VERSION: "0.5.6rc5"' in workflow
+
+
+def test_kernel_data_constrains_icu_for_clean_rust_1_87_consumers() -> None:
+    manifest_path = ROOT / "rust/adam_core_rs_kernel_data/Cargo.toml"
+    with manifest_path.open("rb") as source:
+        dependencies = tomllib.load(source)["dependencies"]
+
+    expected = {"version": "=2.2.0", "default-features": False}
+    for name in (
+        "icu_locale_core",
+        "icu_normalizer",
+        "icu_properties",
+        "icu_provider",
+    ):
+        assert dependencies[name] == expected
+
+    workflow = (ROOT / ".github/workflows/rust-crate-release-candidate.yml").read_text()
+    assert "Verify clean no-lock Rust 1.87 consumer resolution" in workflow
+    assert 'test ! -e "$consumer/Cargo.lock"' in workflow
+    assert 'rustc --version | grep -F "rustc 1.87.0"' in workflow
+    assert "clean Rust 1.87 consumer resolved ICU4X 2.2.0 exactly" in workflow
+
+    publisher = (ROOT / ".github/workflows/publish-crates.yml").read_text()
+    assert "default: 0.1.0-rc.5" in publisher
+    assert 'PYTHON_SOURCE_VERSION: "0.5.6rc5"' in publisher
+    assert 'test "$GITHUB_REF" = "refs/tags/v$EXPECTED_VERSION"' in publisher
 
 
 def test_rust_ci_is_reproducible_and_downstream_sources_are_exact() -> None:


### PR DESCRIPTION
## Summary

Integrate the already-published and independently verified adam-core successors:

- Python/PyO3 `0.5.6rc6`
- six public Rust crates `0.1.0-rc.5`
- authoritative Rust/MSRV `1.87`
- exact internal prerelease pins and ICU4X `2.2.0` consumer resolution
- release workflow/provenance hardening and Python/Rust tag-line separation

## Provenance and validation

- Exact head: `ae4a6f1d7ba937d41b86d3ddce343524737d9708`
- Published tag: `v0.5.6rc6`
- Wheel acceptance run: `33192675600`
- PyPI publication run: `33199504871`
- All 12 supported wheels are public, unyanked, byte-identical to the accepted publication set, and carry trusted PyPI attestations.
- Rust 1.87 fmt, strict Clippy, tests, docs, packaging, fresh no-lock consumers, frozen 44-API regression, 132/132 native benchmark rows, Python suite, wheel inspection, and clean-room acceptance passed.

This PR only integrates the exact released source into `main`; it does not rebuild, republish, or move tags.
